### PR TITLE
feat: add learning memory (spec 03)

### DIFF
--- a/docs/superpowers/plans/2026-04-10-learning-memory.md
+++ b/docs/superpowers/plans/2026-04-10-learning-memory.md
@@ -1,0 +1,2422 @@
+# Learning Memory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a persistent markdown-based learning memory with four structured sections, a pattern engine for Do-Not-Repeat enforcement, multi-ecosystem initialization seeding, and a reflection command for pruning to token budget.
+
+**Architecture:** Pure markdown storage (`learning-memory.md`) parsed and serialized by `learning-memory.ts`. Pattern extraction and matching are isolated in `pattern-engine.ts`. Initialization seeding inspects `package.json`, `pyproject.toml`, `Cargo.toml`, and `go.mod`. A `mink reflect` CLI command prunes the memory (merge duplicates, then trim oldest) and is also called from session-stop.
+
+**Tech Stack:** TypeScript, Bun (test runner + runtime), no external dependencies
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| **Create:** `src/types/learning-memory.ts` | Interfaces for sections, entries, patterns, match results |
+| **Create:** `src/core/learning-memory.ts` | Parse markdown → structure, serialize structure → markdown, add/remove entries per section |
+| **Create:** `src/core/pattern-engine.ts` | Extract enforceable patterns from Do-Not-Repeat entries, match patterns against content |
+| **Create:** `src/core/seed.ts` | Parse project metadata files, detect frameworks, generate seed learning memory |
+| **Create:** `src/core/reflection.ts` | Token budget check, duplicate merge, oldest-first trim |
+| **Create:** `src/commands/reflect.ts` | CLI handler: load memory, run reflection, save, print summary |
+| **Modify:** `src/core/fs-utils.ts` | Add `atomicWriteText()` for markdown files |
+| **Modify:** `src/core/paths.ts` | Add `learningMemoryPath()` |
+| **Modify:** `src/types/file-index.ts` | Add `learningMemoryTokenBudget` to `ProjectConfig` |
+| **Modify:** `src/cli.ts` | Add `reflect` command route |
+| **Modify:** `src/commands/session-stop.ts` | Call reflect after finalization, replace hardcoded path |
+| **Modify:** `src/commands/init.ts` | Seed learning memory on init |
+| **Create:** `tests/unit/learning-memory.test.ts` | Parse/serialize/CRUD tests |
+| **Create:** `tests/unit/pattern-engine.test.ts` | Pattern extraction and matching tests |
+| **Create:** `tests/unit/seed.test.ts` | Metadata parsing and framework detection tests |
+| **Create:** `tests/unit/reflection.test.ts` | Merge, trim, budget enforcement tests |
+| **Create:** `tests/unit/reflect-command.test.ts` | CLI reflect command tests |
+| **Create:** `tests/integration/learning-memory.test.ts` | End-to-end: init → seed → add entries → reflect → verify |
+
+---
+
+### Task 1: Types and Interfaces
+
+**Files:**
+- Create: `src/types/learning-memory.ts`
+- Test: `tests/unit/learning-memory.test.ts` (started, expanded in Task 2)
+
+- [ ] **Step 1: Create the types file**
+
+```typescript
+// src/types/learning-memory.ts
+
+export type SectionName =
+  | "User Preferences"
+  | "Key Learnings"
+  | "Do-Not-Repeat"
+  | "Decision Log";
+
+export interface LearningMemory {
+  projectName: string;
+  sections: Record<SectionName, string[]>;
+}
+
+export interface ExtractedPattern {
+  type: "literal" | "word-boundary";
+  pattern: string;
+  sourceEntry: string;
+}
+
+export interface PatternMatch {
+  pattern: ExtractedPattern;
+  matchedText: string;
+  index: number;
+}
+
+export interface ReflectionResult {
+  beforeTokens: number;
+  afterTokens: number;
+  mergedCount: number;
+  trimmedCount: number;
+  withinBudget: boolean;
+}
+
+export interface SeedInfo {
+  projectName: string;
+  description: string;
+  frameworks: string[];
+}
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `bun build src/types/learning-memory.ts --no-bundle`
+Expected: No errors
+
+- [ ] **Step 3: Add `learningMemoryTokenBudget` to `ProjectConfig`**
+
+In `src/types/file-index.ts`, add the optional field to the existing `ProjectConfig` interface:
+
+```typescript
+export interface ProjectConfig {
+  excludePatterns?: string[];
+  maxFiles?: number;
+  learningMemoryTokenBudget?: number;
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/learning-memory.ts src/types/file-index.ts
+git commit -m "feat(learning-memory): add types and interfaces"
+```
+
+---
+
+### Task 2: Learning Memory Parse and Serialize
+
+**Files:**
+- Create: `src/core/learning-memory.ts`
+- Test: `tests/unit/learning-memory.test.ts`
+
+- [ ] **Step 1: Write failing tests for parsing**
+
+```typescript
+// tests/unit/learning-memory.test.ts
+import { describe, expect, test } from "bun:test";
+import {
+  parseLearningMemory,
+  serializeLearningMemory,
+  createEmptyLearningMemory,
+} from "../../src/core/learning-memory";
+import type { LearningMemory } from "../../src/types/learning-memory";
+
+describe("learning-memory", () => {
+  describe("createEmptyLearningMemory", () => {
+    test("creates memory with project name and empty sections", () => {
+      const mem = createEmptyLearningMemory("my-project");
+      expect(mem.projectName).toBe("my-project");
+      expect(mem.sections["User Preferences"]).toEqual([]);
+      expect(mem.sections["Key Learnings"]).toEqual([]);
+      expect(mem.sections["Do-Not-Repeat"]).toEqual([]);
+      expect(mem.sections["Decision Log"]).toEqual([]);
+    });
+  });
+
+  describe("parseLearningMemory", () => {
+    test("parses well-formed markdown into sections", () => {
+      const md = [
+        "# Learning Memory — my-project",
+        "",
+        "## User Preferences",
+        "",
+        "- Use named exports",
+        "- Prefer const over let",
+        "",
+        "## Key Learnings",
+        "",
+        "- API uses sliding window rate limiting",
+        "",
+        "## Do-Not-Repeat",
+        "",
+        '- [2026-04-10] Never use "var"',
+        "",
+        "## Decision Log",
+        "",
+        "- [2026-04-10] Chose Bun as runtime",
+      ].join("\n");
+
+      const mem = parseLearningMemory(md);
+      expect(mem.projectName).toBe("my-project");
+      expect(mem.sections["User Preferences"]).toEqual([
+        "Use named exports",
+        "Prefer const over let",
+      ]);
+      expect(mem.sections["Key Learnings"]).toEqual([
+        "API uses sliding window rate limiting",
+      ]);
+      expect(mem.sections["Do-Not-Repeat"]).toEqual([
+        '[2026-04-10] Never use "var"',
+      ]);
+      expect(mem.sections["Decision Log"]).toEqual([
+        "[2026-04-10] Chose Bun as runtime",
+      ]);
+    });
+
+    test("handles empty sections", () => {
+      const md = [
+        "# Learning Memory — test",
+        "",
+        "## User Preferences",
+        "",
+        "## Key Learnings",
+        "",
+        "## Do-Not-Repeat",
+        "",
+        "## Decision Log",
+      ].join("\n");
+
+      const mem = parseLearningMemory(md);
+      expect(mem.sections["User Preferences"]).toEqual([]);
+      expect(mem.sections["Key Learnings"]).toEqual([]);
+      expect(mem.sections["Do-Not-Repeat"]).toEqual([]);
+      expect(mem.sections["Decision Log"]).toEqual([]);
+    });
+
+    test("handles missing title — uses fallback name", () => {
+      const md = [
+        "## User Preferences",
+        "",
+        "- Something",
+      ].join("\n");
+
+      const mem = parseLearningMemory(md);
+      expect(mem.projectName).toBe("unknown");
+      expect(mem.sections["User Preferences"]).toEqual(["Something"]);
+    });
+
+    test("ignores content outside recognized sections", () => {
+      const md = [
+        "# Learning Memory — test",
+        "",
+        "Some random text here",
+        "",
+        "## User Preferences",
+        "",
+        "- Real entry",
+        "",
+        "## Unknown Section",
+        "",
+        "- Should be ignored",
+        "",
+        "## Key Learnings",
+        "",
+        "## Do-Not-Repeat",
+        "",
+        "## Decision Log",
+      ].join("\n");
+
+      const mem = parseLearningMemory(md);
+      expect(mem.sections["User Preferences"]).toEqual(["Real entry"]);
+    });
+
+    test("returns empty memory for empty string", () => {
+      const mem = parseLearningMemory("");
+      expect(mem.projectName).toBe("unknown");
+      expect(mem.sections["User Preferences"]).toEqual([]);
+    });
+  });
+
+  describe("serializeLearningMemory", () => {
+    test("produces well-formed markdown", () => {
+      const mem: LearningMemory = {
+        projectName: "my-project",
+        sections: {
+          "User Preferences": ["Use named exports"],
+          "Key Learnings": ["API uses rate limiting"],
+          "Do-Not-Repeat": ['[2026-04-10] Never use "var"'],
+          "Decision Log": ["[2026-04-10] Chose Bun"],
+        },
+      };
+
+      const md = serializeLearningMemory(mem);
+      expect(md).toContain("# Learning Memory — my-project");
+      expect(md).toContain("## User Preferences");
+      expect(md).toContain("- Use named exports");
+      expect(md).toContain("## Key Learnings");
+      expect(md).toContain("- API uses rate limiting");
+      expect(md).toContain("## Do-Not-Repeat");
+      expect(md).toContain('- [2026-04-10] Never use "var"');
+      expect(md).toContain("## Decision Log");
+      expect(md).toContain("- [2026-04-10] Chose Bun");
+    });
+
+    test("round-trips: parse → serialize → parse produces identical structure", () => {
+      const original: LearningMemory = {
+        projectName: "roundtrip",
+        sections: {
+          "User Preferences": ["Pref A", "Pref B"],
+          "Key Learnings": ["Learning 1"],
+          "Do-Not-Repeat": ['[2026-01-01] Avoid "any" type'],
+          "Decision Log": ["[2026-01-01] Use monorepo"],
+        },
+      };
+
+      const md = serializeLearningMemory(original);
+      const parsed = parseLearningMemory(md);
+      expect(parsed).toEqual(original);
+    });
+
+    test("empty sections are rendered with heading only", () => {
+      const mem = createEmptyLearningMemory("empty-project");
+      const md = serializeLearningMemory(mem);
+      expect(md).toContain("## User Preferences");
+      expect(md).toContain("## Do-Not-Repeat");
+      // No "- " entries between sections
+      const lines = md.split("\n");
+      const prefIdx = lines.findIndex((l) => l === "## User Preferences");
+      const nextSection = lines.findIndex(
+        (l, i) => i > prefIdx && l.startsWith("## ")
+      );
+      const between = lines.slice(prefIdx + 1, nextSection).filter((l) => l.startsWith("- "));
+      expect(between).toHaveLength(0);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/unit/learning-memory.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the learning memory module**
+
+```typescript
+// src/core/learning-memory.ts
+import type { LearningMemory, SectionName } from "../types/learning-memory";
+
+const SECTION_ORDER: SectionName[] = [
+  "User Preferences",
+  "Key Learnings",
+  "Do-Not-Repeat",
+  "Decision Log",
+];
+
+const SECTION_NAMES = new Set<string>(SECTION_ORDER);
+
+export function createEmptyLearningMemory(projectName: string): LearningMemory {
+  return {
+    projectName,
+    sections: {
+      "User Preferences": [],
+      "Key Learnings": [],
+      "Do-Not-Repeat": [],
+      "Decision Log": [],
+    },
+  };
+}
+
+export function parseLearningMemory(markdown: string): LearningMemory {
+  const lines = markdown.split("\n");
+
+  // Extract project name from title
+  let projectName = "unknown";
+  const titleLine = lines.find((l) => l.startsWith("# Learning Memory"));
+  if (titleLine) {
+    const match = titleLine.match(/^# Learning Memory\s*—\s*(.+)$/);
+    if (match) {
+      projectName = match[1].trim();
+    }
+  }
+
+  const mem = createEmptyLearningMemory(projectName);
+
+  let currentSection: SectionName | null = null;
+
+  for (const line of lines) {
+    // Check for section heading
+    const headingMatch = line.match(/^## (.+)$/);
+    if (headingMatch) {
+      const name = headingMatch[1].trim();
+      if (SECTION_NAMES.has(name)) {
+        currentSection = name as SectionName;
+      } else {
+        currentSection = null;
+      }
+      continue;
+    }
+
+    // Check for entry
+    if (currentSection && line.startsWith("- ")) {
+      const entry = line.slice(2).trim();
+      if (entry.length > 0) {
+        mem.sections[currentSection].push(entry);
+      }
+    }
+  }
+
+  return mem;
+}
+
+export function serializeLearningMemory(mem: LearningMemory): string {
+  const lines: string[] = [`# Learning Memory — ${mem.projectName}`, ""];
+
+  for (const section of SECTION_ORDER) {
+    lines.push(`## ${section}`, "");
+    for (const entry of mem.sections[section]) {
+      lines.push(`- ${entry}`);
+    }
+    lines.push("");
+  }
+
+  // Remove trailing blank line to end with single newline
+  while (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+export function addEntry(
+  mem: LearningMemory,
+  section: SectionName,
+  entry: string
+): void {
+  mem.sections[section].push(entry);
+}
+
+export function removeEntry(
+  mem: LearningMemory,
+  section: SectionName,
+  index: number
+): void {
+  if (index >= 0 && index < mem.sections[section].length) {
+    mem.sections[section].splice(index, 1);
+  }
+}
+
+export function getEntries(mem: LearningMemory, section: SectionName): string[] {
+  return mem.sections[section];
+}
+
+export function totalEntryCount(mem: LearningMemory): number {
+  return SECTION_ORDER.reduce(
+    (sum, section) => sum + mem.sections[section].length,
+    0
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/unit/learning-memory.test.ts`
+Expected: All PASS
+
+- [ ] **Step 5: Add tests for addEntry, removeEntry, getEntries, totalEntryCount**
+
+Append to the test file:
+
+```typescript
+  describe("addEntry", () => {
+    test("appends entry to specified section", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "User Preferences", "Use semicolons");
+      expect(mem.sections["User Preferences"]).toEqual(["Use semicolons"]);
+    });
+
+    test("appends multiple entries in order", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "Key Learnings", "First");
+      addEntry(mem, "Key Learnings", "Second");
+      expect(mem.sections["Key Learnings"]).toEqual(["First", "Second"]);
+    });
+  });
+
+  describe("removeEntry", () => {
+    test("removes entry at given index", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "User Preferences", "A");
+      addEntry(mem, "User Preferences", "B");
+      addEntry(mem, "User Preferences", "C");
+      removeEntry(mem, "User Preferences", 1);
+      expect(mem.sections["User Preferences"]).toEqual(["A", "C"]);
+    });
+
+    test("no-ops for out-of-bounds index", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "User Preferences", "A");
+      removeEntry(mem, "User Preferences", 5);
+      expect(mem.sections["User Preferences"]).toEqual(["A"]);
+    });
+
+    test("no-ops for negative index", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "User Preferences", "A");
+      removeEntry(mem, "User Preferences", -1);
+      expect(mem.sections["User Preferences"]).toEqual(["A"]);
+    });
+  });
+
+  describe("getEntries", () => {
+    test("returns entries for a section", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "Do-Not-Repeat", "[2026-04-10] Rule");
+      expect(getEntries(mem, "Do-Not-Repeat")).toEqual(["[2026-04-10] Rule"]);
+    });
+
+    test("returns empty array for empty section", () => {
+      const mem = createEmptyLearningMemory("test");
+      expect(getEntries(mem, "Decision Log")).toEqual([]);
+    });
+  });
+
+  describe("totalEntryCount", () => {
+    test("counts entries across all sections", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "User Preferences", "A");
+      addEntry(mem, "Key Learnings", "B");
+      addEntry(mem, "Do-Not-Repeat", "C");
+      expect(totalEntryCount(mem)).toBe(3);
+    });
+
+    test("returns 0 for empty memory", () => {
+      const mem = createEmptyLearningMemory("test");
+      expect(totalEntryCount(mem)).toBe(0);
+    });
+  });
+```
+
+Import `addEntry`, `removeEntry`, `getEntries`, `totalEntryCount` at the top of the test file.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `bun test tests/unit/learning-memory.test.ts`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/learning-memory.ts tests/unit/learning-memory.test.ts
+git commit -m "feat(learning-memory): add parse, serialize, and CRUD functions"
+```
+
+---
+
+### Task 3: `atomicWriteText` and `learningMemoryPath`
+
+**Files:**
+- Modify: `src/core/fs-utils.ts`
+- Modify: `src/core/paths.ts`
+- Test: `tests/unit/fs-utils.test.ts` (existing)
+
+- [ ] **Step 1: Write failing test for `atomicWriteText`**
+
+Append to `tests/unit/fs-utils.test.ts`:
+
+```typescript
+import { atomicWriteText } from "../../src/core/fs-utils";
+
+describe("atomicWriteText", () => {
+  test("writes text content to file", () => {
+    const filePath = join(dir, "test.md");
+    atomicWriteText(filePath, "# Hello\n\nWorld\n");
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toBe("# Hello\n\nWorld\n");
+  });
+
+  test("overwrites existing file atomically", () => {
+    const filePath = join(dir, "test.md");
+    atomicWriteText(filePath, "first");
+    atomicWriteText(filePath, "second");
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toBe("second");
+  });
+
+  test("creates parent directories", () => {
+    const filePath = join(dir, "nested", "deep", "test.md");
+    atomicWriteText(filePath, "content");
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toBe("content");
+  });
+});
+```
+
+Note: The existing `fs-utils.test.ts` already has a `dir` variable with `beforeEach`/`afterEach` for temp dirs and imports `readFileSync`. Add the `atomicWriteText` import at the top.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/unit/fs-utils.test.ts`
+Expected: FAIL — `atomicWriteText` not found
+
+- [ ] **Step 3: Implement `atomicWriteText`**
+
+Add to `src/core/fs-utils.ts`:
+
+```typescript
+export function atomicWriteText(filePath: string, content: string): void {
+  const tmp = filePath + ".tmp";
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(tmp, content);
+  renameSync(tmp, filePath);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/unit/fs-utils.test.ts`
+Expected: All PASS
+
+- [ ] **Step 5: Add `learningMemoryPath` to paths.ts**
+
+Add to `src/core/paths.ts`:
+
+```typescript
+export function learningMemoryPath(cwd: string): string {
+  return join(projectDir(cwd), "learning-memory.md");
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/fs-utils.ts src/core/paths.ts tests/unit/fs-utils.test.ts
+git commit -m "feat(learning-memory): add atomicWriteText and learningMemoryPath"
+```
+
+---
+
+### Task 4: Pattern Engine
+
+**Files:**
+- Create: `src/core/pattern-engine.ts`
+- Test: `tests/unit/pattern-engine.test.ts`
+
+- [ ] **Step 1: Write failing tests for pattern extraction**
+
+```typescript
+// tests/unit/pattern-engine.test.ts
+import { describe, expect, test } from "bun:test";
+import { extractPatterns, matchPatterns } from "../../src/core/pattern-engine";
+
+describe("pattern-engine", () => {
+  describe("extractPatterns", () => {
+    test("extracts double-quoted strings as literal patterns", () => {
+      const patterns = extractPatterns(['[2026-04-10] Never use "var"']);
+      expect(patterns).toHaveLength(1);
+      expect(patterns[0].type).toBe("literal");
+      expect(patterns[0].pattern).toBe("var");
+      expect(patterns[0].sourceEntry).toBe('[2026-04-10] Never use "var"');
+    });
+
+    test("extracts single-quoted strings as literal patterns", () => {
+      const patterns = extractPatterns(["[2026-04-10] Avoid 'export default'"]);
+      expect(patterns).toHaveLength(1);
+      expect(patterns[0].type).toBe("literal");
+      expect(patterns[0].pattern).toBe("export default");
+    });
+
+    test("extracts 'never use' phrases as word-boundary patterns", () => {
+      const patterns = extractPatterns([
+        "[2026-04-10] Never use default exports",
+      ]);
+      expect(patterns).toHaveLength(1);
+      expect(patterns[0].type).toBe("word-boundary");
+      expect(patterns[0].pattern).toBe("default exports");
+    });
+
+    test("extracts 'avoid' phrases as word-boundary patterns", () => {
+      const patterns = extractPatterns([
+        "[2026-04-10] Avoid mocking the database in integration tests",
+      ]);
+      expect(patterns).toHaveLength(1);
+      expect(patterns[0].type).toBe("word-boundary");
+      expect(patterns[0].pattern).toBe("mocking the database");
+    });
+
+    test("'avoid' phrase stops at dash", () => {
+      const patterns = extractPatterns([
+        "[2026-04-10] Avoid mocking — use real fixtures instead",
+      ]);
+      expect(patterns).toHaveLength(1);
+      expect(patterns[0].pattern).toBe("mocking");
+    });
+
+    test("extracts both quoted and phrase patterns from one entry", () => {
+      const patterns = extractPatterns([
+        '[2026-04-10] Never use "var" — avoid global scope pollution',
+      ]);
+      expect(patterns.length).toBeGreaterThanOrEqual(2);
+      const types = patterns.map((p) => p.type);
+      expect(types).toContain("literal");
+      expect(types).toContain("word-boundary");
+    });
+
+    test("returns empty array for entry with no extractable pattern", () => {
+      const patterns = extractPatterns([
+        "[2026-04-10] Be careful with auth",
+      ]);
+      expect(patterns).toHaveLength(0);
+    });
+
+    test("handles multiple entries", () => {
+      const patterns = extractPatterns([
+        '[2026-04-10] Never use "var"',
+        "[2026-04-11] Avoid default exports",
+      ]);
+      expect(patterns).toHaveLength(2);
+    });
+
+    test("returns empty array for empty input", () => {
+      const patterns = extractPatterns([]);
+      expect(patterns).toHaveLength(0);
+    });
+
+    test("extracts multiple quoted strings from one entry", () => {
+      const patterns = extractPatterns([
+        '[2026-04-10] Never use "var" or "any"',
+      ]);
+      const literals = patterns.filter((p) => p.type === "literal");
+      expect(literals).toHaveLength(2);
+      expect(literals.map((p) => p.pattern)).toContain("var");
+      expect(literals.map((p) => p.pattern)).toContain("any");
+    });
+  });
+
+  describe("matchPatterns", () => {
+    test("matches literal pattern in content", () => {
+      const patterns = extractPatterns(['[2026-04-10] Never use "var"']);
+      const matches = matchPatterns(patterns, "var x = 5;");
+      expect(matches).toHaveLength(1);
+      expect(matches[0].matchedText).toBe("var");
+    });
+
+    test("literal match is case-sensitive", () => {
+      const patterns = extractPatterns(['[2026-04-10] Never use "var"']);
+      const matches = matchPatterns(patterns, "VAR x = 5;");
+      expect(matches).toHaveLength(0);
+    });
+
+    test("matches word-boundary pattern in content", () => {
+      const patterns = extractPatterns([
+        "[2026-04-10] Avoid default exports",
+      ]);
+      const matches = matchPatterns(patterns, "export default function foo() {}");
+      expect(matches).toHaveLength(1);
+    });
+
+    test("word-boundary match is case-insensitive", () => {
+      const patterns = extractPatterns([
+        "[2026-04-10] Avoid Default Exports",
+      ]);
+      const matches = matchPatterns(patterns, "export default function foo() {}");
+      expect(matches).toHaveLength(1);
+    });
+
+    test("no match when content does not contain pattern", () => {
+      const patterns = extractPatterns(['[2026-04-10] Never use "var"']);
+      const matches = matchPatterns(patterns, "const x = 5;");
+      expect(matches).toHaveLength(0);
+    });
+
+    test("multiple patterns can match same content", () => {
+      const patterns = extractPatterns([
+        '[2026-04-10] Never use "var"',
+        '[2026-04-11] Avoid "let" — prefer const',
+      ]);
+      const matches = matchPatterns(patterns, "var x = 5; let y = 10;");
+      expect(matches).toHaveLength(2);
+    });
+
+    test("returns empty for empty content", () => {
+      const patterns = extractPatterns(['[2026-04-10] Never use "var"']);
+      const matches = matchPatterns(patterns, "");
+      expect(matches).toHaveLength(0);
+    });
+
+    test("returns empty for empty patterns", () => {
+      const matches = matchPatterns([], "var x = 5;");
+      expect(matches).toHaveLength(0);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/unit/pattern-engine.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the pattern engine**
+
+```typescript
+// src/core/pattern-engine.ts
+import type { ExtractedPattern, PatternMatch } from "../types/learning-memory";
+
+function stripDatePrefix(entry: string): string {
+  return entry.replace(/^\[\d{4}-\d{2}-\d{2}\]\s*/, "");
+}
+
+export function extractPatterns(entries: string[]): ExtractedPattern[] {
+  const patterns: ExtractedPattern[] = [];
+
+  for (const entry of entries) {
+    const text = stripDatePrefix(entry);
+
+    // Extract quoted strings (double or single quotes)
+    const quoteRegex = /["']([^"']+)["']/g;
+    let quoteMatch: RegExpExecArray | null;
+    while ((quoteMatch = quoteRegex.exec(text)) !== null) {
+      patterns.push({
+        type: "literal",
+        pattern: quoteMatch[1],
+        sourceEntry: entry,
+      });
+    }
+
+    // Extract "never use" phrases
+    const neverUseMatch = text.match(/\bnever use\s+(.+?)(?:\s*[—\-–.]|$)/i);
+    if (neverUseMatch) {
+      // Remove any quoted portions from the phrase (already extracted above)
+      let phrase = neverUseMatch[1].replace(/["'][^"']+["']/g, "").trim();
+      // Clean up leftover connectors
+      phrase = phrase.replace(/^\s*(or|and)\s+/i, "").trim();
+      if (phrase.length > 0) {
+        patterns.push({
+          type: "word-boundary",
+          pattern: phrase,
+          sourceEntry: entry,
+        });
+      }
+    }
+
+    // Extract "avoid" phrases
+    const avoidMatch = text.match(/\bavoid\s+(.+?)(?:\s*[—\-–.]|$)/i);
+    if (avoidMatch) {
+      let phrase = avoidMatch[1].replace(/["'][^"']+["']/g, "").trim();
+      phrase = phrase.replace(/^\s*(or|and)\s+/i, "").trim();
+      if (phrase.length > 0) {
+        patterns.push({
+          type: "word-boundary",
+          pattern: phrase,
+          sourceEntry: entry,
+        });
+      }
+    }
+  }
+
+  return patterns;
+}
+
+export function matchPatterns(
+  patterns: ExtractedPattern[],
+  content: string
+): PatternMatch[] {
+  if (content.length === 0 || patterns.length === 0) return [];
+
+  const matches: PatternMatch[] = [];
+
+  for (const pattern of patterns) {
+    if (pattern.type === "literal") {
+      const idx = content.indexOf(pattern.pattern);
+      if (idx !== -1) {
+        matches.push({
+          pattern,
+          matchedText: pattern.pattern,
+          index: idx,
+        });
+      }
+    } else {
+      // Word-boundary match, case-insensitive
+      const escaped = pattern.pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const regex = new RegExp(`\\b${escaped}\\b`, "i");
+      const match = regex.exec(content);
+      if (match) {
+        matches.push({
+          pattern,
+          matchedText: match[0],
+          index: match.index,
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/unit/pattern-engine.test.ts`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/pattern-engine.ts tests/unit/pattern-engine.test.ts
+git commit -m "feat(learning-memory): add pattern extraction and matching engine"
+```
+
+---
+
+### Task 5: Initialization Seeding
+
+**Files:**
+- Create: `src/core/seed.ts`
+- Test: `tests/unit/seed.test.ts`
+
+- [ ] **Step 1: Write failing tests for metadata parsing**
+
+```typescript
+// tests/unit/seed.test.ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { seedLearningMemory, parsePackageJson, parsePyprojectToml, parseCargoToml, parseGoMod } from "../../src/core/seed";
+import type { SeedInfo } from "../../src/types/learning-memory";
+
+describe("seed", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mink-seed-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe("parsePackageJson", () => {
+    test("extracts name, description, and frameworks from dependencies", () => {
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({
+          name: "my-app",
+          description: "A cool app",
+          dependencies: { react: "^18.0.0", "react-dom": "^18.0.0" },
+          devDependencies: { typescript: "^5.0.0", jest: "^29.0.0" },
+        })
+      );
+
+      const info = parsePackageJson(join(dir, "package.json"));
+      expect(info).not.toBeNull();
+      expect(info!.projectName).toBe("my-app");
+      expect(info!.description).toBe("A cool app");
+      expect(info!.frameworks).toContain("React");
+      expect(info!.frameworks).toContain("TypeScript");
+      expect(info!.frameworks).toContain("Jest");
+    });
+
+    test("returns null for missing file", () => {
+      const info = parsePackageJson(join(dir, "package.json"));
+      expect(info).toBeNull();
+    });
+
+    test("returns null for malformed JSON", () => {
+      writeFileSync(join(dir, "package.json"), "not json {{{");
+      const info = parsePackageJson(join(dir, "package.json"));
+      expect(info).toBeNull();
+    });
+
+    test("handles missing description", () => {
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({ name: "bare-project" })
+      );
+      const info = parsePackageJson(join(dir, "package.json"));
+      expect(info!.description).toBe("");
+      expect(info!.frameworks).toEqual([]);
+    });
+  });
+
+  describe("parsePyprojectToml", () => {
+    test("extracts name and description from [project] section", () => {
+      writeFileSync(
+        join(dir, "pyproject.toml"),
+        [
+          "[project]",
+          'name = "my-api"',
+          'description = "A REST API"',
+          "dependencies = [",
+          '  "fastapi>=0.100.0",',
+          '  "sqlalchemy>=2.0",',
+          "]",
+        ].join("\n")
+      );
+
+      const info = parsePyprojectToml(join(dir, "pyproject.toml"));
+      expect(info).not.toBeNull();
+      expect(info!.projectName).toBe("my-api");
+      expect(info!.description).toBe("A REST API");
+      expect(info!.frameworks).toContain("FastAPI");
+      expect(info!.frameworks).toContain("SQLAlchemy");
+    });
+
+    test("returns null for missing file", () => {
+      const info = parsePyprojectToml(join(dir, "pyproject.toml"));
+      expect(info).toBeNull();
+    });
+  });
+
+  describe("parseCargoToml", () => {
+    test("extracts name and description from [package] section", () => {
+      writeFileSync(
+        join(dir, "Cargo.toml"),
+        [
+          "[package]",
+          'name = "my-service"',
+          'description = "A Rust service"',
+          "",
+          "[dependencies]",
+          'actix-web = "4"',
+          'serde = { version = "1", features = ["derive"] }',
+        ].join("\n")
+      );
+
+      const info = parseCargoToml(join(dir, "Cargo.toml"));
+      expect(info).not.toBeNull();
+      expect(info!.projectName).toBe("my-service");
+      expect(info!.description).toBe("A Rust service");
+      expect(info!.frameworks).toContain("Actix Web");
+      expect(info!.frameworks).toContain("Serde");
+    });
+
+    test("returns null for missing file", () => {
+      const info = parseCargoToml(join(dir, "Cargo.toml"));
+      expect(info).toBeNull();
+    });
+  });
+
+  describe("parseGoMod", () => {
+    test("extracts module name and detects frameworks", () => {
+      writeFileSync(
+        join(dir, "go.mod"),
+        [
+          "module github.com/user/my-server",
+          "",
+          "go 1.21",
+          "",
+          "require (",
+          "\tgithub.com/gin-gonic/gin v1.9.1",
+          "\tgorm.io/gorm v1.25.0",
+          ")",
+        ].join("\n")
+      );
+
+      const info = parseGoMod(join(dir, "go.mod"));
+      expect(info).not.toBeNull();
+      expect(info!.projectName).toBe("my-server");
+      expect(info!.description).toBe("");
+      expect(info!.frameworks).toContain("Gin");
+      expect(info!.frameworks).toContain("GORM");
+    });
+
+    test("returns null for missing file", () => {
+      const info = parseGoMod(join(dir, "go.mod"));
+      expect(info).toBeNull();
+    });
+  });
+
+  describe("seedLearningMemory", () => {
+    test("seeds from package.json", () => {
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({
+          name: "my-app",
+          description: "A web app",
+          dependencies: { react: "^18.0.0" },
+        })
+      );
+
+      const mem = seedLearningMemory(dir);
+      expect(mem.projectName).toBe("my-app");
+      expect(mem.sections["Key Learnings"].join(" ")).toContain("my-app");
+      expect(mem.sections["Key Learnings"].join(" ")).toContain("React");
+    });
+
+    test("seeds from multiple metadata files", () => {
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({ name: "mono", dependencies: { typescript: "^5.0" } })
+      );
+      writeFileSync(
+        join(dir, "pyproject.toml"),
+        ['[project]', 'name = "mono-py"', 'dependencies = ["flask"]'].join("\n")
+      );
+
+      const mem = seedLearningMemory(dir);
+      const learnings = mem.sections["Key Learnings"].join(" ");
+      expect(learnings).toContain("TypeScript");
+      expect(learnings).toContain("Flask");
+    });
+
+    test("falls back to directory name when no metadata found", () => {
+      const mem = seedLearningMemory(dir);
+      // dir is a temp path, project name should be the basename
+      expect(mem.projectName).toBeTruthy();
+      expect(mem.sections["Key Learnings"]).toHaveLength(0);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/unit/seed.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the seed module**
+
+```typescript
+// src/core/seed.ts
+import { readFileSync } from "fs";
+import { basename, join } from "path";
+import {
+  createEmptyLearningMemory,
+  addEntry,
+} from "./learning-memory";
+import type { LearningMemory, SeedInfo } from "../types/learning-memory";
+
+// Framework detection maps
+const NPM_FRAMEWORKS: Record<string, string> = {
+  react: "React",
+  "react-dom": "React",
+  next: "Next.js",
+  vue: "Vue",
+  nuxt: "Nuxt",
+  svelte: "Svelte",
+  "@sveltejs/kit": "SvelteKit",
+  angular: "Angular",
+  "@angular/core": "Angular",
+  express: "Express",
+  fastify: "Fastify",
+  hono: "Hono",
+  koa: "Koa",
+  nestjs: "NestJS",
+  "@nestjs/core": "NestJS",
+  typescript: "TypeScript",
+  jest: "Jest",
+  vitest: "Vitest",
+  mocha: "Mocha",
+  tailwindcss: "Tailwind CSS",
+  prisma: "Prisma",
+  "@prisma/client": "Prisma",
+  drizzle: "Drizzle",
+  "drizzle-orm": "Drizzle",
+};
+
+const PYTHON_FRAMEWORKS: Record<string, string> = {
+  fastapi: "FastAPI",
+  flask: "Flask",
+  django: "Django",
+  sqlalchemy: "SQLAlchemy",
+  pytest: "pytest",
+  pydantic: "Pydantic",
+  celery: "Celery",
+  httpx: "HTTPX",
+  uvicorn: "Uvicorn",
+};
+
+const CARGO_FRAMEWORKS: Record<string, string> = {
+  "actix-web": "Actix Web",
+  axum: "Axum",
+  tokio: "Tokio",
+  serde: "Serde",
+  diesel: "Diesel",
+  sqlx: "SQLx",
+  warp: "Warp",
+  rocket: "Rocket",
+};
+
+const GO_FRAMEWORKS: Record<string, string> = {
+  "github.com/gin-gonic/gin": "Gin",
+  "github.com/gofiber/fiber": "Fiber",
+  "github.com/labstack/echo": "Echo",
+  "gorm.io/gorm": "GORM",
+  "github.com/gorilla/mux": "Gorilla Mux",
+};
+
+function safeReadFile(filePath: string): string | null {
+  try {
+    return readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+export function parsePackageJson(filePath: string): SeedInfo | null {
+  const raw = safeReadFile(filePath);
+  if (raw === null) return null;
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  const projectName = (parsed.name as string) || "";
+  const description = (parsed.description as string) || "";
+
+  const deps = {
+    ...(parsed.dependencies as Record<string, string> ?? {}),
+    ...(parsed.devDependencies as Record<string, string> ?? {}),
+  };
+
+  const frameworks = new Set<string>();
+  for (const dep of Object.keys(deps)) {
+    const fw = NPM_FRAMEWORKS[dep];
+    if (fw) frameworks.add(fw);
+  }
+
+  return { projectName, description, frameworks: [...frameworks] };
+}
+
+export function parsePyprojectToml(filePath: string): SeedInfo | null {
+  const raw = safeReadFile(filePath);
+  if (raw === null) return null;
+
+  // Simple TOML parsing for [project] section
+  let projectName = "";
+  let description = "";
+  const frameworks = new Set<string>();
+
+  const nameMatch = raw.match(/^\s*name\s*=\s*"([^"]+)"/m);
+  if (nameMatch) projectName = nameMatch[1];
+
+  const descMatch = raw.match(/^\s*description\s*=\s*"([^"]+)"/m);
+  if (descMatch) description = descMatch[1];
+
+  // Check dependencies list
+  for (const [pkg, fw] of Object.entries(PYTHON_FRAMEWORKS)) {
+    if (raw.includes(pkg)) {
+      frameworks.add(fw);
+    }
+  }
+
+  return { projectName, description, frameworks: [...frameworks] };
+}
+
+export function parseCargoToml(filePath: string): SeedInfo | null {
+  const raw = safeReadFile(filePath);
+  if (raw === null) return null;
+
+  let projectName = "";
+  let description = "";
+  const frameworks = new Set<string>();
+
+  const nameMatch = raw.match(/^\s*name\s*=\s*"([^"]+)"/m);
+  if (nameMatch) projectName = nameMatch[1];
+
+  const descMatch = raw.match(/^\s*description\s*=\s*"([^"]+)"/m);
+  if (descMatch) description = descMatch[1];
+
+  for (const [pkg, fw] of Object.entries(CARGO_FRAMEWORKS)) {
+    if (raw.includes(pkg)) {
+      frameworks.add(fw);
+    }
+  }
+
+  return { projectName, description, frameworks: [...frameworks] };
+}
+
+export function parseGoMod(filePath: string): SeedInfo | null {
+  const raw = safeReadFile(filePath);
+  if (raw === null) return null;
+
+  let projectName = "";
+  const frameworks = new Set<string>();
+
+  // Module name is the last path segment
+  const moduleMatch = raw.match(/^module\s+(.+)$/m);
+  if (moduleMatch) {
+    const modulePath = moduleMatch[1].trim();
+    const parts = modulePath.split("/");
+    projectName = parts[parts.length - 1];
+  }
+
+  for (const [pkg, fw] of Object.entries(GO_FRAMEWORKS)) {
+    if (raw.includes(pkg)) {
+      frameworks.add(fw);
+    }
+  }
+
+  return { projectName, description: "", frameworks: [...frameworks] };
+}
+
+export function seedLearningMemory(projectRoot: string): LearningMemory {
+  const infos: SeedInfo[] = [];
+
+  const pkg = parsePackageJson(join(projectRoot, "package.json"));
+  if (pkg) infos.push(pkg);
+
+  const pyproject = parsePyprojectToml(join(projectRoot, "pyproject.toml"));
+  if (pyproject) infos.push(pyproject);
+
+  const cargo = parseCargoToml(join(projectRoot, "Cargo.toml"));
+  if (cargo) infos.push(cargo);
+
+  const goMod = parseGoMod(join(projectRoot, "go.mod"));
+  if (goMod) infos.push(goMod);
+
+  // Pick project name from first metadata file with a name, or fallback to dirname
+  const projectName =
+    infos.find((i) => i.projectName)?.projectName || basename(projectRoot);
+
+  const mem = createEmptyLearningMemory(projectName);
+
+  // Add project info to Key Learnings
+  const firstDesc = infos.find((i) => i.description)?.description;
+  if (firstDesc) {
+    addEntry(mem, "Key Learnings", `Project: ${projectName} — ${firstDesc}`);
+  }
+
+  // Collect all unique frameworks
+  const allFrameworks = new Set<string>();
+  for (const info of infos) {
+    for (const fw of info.frameworks) {
+      allFrameworks.add(fw);
+    }
+  }
+
+  if (allFrameworks.size > 0) {
+    addEntry(
+      mem,
+      "Key Learnings",
+      `Detected frameworks: ${[...allFrameworks].sort().join(", ")}`
+    );
+  }
+
+  return mem;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/unit/seed.test.ts`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/seed.ts tests/unit/seed.test.ts
+git commit -m "feat(learning-memory): add multi-ecosystem initialization seeding"
+```
+
+---
+
+### Task 6: Reflection (Pruning)
+
+**Files:**
+- Create: `src/core/reflection.ts`
+- Test: `tests/unit/reflection.test.ts`
+
+- [ ] **Step 1: Write failing tests for reflection**
+
+```typescript
+// tests/unit/reflection.test.ts
+import { describe, expect, test } from "bun:test";
+import { reflectMemory, mergeDuplicates, trimOldest } from "../../src/core/reflection";
+import {
+  createEmptyLearningMemory,
+  addEntry,
+  serializeLearningMemory,
+  totalEntryCount,
+} from "../../src/core/learning-memory";
+import type { LearningMemory } from "../../src/types/learning-memory";
+
+describe("reflection", () => {
+  describe("mergeDuplicates", () => {
+    test("removes exact duplicate entries within a section", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "User Preferences", "Use semicolons");
+      addEntry(mem, "User Preferences", "Use semicolons");
+      addEntry(mem, "User Preferences", "Prefer const");
+
+      const merged = mergeDuplicates(mem);
+      expect(merged.sections["User Preferences"]).toEqual([
+        "Use semicolons",
+        "Prefer const",
+      ]);
+    });
+
+    test("removes duplicates with whitespace differences", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "Key Learnings", "API uses rate limiting");
+      addEntry(mem, "Key Learnings", "API  uses  rate  limiting");
+
+      const merged = mergeDuplicates(mem);
+      expect(merged.sections["Key Learnings"]).toHaveLength(1);
+    });
+
+    test("merges Do-Not-Repeat entries with same quoted pattern — keeps newer date", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "Do-Not-Repeat", '[2026-01-01] Never use "var"');
+      addEntry(mem, "Do-Not-Repeat", '[2026-04-10] Avoid "var" — always use const');
+
+      const merged = mergeDuplicates(mem);
+      expect(merged.sections["Do-Not-Repeat"]).toHaveLength(1);
+      expect(merged.sections["Do-Not-Repeat"][0]).toContain("2026-04-10");
+    });
+
+    test("does not merge entries with different quoted patterns", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "Do-Not-Repeat", '[2026-01-01] Never use "var"');
+      addEntry(mem, "Do-Not-Repeat", '[2026-01-02] Never use "any"');
+
+      const merged = mergeDuplicates(mem);
+      expect(merged.sections["Do-Not-Repeat"]).toHaveLength(2);
+    });
+
+    test("no-ops when there are no duplicates", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "User Preferences", "A");
+      addEntry(mem, "User Preferences", "B");
+
+      const merged = mergeDuplicates(mem);
+      expect(merged.sections["User Preferences"]).toEqual(["A", "B"]);
+    });
+
+    test("preserves entries across different sections", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "User Preferences", "Same text");
+      addEntry(mem, "Key Learnings", "Same text");
+
+      const merged = mergeDuplicates(mem);
+      expect(merged.sections["User Preferences"]).toEqual(["Same text"]);
+      expect(merged.sections["Key Learnings"]).toEqual(["Same text"]);
+    });
+  });
+
+  describe("trimOldest", () => {
+    test("trims Decision Log entries first", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "Decision Log", "[2026-01-01] Old decision");
+      addEntry(mem, "Decision Log", "[2026-02-01] Newer decision");
+      addEntry(mem, "User Preferences", "Pref A");
+      addEntry(mem, "Do-Not-Repeat", "[2026-01-01] Important rule");
+
+      // Trim 1 entry
+      const trimmed = trimOldest(mem, 1);
+      expect(trimmed.sections["Decision Log"]).toHaveLength(1);
+      expect(trimmed.sections["Decision Log"][0]).toContain("Newer decision");
+      expect(trimmed.sections["Do-Not-Repeat"]).toHaveLength(1);
+      expect(trimmed.sections["User Preferences"]).toHaveLength(1);
+    });
+
+    test("trims Key Learnings and User Preferences after Decision Log is empty", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "Key Learnings", "Learning A");
+      addEntry(mem, "Key Learnings", "Learning B");
+      addEntry(mem, "User Preferences", "Pref A");
+      addEntry(mem, "Do-Not-Repeat", "[2026-01-01] Rule");
+
+      // Trim 2 entries — no Decision Log to trim, so goes to Key Learnings then User Preferences
+      const trimmed = trimOldest(mem, 2);
+      expect(trimmed.sections["Key Learnings"]).toHaveLength(1);
+      expect(trimmed.sections["Key Learnings"][0]).toBe("Learning B");
+      expect(trimmed.sections["User Preferences"]).toHaveLength(0);
+      expect(trimmed.sections["Do-Not-Repeat"]).toHaveLength(1);
+    });
+
+    test("trims Do-Not-Repeat last", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "Do-Not-Repeat", "[2026-01-01] Rule A");
+      addEntry(mem, "Do-Not-Repeat", "[2026-02-01] Rule B");
+
+      // Trim 1 — only DNR entries available
+      const trimmed = trimOldest(mem, 1);
+      expect(trimmed.sections["Do-Not-Repeat"]).toHaveLength(1);
+      expect(trimmed.sections["Do-Not-Repeat"][0]).toContain("Rule B");
+    });
+
+    test("no-ops when trimCount is 0", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "User Preferences", "A");
+
+      const trimmed = trimOldest(mem, 0);
+      expect(trimmed.sections["User Preferences"]).toEqual(["A"]);
+    });
+
+    test("handles trimming more entries than exist", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "User Preferences", "A");
+
+      const trimmed = trimOldest(mem, 10);
+      expect(totalEntryCount(trimmed)).toBe(0);
+    });
+  });
+
+  describe("reflectMemory", () => {
+    test("returns no-op result when under budget", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "User Preferences", "A short entry");
+
+      const result = reflectMemory(mem, 2000);
+      expect(result.result.mergedCount).toBe(0);
+      expect(result.result.trimmedCount).toBe(0);
+      expect(result.result.withinBudget).toBe(true);
+    });
+
+    test("merges duplicates to get under budget", () => {
+      const mem = createEmptyLearningMemory("test");
+      // Add many duplicate entries to push over a low budget
+      for (let i = 0; i < 20; i++) {
+        addEntry(mem, "User Preferences", "Duplicate entry content");
+      }
+
+      const result = reflectMemory(mem, 2000);
+      expect(result.result.mergedCount).toBeGreaterThan(0);
+      expect(result.result.withinBudget).toBe(true);
+    });
+
+    test("trims oldest when merging is insufficient", () => {
+      const mem = createEmptyLearningMemory("test");
+      // Add many unique entries to push over a very low budget
+      for (let i = 0; i < 50; i++) {
+        addEntry(mem, "Decision Log", `[2026-01-${String(i + 1).padStart(2, "0")}] Unique decision number ${i}`);
+      }
+
+      const result = reflectMemory(mem, 200);
+      expect(result.result.trimmedCount).toBeGreaterThan(0);
+      expect(result.result.withinBudget).toBe(true);
+    });
+
+    test("returns updated memory", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "User Preferences", "Same");
+      addEntry(mem, "User Preferences", "Same");
+
+      const { memory } = reflectMemory(mem, 2000);
+      expect(memory.sections["User Preferences"]).toHaveLength(1);
+    });
+
+    test("handles zero budget — skips pruning", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "User Preferences", "A");
+
+      const result = reflectMemory(mem, 0);
+      expect(result.result.withinBudget).toBe(true);
+      expect(result.memory.sections["User Preferences"]).toEqual(["A"]);
+    });
+
+    test("handles negative budget — skips pruning", () => {
+      const mem = createEmptyLearningMemory("test");
+      addEntry(mem, "User Preferences", "A");
+
+      const result = reflectMemory(mem, -1);
+      expect(result.result.withinBudget).toBe(true);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/unit/reflection.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the reflection module**
+
+```typescript
+// src/core/reflection.ts
+import type {
+  LearningMemory,
+  SectionName,
+  ReflectionResult,
+} from "../types/learning-memory";
+import {
+  createEmptyLearningMemory,
+  serializeLearningMemory,
+  totalEntryCount,
+} from "./learning-memory";
+import { estimateTokens } from "./token-estimate";
+
+function normalize(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function extractQuoted(entry: string): string | null {
+  const match = entry.match(/["']([^"']+)["']/);
+  return match ? match[1] : null;
+}
+
+function parseDate(entry: string): string {
+  const match = entry.match(/^\[(\d{4}-\d{2}-\d{2})\]/);
+  return match ? match[1] : "0000-00-00";
+}
+
+function estimateMemoryTokens(mem: LearningMemory): number {
+  const content = serializeLearningMemory(mem);
+  return estimateTokens(content, "learning-memory.md");
+}
+
+export function mergeDuplicates(mem: LearningMemory): LearningMemory {
+  const merged = createEmptyLearningMemory(mem.projectName);
+
+  const sectionNames: SectionName[] = [
+    "User Preferences",
+    "Key Learnings",
+    "Do-Not-Repeat",
+    "Decision Log",
+  ];
+
+  for (const section of sectionNames) {
+    const entries = mem.sections[section];
+
+    if (section === "Do-Not-Repeat") {
+      // Group by quoted pattern, keep the entry with the newest date
+      const byPattern = new Map<string, string>();
+      const noPattern: string[] = [];
+
+      for (const entry of entries) {
+        const quoted = extractQuoted(entry);
+        if (quoted) {
+          const existing = byPattern.get(quoted);
+          if (existing) {
+            // Keep the one with the newer date
+            if (parseDate(entry) > parseDate(existing)) {
+              byPattern.set(quoted, entry);
+            }
+          } else {
+            byPattern.set(quoted, entry);
+          }
+        } else {
+          // No quoted pattern — deduplicate by normalized text
+          const norm = normalize(entry);
+          if (!noPattern.some((e) => normalize(e) === norm)) {
+            noPattern.push(entry);
+          }
+        }
+      }
+
+      merged.sections[section] = [...byPattern.values(), ...noPattern];
+    } else {
+      // Deduplicate by normalized text
+      const seen = new Set<string>();
+      for (const entry of entries) {
+        const norm = normalize(entry);
+        if (!seen.has(norm)) {
+          seen.add(norm);
+          merged.sections[section].push(entry);
+        }
+      }
+    }
+  }
+
+  return merged;
+}
+
+// Trim order: Decision Log first, then Key Learnings, then User Preferences, then Do-Not-Repeat last
+const TRIM_ORDER: SectionName[] = [
+  "Decision Log",
+  "Key Learnings",
+  "User Preferences",
+  "Do-Not-Repeat",
+];
+
+export function trimOldest(mem: LearningMemory, trimCount: number): LearningMemory {
+  const trimmed = createEmptyLearningMemory(mem.projectName);
+
+  // Deep copy sections
+  for (const section of TRIM_ORDER) {
+    trimmed.sections[section] = [...mem.sections[section]];
+  }
+
+  let remaining = trimCount;
+
+  for (const section of TRIM_ORDER) {
+    if (remaining <= 0) break;
+
+    const entries = trimmed.sections[section];
+    const toRemove = Math.min(remaining, entries.length);
+
+    if (toRemove > 0) {
+      // Remove oldest (first) entries
+      trimmed.sections[section] = entries.slice(toRemove);
+      remaining -= toRemove;
+    }
+  }
+
+  return trimmed;
+}
+
+export function reflectMemory(
+  mem: LearningMemory,
+  tokenBudget: number
+): { memory: LearningMemory; result: ReflectionResult } {
+  // Skip pruning for zero or negative budget
+  if (tokenBudget <= 0) {
+    const tokens = estimateMemoryTokens(mem);
+    return {
+      memory: mem,
+      result: {
+        beforeTokens: tokens,
+        afterTokens: tokens,
+        mergedCount: 0,
+        trimmedCount: 0,
+        withinBudget: true,
+      },
+    };
+  }
+
+  const beforeTokens = estimateMemoryTokens(mem);
+
+  if (beforeTokens <= tokenBudget) {
+    return {
+      memory: mem,
+      result: {
+        beforeTokens,
+        afterTokens: beforeTokens,
+        mergedCount: 0,
+        trimmedCount: 0,
+        withinBudget: true,
+      },
+    };
+  }
+
+  // Step 1: Merge duplicates
+  const beforeMergeCount = totalEntryCount(mem);
+  let current = mergeDuplicates(mem);
+  const afterMergeCount = totalEntryCount(current);
+  const mergedCount = beforeMergeCount - afterMergeCount;
+
+  let afterTokens = estimateMemoryTokens(current);
+
+  if (afterTokens <= tokenBudget) {
+    return {
+      memory: current,
+      result: {
+        beforeTokens,
+        afterTokens,
+        mergedCount,
+        trimmedCount: 0,
+        withinBudget: true,
+      },
+    };
+  }
+
+  // Step 2: Trim oldest, one at a time
+  let trimmedCount = 0;
+
+  while (afterTokens > tokenBudget && totalEntryCount(current) > 0) {
+    current = trimOldest(current, 1);
+    trimmedCount++;
+    afterTokens = estimateMemoryTokens(current);
+  }
+
+  return {
+    memory: current,
+    result: {
+      beforeTokens,
+      afterTokens,
+      mergedCount,
+      trimmedCount,
+      withinBudget: afterTokens <= tokenBudget,
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/unit/reflection.test.ts`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/reflection.ts tests/unit/reflection.test.ts
+git commit -m "feat(learning-memory): add reflection with merge and trim pruning"
+```
+
+---
+
+### Task 7: Reflect CLI Command
+
+**Files:**
+- Create: `src/commands/reflect.ts`
+- Create: `tests/unit/reflect-command.test.ts`
+- Modify: `src/cli.ts`
+
+- [ ] **Step 1: Write failing tests for the reflect command**
+
+```typescript
+// tests/unit/reflect-command.test.ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { atomicWriteText } from "../../src/core/fs-utils";
+import {
+  createEmptyLearningMemory,
+  addEntry,
+  serializeLearningMemory,
+  parseLearningMemory,
+} from "../../src/core/learning-memory";
+import { reflect } from "../../src/commands/reflect";
+
+describe("reflect command", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mink-reflect-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("returns without error when learning memory is missing", () => {
+    const result = reflect(dir, join(dir, "learning-memory.md"), join(dir, "config.json"));
+    expect(result).toBeNull();
+  });
+
+  test("prunes duplicates and saves", () => {
+    const mem = createEmptyLearningMemory("test");
+    addEntry(mem, "User Preferences", "Duplicate");
+    addEntry(mem, "User Preferences", "Duplicate");
+    addEntry(mem, "User Preferences", "Unique");
+
+    const memPath = join(dir, "learning-memory.md");
+    atomicWriteText(memPath, serializeLearningMemory(mem));
+
+    const result = reflect(dir, memPath, join(dir, "config.json"));
+    expect(result).not.toBeNull();
+
+    // Read back the file
+    const saved = readFileSync(memPath, "utf-8");
+    const parsed = parseLearningMemory(saved);
+    expect(parsed.sections["User Preferences"]).toEqual(["Duplicate", "Unique"]);
+  });
+
+  test("uses default budget of 2000 when no config", () => {
+    const mem = createEmptyLearningMemory("test");
+    addEntry(mem, "User Preferences", "Short entry");
+
+    const memPath = join(dir, "learning-memory.md");
+    atomicWriteText(memPath, serializeLearningMemory(mem));
+
+    const result = reflect(dir, memPath, join(dir, "config.json"));
+    expect(result).not.toBeNull();
+    expect(result!.withinBudget).toBe(true);
+  });
+
+  test("reads custom budget from config", () => {
+    const mem = createEmptyLearningMemory("test");
+    for (let i = 0; i < 30; i++) {
+      addEntry(mem, "Decision Log", `[2026-01-${String(i + 1).padStart(2, "0")}] Decision ${i} with some extra text to take up space`);
+    }
+
+    const memPath = join(dir, "learning-memory.md");
+    atomicWriteText(memPath, serializeLearningMemory(mem));
+
+    // Write a config with a very low budget
+    const configPath = join(dir, "config.json");
+    const { atomicWriteJson } = require("../../src/core/fs-utils");
+    atomicWriteJson(configPath, { learningMemoryTokenBudget: 100 });
+
+    const result = reflect(dir, memPath, configPath);
+    expect(result).not.toBeNull();
+    expect(result!.trimmedCount).toBeGreaterThan(0);
+    expect(result!.withinBudget).toBe(true);
+  });
+
+  test("does not modify file if already within budget and no duplicates", () => {
+    const mem = createEmptyLearningMemory("test");
+    addEntry(mem, "User Preferences", "Unique entry");
+
+    const memPath = join(dir, "learning-memory.md");
+    const content = serializeLearningMemory(mem);
+    atomicWriteText(memPath, content);
+
+    reflect(dir, memPath, join(dir, "config.json"));
+
+    const saved = readFileSync(memPath, "utf-8");
+    expect(saved).toBe(content);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/unit/reflect-command.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the reflect command**
+
+```typescript
+// src/commands/reflect.ts
+import { readFileSync, existsSync } from "fs";
+import { atomicWriteText } from "../core/fs-utils";
+import { safeReadJson } from "../core/fs-utils";
+import {
+  parseLearningMemory,
+  serializeLearningMemory,
+} from "../core/learning-memory";
+import { reflectMemory } from "../core/reflection";
+import type { ProjectConfig } from "../types/file-index";
+import type { ReflectionResult } from "../types/learning-memory";
+
+const DEFAULT_TOKEN_BUDGET = 2000;
+
+export function reflect(
+  projectDir: string,
+  memoryPath: string,
+  configPath: string
+): ReflectionResult | null {
+  if (!existsSync(memoryPath)) {
+    console.log("[mink] no learning memory found");
+    return null;
+  }
+
+  const content = readFileSync(memoryPath, "utf-8");
+  const mem = parseLearningMemory(content);
+
+  // Load token budget from config
+  const config = (safeReadJson(configPath) as ProjectConfig) ?? {};
+  const budget = config.learningMemoryTokenBudget ?? DEFAULT_TOKEN_BUDGET;
+
+  const { memory, result } = reflectMemory(mem, budget);
+
+  // Only write if something changed
+  if (result.mergedCount > 0 || result.trimmedCount > 0) {
+    atomicWriteText(memoryPath, serializeLearningMemory(memory));
+  }
+
+  console.log("[mink] reflect");
+  console.log(
+    `  tokens: ${result.beforeTokens} → ${result.afterTokens} (${result.withinBudget ? "within" : "over"} ${budget} budget)`
+  );
+  if (result.mergedCount > 0) {
+    console.log(`  merged: ${result.mergedCount} duplicate entries`);
+  }
+  if (result.trimmedCount > 0) {
+    console.log(`  trimmed: ${result.trimmedCount} stale entries`);
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/unit/reflect-command.test.ts`
+Expected: All PASS
+
+- [ ] **Step 5: Add `reflect` to CLI routing**
+
+In `src/cli.ts`, add a new case before the `default` case:
+
+```typescript
+  case "reflect": {
+    const { reflect } = await import("./commands/reflect");
+    const { learningMemoryPath, configPath } = await import("./core/paths");
+    reflect(cwd, learningMemoryPath(cwd), configPath(cwd));
+    break;
+  }
+```
+
+Also update the usage string:
+
+```typescript
+    console.error("Usage: mink <session-start|session-stop|init|scan|reflect>");
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/reflect.ts tests/unit/reflect-command.test.ts src/cli.ts
+git commit -m "feat(learning-memory): add mink reflect command with CLI routing"
+```
+
+---
+
+### Task 8: Session-Stop Integration
+
+**Files:**
+- Modify: `src/commands/session-stop.ts`
+- Modify: `tests/unit/session-stop.test.ts`
+
+- [ ] **Step 1: Write failing test for reflect-on-stop behavior**
+
+Add to `tests/unit/session-stop.test.ts`:
+
+```typescript
+  test("calls reflect on session stop", () => {
+    const state = createSessionState();
+    recordRead(state, "/src/a.ts", 100, true);
+    const sessionFile = setupSession(dir, state);
+
+    // Create a learning memory with duplicates
+    const memPath = join(dir, "learning-memory.md");
+    writeFileSync(
+      memPath,
+      [
+        "# Learning Memory — test",
+        "",
+        "## User Preferences",
+        "",
+        "- Duplicate",
+        "- Duplicate",
+        "",
+        "## Key Learnings",
+        "",
+        "## Do-Not-Repeat",
+        "",
+        "## Decision Log",
+        "",
+      ].join("\n")
+    );
+
+    sessionStop(sessionFile);
+
+    // Verify duplicates were merged
+    const saved = readFileSync(memPath, "utf-8");
+    const occurrences = saved.split("- Duplicate").length - 1;
+    expect(occurrences).toBe(1);
+  });
+```
+
+Add `readFileSync` to the imports at the top of the file if not already present.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/unit/session-stop.test.ts`
+Expected: FAIL — duplicate not merged (reflect not wired yet)
+
+- [ ] **Step 3: Update session-stop to call reflect and use learningMemoryPath**
+
+Replace the `isLearningMemoryStale` function and its usage in `src/commands/session-stop.ts`:
+
+```typescript
+import { statSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { safeReadJson, atomicWriteJson } from "../core/fs-utils";
+import { isSessionState, buildSummary } from "../core/session";
+import { reflect } from "./reflect";
+import type { SessionState, SessionFinalizer } from "../types/session";
+
+const noopFinalizer: SessionFinalizer = {
+  appendSession() {},
+  updateSession() {},
+};
+
+function hasActivity(state: SessionState): boolean {
+  return Object.keys(state.reads).length > 0 || state.writes.length > 0;
+}
+
+function getEditCounts(state: SessionState): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const write of state.writes) {
+    counts[write.filePath] = (counts[write.filePath] || 0) + 1;
+  }
+  return counts;
+}
+
+function isLearningMemoryStale(memoryPath: string): boolean {
+  try {
+    const stat = statSync(memoryPath);
+    const ageMs = Date.now() - stat.mtimeMs;
+    const twentyFourHours = 24 * 60 * 60 * 1000;
+    return ageMs > twentyFourHours;
+  } catch {
+    return false;
+  }
+}
+
+export function sessionStop(
+  sessionFile: string,
+  finalizer: SessionFinalizer = noopFinalizer,
+  onReminder: (msg: string) => void = (msg) => console.error(msg)
+): void {
+  const raw = safeReadJson(sessionFile);
+  if (!isSessionState(raw)) {
+    if (raw !== null) {
+      console.error("[mink] session.json is corrupt — skipping finalization");
+    }
+    return;
+  }
+
+  const state: SessionState = raw;
+  state.stopCount++;
+
+  if (hasActivity(state)) {
+    const summary = buildSummary(state);
+
+    if (state.stopCount === 1) {
+      finalizer.appendSession(summary);
+    } else {
+      finalizer.updateSession(summary);
+    }
+  }
+
+  // Check for files edited 3+ times
+  const editCounts = getEditCounts(state);
+  for (const [filePath, count] of Object.entries(editCounts)) {
+    if (count >= 3) {
+      onReminder(
+        `[mink] ${filePath} was edited ${count} times — consider logging a bug`
+      );
+    }
+  }
+
+  // Run reflection on learning memory
+  const projDir = dirname(sessionFile);
+  const memoryPath = join(projDir, "learning-memory.md");
+  const cfgPath = join(projDir, "config.json");
+
+  if (existsSync(memoryPath)) {
+    reflect(projDir, memoryPath, cfgPath);
+  }
+
+  // Check if learning memory is stale (>24h since last update)
+  if (isLearningMemoryStale(memoryPath)) {
+    onReminder(
+      "[mink] learning memory hasn't been updated in 24+ hours — consider reviewing it"
+    );
+  }
+
+  atomicWriteJson(sessionFile, state);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/unit/session-stop.test.ts`
+Expected: All PASS
+
+- [ ] **Step 5: Run all tests to verify no regressions**
+
+Run: `bun test`
+Expected: All existing tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/session-stop.ts tests/unit/session-stop.test.ts
+git commit -m "feat(learning-memory): wire reflect into session-stop"
+```
+
+---
+
+### Task 9: Init Integration
+
+**Files:**
+- Modify: `src/commands/init.ts`
+- Modify: `tests/unit/init.test.ts`
+
+- [ ] **Step 1: Write failing test for seed-on-init**
+
+Add to `tests/unit/init.test.ts`:
+
+```typescript
+  test("creates learning memory on init", async () => {
+    // After init, learning-memory.md should exist in project dir
+    // We need to verify init calls seedLearningMemory
+    // Use a temp project directory with a package.json
+
+    const projectDir = mkdtempSync(join(tmpdir(), "mink-init-seed-"));
+    writeFileSync(
+      join(projectDir, "package.json"),
+      JSON.stringify({ name: "test-project", description: "A test", dependencies: { react: "^18" } })
+    );
+
+    await init(projectDir);
+
+    const memPath = join(dir, "learning-memory.md");
+    // Note: the actual path is in ~/.mink/projects/<slug>/
+    // We need to check the project dir — use paths helper
+    const { learningMemoryPath } = await import("../../src/core/paths");
+    const actualPath = learningMemoryPath(projectDir);
+    expect(existsSync(actualPath)).toBe(true);
+
+    const content = readFileSync(actualPath, "utf-8");
+    expect(content).toContain("test-project");
+    expect(content).toContain("React");
+
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+```
+
+Add `existsSync, readFileSync` to imports. Adjust based on existing test patterns in `init.test.ts`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/unit/init.test.ts`
+Expected: FAIL — learning-memory.md not created
+
+- [ ] **Step 3: Update init.ts to seed learning memory**
+
+Add to `src/commands/init.ts`, in the `init` function, after the scan call:
+
+```typescript
+  // Seed learning memory if it doesn't exist
+  const { learningMemoryPath } = await import("../core/paths");
+  const memPath = learningMemoryPath(cwd);
+  if (!existsSync(memPath)) {
+    const { seedLearningMemory } = await import("../core/seed");
+    const { serializeLearningMemory } = await import("../core/learning-memory");
+    const { atomicWriteText } = await import("../core/fs-utils");
+    const mem = seedLearningMemory(cwd);
+    atomicWriteText(memPath, serializeLearningMemory(mem));
+  }
+```
+
+Add `existsSync` to the `fs` import at the top of the file.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/unit/init.test.ts`
+Expected: All PASS
+
+- [ ] **Step 5: Run all tests to verify no regressions**
+
+Run: `bun test`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/init.ts tests/unit/init.test.ts
+git commit -m "feat(learning-memory): seed learning memory on mink init"
+```
+
+---
+
+### Task 10: Integration Tests
+
+**Files:**
+- Create: `tests/integration/learning-memory.test.ts`
+
+- [ ] **Step 1: Write integration tests**
+
+```typescript
+// tests/integration/learning-memory.test.ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { atomicWriteText } from "../../src/core/fs-utils";
+import { seedLearningMemory } from "../../src/core/seed";
+import {
+  parseLearningMemory,
+  serializeLearningMemory,
+  addEntry,
+  createEmptyLearningMemory,
+} from "../../src/core/learning-memory";
+import { extractPatterns, matchPatterns } from "../../src/core/pattern-engine";
+import { reflectMemory } from "../../src/core/reflection";
+import { reflect } from "../../src/commands/reflect";
+
+describe("learning memory integration", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mink-lm-int-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("full lifecycle: seed → add entries → reflect → verify", () => {
+    // Seed
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        name: "lifecycle-test",
+        description: "Integration test project",
+        dependencies: { express: "^4.0", typescript: "^5.0" },
+      })
+    );
+
+    const mem = seedLearningMemory(dir);
+    expect(mem.projectName).toBe("lifecycle-test");
+    expect(mem.sections["Key Learnings"].join(" ")).toContain("Express");
+
+    // Add entries
+    addEntry(mem, "User Preferences", "Prefer named exports");
+    addEntry(mem, "Do-Not-Repeat", '[2026-04-10] Never use "var" — always const');
+    addEntry(mem, "Decision Log", "[2026-04-10] Use Express over Koa");
+
+    // Save
+    const memPath = join(dir, "learning-memory.md");
+    atomicWriteText(memPath, serializeLearningMemory(mem));
+
+    // Read back and verify round-trip
+    const saved = readFileSync(memPath, "utf-8");
+    const parsed = parseLearningMemory(saved);
+    expect(parsed.projectName).toBe("lifecycle-test");
+    expect(parsed.sections["User Preferences"]).toContain("Prefer named exports");
+    expect(parsed.sections["Do-Not-Repeat"]).toHaveLength(1);
+  });
+
+  test("pattern extraction → matching end-to-end", () => {
+    const mem = createEmptyLearningMemory("test");
+    addEntry(mem, "Do-Not-Repeat", '[2026-04-10] Never use "var" — always const');
+    addEntry(mem, "Do-Not-Repeat", "[2026-04-10] Avoid mocking the database in integration tests");
+
+    const patterns = extractPatterns(mem.sections["Do-Not-Repeat"]);
+
+    // Should match "var" in code
+    const codeWithVar = 'function foo() { var x = 5; return x; }';
+    const varMatches = matchPatterns(patterns, codeWithVar);
+    expect(varMatches.length).toBeGreaterThan(0);
+    expect(varMatches.some((m) => m.matchedText === "var")).toBe(true);
+
+    // Should match "mocking the database" in test code
+    const testCode = 'describe("api", () => { mocking the database for speed });';
+    const mockMatches = matchPatterns(patterns, testCode);
+    expect(mockMatches.length).toBeGreaterThan(0);
+
+    // Should NOT match clean code
+    const cleanCode = 'const x = 5; const db = connectReal();';
+    const noMatches = matchPatterns(patterns, cleanCode);
+    expect(noMatches).toHaveLength(0);
+  });
+
+  test("reflect command prunes bloated memory via file", () => {
+    const mem = createEmptyLearningMemory("test");
+    // Add many entries to exceed a low budget
+    for (let i = 0; i < 30; i++) {
+      addEntry(mem, "Decision Log", `[2026-01-${String(i + 1).padStart(2, "0")}] Decision ${i} with padding text`);
+    }
+    addEntry(mem, "Do-Not-Repeat", '[2026-04-10] Never use "eval"');
+
+    const memPath = join(dir, "learning-memory.md");
+    atomicWriteText(memPath, serializeLearningMemory(mem));
+
+    // Config with low budget
+    const configPath = join(dir, "config.json");
+    writeFileSync(configPath, JSON.stringify({ learningMemoryTokenBudget: 200 }));
+
+    const result = reflect(dir, memPath, configPath);
+    expect(result).not.toBeNull();
+    expect(result!.withinBudget).toBe(true);
+    expect(result!.trimmedCount).toBeGreaterThan(0);
+
+    // Do-Not-Repeat should survive (trimmed last)
+    const saved = readFileSync(memPath, "utf-8");
+    const parsed = parseLearningMemory(saved);
+    expect(parsed.sections["Do-Not-Repeat"].length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("corrupted learning memory file is handled gracefully", () => {
+    const memPath = join(dir, "learning-memory.md");
+    writeFileSync(memPath, "completely garbled \x00\x01\x02 content");
+
+    // parseLearningMemory should not throw
+    const content = readFileSync(memPath, "utf-8");
+    const parsed = parseLearningMemory(content);
+    expect(parsed.projectName).toBe("unknown");
+    expect(parsed.sections["User Preferences"]).toEqual([]);
+  });
+
+  test("empty project seeds with directory name only", () => {
+    const mem = seedLearningMemory(dir);
+    expect(mem.projectName).toBeTruthy();
+    expect(mem.sections["Key Learnings"]).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `bun test tests/integration/learning-memory.test.ts`
+Expected: All PASS
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `bun test`
+Expected: All PASS across all test files
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/learning-memory.test.ts
+git commit -m "test(learning-memory): add integration tests for full lifecycle"
+```
+
+---
+
+### Task 11: E2E Smoke Test
+
+**Files:** None (manual verification)
+
+- [ ] **Step 1: Run `mink init` in a test project**
+
+```bash
+cd /tmp && mkdir smoke-lm && cd smoke-lm
+echo '{"name":"smoke","description":"Smoke test","dependencies":{"express":"^4"}}' > package.json
+bun /Users/drewpayment/dev/mink/src/cli.ts init
+```
+
+Expected: Output shows initialized, learning memory file created.
+
+- [ ] **Step 2: Verify learning memory was created with seed content**
+
+```bash
+cat ~/.mink/projects/smoke-*/learning-memory.md
+```
+
+Expected: Contains `# Learning Memory — smoke`, Key Learnings with Express detected, all 4 sections present.
+
+- [ ] **Step 3: Run `mink reflect`**
+
+```bash
+bun /Users/drewpayment/dev/mink/src/cli.ts reflect
+```
+
+Expected: Output shows token count, within budget, no merges or trims needed.
+
+- [ ] **Step 4: Clean up**
+
+```bash
+rm -rf /tmp/smoke-lm ~/.mink/projects/smoke-*
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec Requirement | Task |
+|-----------------|------|
+| Four-section structure | Task 1 (types), Task 2 (parse/serialize) |
+| Initialization seeding from metadata | Task 5 (seed), Task 9 (init integration) |
+| Manual updates (add/remove entries) | Task 2 (CRUD functions) |
+| Pattern extraction from Do-Not-Repeat | Task 4 (pattern engine) |
+| Pattern matching against content | Task 4 (matchPatterns) |
+| Non-blocking warnings only | Task 4 (returns matches, never blocks) |
+| Token budget enforcement | Task 6 (reflection) |
+| Merge duplicates, then trim oldest | Task 6 (mergeDuplicates, trimOldest) |
+| `mink reflect` CLI command | Task 7 |
+| Session-stop calls reflect | Task 8 |
+| Staleness reminder (>24h) | Task 8 (preserved from existing code) |
+| Init seeds learning memory | Task 9 |
+| Corrupted file recovery | Task 2 (parseLearningMemory handles any input), Task 10 (edge test) |
+| Multiple matching warnings | Task 4 (matchPatterns returns all matches), Task 10 (integration test) |
+
+**Placeholder scan:** No TBD, TODO, or vague instructions found.
+
+**Type consistency:** `LearningMemory`, `SectionName`, `ExtractedPattern`, `PatternMatch`, `ReflectionResult`, `SeedInfo` — all used consistently across tasks 1-10. Function signatures match between implementation and test code.

--- a/docs/superpowers/specs/2026-04-10-learning-memory-design.md
+++ b/docs/superpowers/specs/2026-04-10-learning-memory-design.md
@@ -1,0 +1,262 @@
+# Learning Memory — Implementation Design
+
+## Summary
+
+Spec 03 builds a persistent, structured markdown document that accumulates project knowledge across sessions. It has four sections: User Preferences, Key Learnings, Do-Not-Repeat, and Decision Log. A pattern engine extracts enforceable rules from Do-Not-Repeat entries for future pre-write hook integration (spec 06). A reflection command prunes the memory to stay within a configurable token budget.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Storage format | Pure markdown (`learning-memory.md`) | Human-readable, the spec describes it as a "document," entries are natural-language prose |
+| Pattern extraction scope | Exact spec — quoted strings + "never use"/"avoid" only | Predictable behavior, minimal false positives, expandable later |
+| Initialization seeding | Multi-ecosystem (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`) | Broader coverage from the start |
+| Pruning trigger | `mink reflect` CLI command, also called from session-stop | Standalone command for flexibility, automatic on session end |
+| Pruning strategy | Merge duplicates first, then trim oldest | Matches spec language, preserves unique actionable entries |
+| Write enforcement | Pure functions only (no hook wiring until spec 06) | Functions are testable in isolation, spec 06 wires the hook |
+
+## Module Structure
+
+```
+src/
+├── core/
+│   ├── learning-memory.ts    # CRUD: parse, serialize, add/remove entries, section management
+│   ├── pattern-engine.ts     # Pure functions: extractPatterns, matchPatterns
+│   ├── reflection.ts         # Pruning: duplicate detection, merge, oldest-first trim
+│   └── seed.ts               # Initialization: parse metadata files, generate seed content
+├── commands/
+│   ├── reflect.ts            # CLI handler: load memory, prune, save
+│   └── session-stop.ts       # (modified) call reflect after session finalization
+├── types/
+│   └── learning-memory.ts    # Interfaces for entries, sections, patterns, match results
+```
+
+State files:
+
+```
+~/.mink/projects/<slug>/
+├── learning-memory.md        # The learning memory document
+├── config.json               # User overrides (learningMemoryTokenBudget)
+```
+
+## Markdown Format
+
+```markdown
+# Learning Memory — my-project
+
+## User Preferences
+
+- Prefer named exports over default exports
+- Use camelCase for variables, PascalCase for types
+
+## Key Learnings
+
+- Project: my-api — A REST API for user management
+- Detected frameworks: Express, TypeScript, Jest
+
+## Do-Not-Repeat
+
+- [2026-04-10] Never use "var" — always "const" or "let"
+- [2026-04-10] Avoid mocking the database in integration tests — use test fixtures instead
+
+## Decision Log
+
+- [2026-04-10] Chose Bun as primary runtime with Node.js fallback for portability
+```
+
+### Parsing Rules
+
+- Sections identified by `## ` heading matching one of the four known names.
+- Entries are lines starting with `- ` under each section heading.
+- Do-Not-Repeat and Decision Log entries require `[YYYY-MM-DD]` date prefix.
+- Blank lines between entries are preserved but ignored during parsing.
+- Everything outside recognized sections is ignored (future-proofing).
+
+### Serialization
+
+Sections emitted in fixed order: User Preferences → Key Learnings → Do-Not-Repeat → Decision Log. Title line is `# Learning Memory — <project-name>`.
+
+## Initialization Seeding
+
+When `mink init` runs (or when learning memory doesn't exist and is needed), `seed.ts` inspects project metadata files.
+
+### Metadata File Parsing
+
+| File | Extract |
+|------|---------|
+| `package.json` | `name`, `description`, `dependencies`/`devDependencies` keys for framework detection |
+| `pyproject.toml` | `[project]` name/description, `[project.dependencies]` for framework detection |
+| `Cargo.toml` | `[package]` name/description, `[dependencies]` keys |
+| `go.mod` | Module path as name, dependency lines for framework detection |
+
+### Framework Detection
+
+Match dependency names against a known map (e.g., `react` → "React", `fastapi` → "FastAPI", `actix-web` → "Actix Web"). List detected frameworks in the Key Learnings section as seed entries.
+
+### Seed Output
+
+```markdown
+# Learning Memory — my-api
+
+## User Preferences
+
+(empty)
+
+## Key Learnings
+
+- Project: my-api — A REST API for user management
+- Detected frameworks: Express, TypeScript, Jest
+
+## Do-Not-Repeat
+
+(empty)
+
+## Decision Log
+
+(empty)
+```
+
+### Edge Cases
+
+- No metadata file found → seed with directory name only, no framework detection.
+- Multiple metadata files (monorepo) → include findings from all.
+- Metadata file exists but is malformed → skip it, no error.
+
+## Pattern Engine
+
+Pure functions in `pattern-engine.ts` for Do-Not-Repeat enforcement.
+
+### `extractPatterns(doNotRepeatEntries: string[])`
+
+Takes raw entry strings, returns an array of pattern objects. Tried in priority order:
+
+1. **Quoted strings** — extract content between `"..."` or `'...'`. Match literally in target content.
+   - `'Never use "var"'` → literal pattern `var`
+   - `'Avoid "export default"'` → literal pattern `export default`
+
+2. **"Never use" / "avoid" phrases** — extract the word(s) following these triggers up to end of phrase (punctuation or dash). Match as word-boundary patterns.
+   - `'Avoid mocking the database in integration tests'` → word-boundary pattern `mocking the database`
+   - `'Never use default exports'` → word-boundary pattern `default exports`
+
+3. **Both can appear in one entry** — extract all patterns found.
+
+4. **No extractable pattern** — entry is skipped, no pattern produced.
+
+### `matchPatterns(patterns, content)`
+
+Takes extracted patterns + file content. Returns array of match results: matched pattern, original Do-Not-Repeat entry text, matched substring location.
+
+- Literal patterns: `content.includes(pattern)` — case-sensitive.
+- Word-boundary patterns: regex with `\b` anchors — case-insensitive.
+
+## Reflection (Pruning)
+
+### Flow
+
+1. **Estimate tokens.** Use `estimateTokens()` on the full markdown content (prose ratio, 4.0 chars/token). If under budget (default 2000), done.
+
+2. **Merge duplicates.** Within each section, compare entries pairwise:
+   - **Exact duplicates** (normalized whitespace) → keep one.
+   - **Same quoted pattern** in Do-Not-Repeat entries → merge, keep newer date.
+   - **Substring containment** — if one entry fully contains another's meaning → keep the more specific one.
+
+3. **Trim oldest.** If still over budget after merging, remove entries one at a time:
+   - Decision Log trimmed first (historical, least actionable).
+   - Key Learnings and User Preferences trimmed next by age.
+   - Do-Not-Repeat trimmed last (enforced, highest value).
+   - Re-check budget after each removal.
+
+### Token Budget
+
+Default 2000, configurable via `config.json` (`learningMemoryTokenBudget`).
+
+### CLI Output
+
+```
+[mink] reflect
+  tokens: 2450 → 1820 (within 2000 budget)
+  merged: 3 duplicate entries
+  trimmed: 2 stale entries
+```
+
+## Session-Stop Integration
+
+After existing finalization logic, session-stop calls the reflect function. This replaces the current `isLearningMemoryStale()` check — reflect handles both pruning and staleness detection (if no entries were added in >24h, emit the reminder).
+
+## CLI Integration
+
+Add to `src/cli.ts`:
+
+```typescript
+case "reflect": {
+  const { reflect } = await import("./commands/reflect");
+  reflect(cwd);
+  break;
+}
+```
+
+## `paths.ts` Extension
+
+```typescript
+export function learningMemoryPath(cwd: string): string {
+  return join(projectDir(cwd), "learning-memory.md");
+}
+```
+
+Replaces the hardcoded path in `session-stop.ts`.
+
+## `fs-utils.ts` Extension
+
+```typescript
+export function atomicWriteText(filePath: string, content: string): void {
+  const tmp = filePath + ".tmp";
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(tmp, content);
+  renameSync(tmp, filePath);
+}
+```
+
+Same crash-safe pattern as `atomicWriteJson`, but writes raw string content for markdown files.
+
+## Init Integration
+
+After creating project dir and running scan, also seed learning memory if it doesn't exist. `init.ts` calls `seed.ts` to generate and write the initial file.
+
+## Error Handling
+
+- **Missing learning memory file** — CRUD functions return empty structure, log warning. `reflect` exits cleanly. Pattern engine returns no patterns.
+- **Corrupted/unparseable file** — Recreate with empty sections, preserve salvageable content as a User Preferences entry, log warning.
+- **Empty sections** — Valid state. Serialization writes section headings with no entries beneath.
+- **Entry with no extractable pattern** — Skipped by pattern engine. No warning, no error.
+- **Multiple patterns match same content** — All matching warnings emitted.
+- **Token budget of 0 or negative** — No budget enforcement, skip pruning.
+- **Metadata file malformed during init** — Skip that file, continue with others. Log warning.
+- **Concurrent writes** — Atomic write via `atomicWriteText` (write `.tmp`, rename).
+
+## Integration Points (Future Specs)
+
+- **Spec 06 (Write Enforcement)** — calls `extractPatterns()` and `matchPatterns()` from `pattern-engine.ts` in the pre-write hook. See integration notes added to spec 06.
+- **Spec 10 (Background Scheduler)** — can invoke `mink reflect` on a schedule for periodic pruning.
+- **Spec 01 (Session Lifecycle)** — `SessionCounters.learnedRuleWarnings` already exists, updated by the future pre-write hook.
+
+## Testing Strategy
+
+### Unit Tests
+
+- **`learning-memory.ts`** — parse markdown into sections, serialize back. Add/remove entries per section. Round-trip: parse → serialize → parse produces identical structure. Edge cases: empty file, missing sections, corrupted content.
+- **`pattern-engine.ts`** — extract quoted strings, "never use" phrases, "avoid" phrases, mixed entries, entries with no pattern. Match literal patterns (case-sensitive), word-boundary patterns (case-insensitive). True positives and true negatives.
+- **`reflection.ts`** — exact duplicate merge, same-pattern merge, substring containment merge. Trim order (Decision Log first, Do-Not-Repeat last). Budget enforcement. No-op when under budget.
+- **`seed.ts`** — parse each metadata format. Framework detection from dependency names. Missing files, malformed files, multiple files.
+
+### Integration Tests
+
+- Full init → seed → verify learning memory file contents match project metadata.
+- Add entries until over budget → reflect → verify merged/trimmed and under budget.
+- Parse Do-Not-Repeat → extract patterns → match against sample code → verify warnings.
+
+### Edge Tests
+
+- Empty project (no metadata files) — seed produces skeleton with directory name only.
+- Learning memory at exactly token budget — no pruning.
+- All entries are unique with no duplicates — merge pass is no-op, trim by age only.
+- Corrupted file triggers recreation with empty sections.

--- a/specs/06-write-enforcement.md
+++ b/specs/06-write-enforcement.md
@@ -112,3 +112,17 @@ THEN the previous version of the file index remains intact
 - Edge: Empty Do-Not-Repeat section produces no warnings and no errors.
 - Edge: Missing bug log file does not crash pre-write.
 - Performance: Post-write completes within 10 seconds including file index update on a 500-entry index.
+
+## Integration Notes
+
+### Spec 03 (Learning Memory) Dependencies
+
+Spec 03 implements the pattern extraction and matching engine as pure functions in `src/core/learning-memory.ts`:
+- `extractPatterns(doNotRepeatSection: string)` — parses quoted strings and "never use"/"avoid" phrases into match patterns
+- `matchPatterns(patterns, content)` — checks content against extracted patterns, returns matched entries
+
+When implementing the pre-write hook, wire these functions into the `PreToolUse` hook handler:
+1. Load learning memory from `learningMemoryPath(cwd)`
+2. Parse the Do-Not-Repeat section
+3. Call `extractPatterns()` → `matchPatterns()` against the write content
+4. Emit warnings for any matches (non-blocking)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,8 +28,15 @@ switch (command) {
     break;
   }
 
+  case "reflect": {
+    const { reflect } = await import("./commands/reflect");
+    const { learningMemoryPath, configPath } = await import("./core/paths");
+    reflect(cwd, learningMemoryPath(cwd), configPath(cwd));
+    break;
+  }
+
   default:
     console.error(`[mink] unknown command: ${command}`);
-    console.error("Usage: mink <session-start|session-stop|init|scan>");
+    console.error("Usage: mink <session-start|session-stop|init|scan|reflect>");
     process.exit(1);
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -81,4 +81,16 @@ export async function init(cwd: string): Promise<void> {
   // Run initial scan
   const { scan } = await import("./scan");
   scan(cwd, { check: false });
+
+  // Seed learning memory if it doesn't exist
+  const { existsSync } = await import("fs");
+  const { learningMemoryPath } = await import("../core/paths");
+  const memPath = learningMemoryPath(cwd);
+  if (!existsSync(memPath)) {
+    const { seedLearningMemory } = await import("../core/seed");
+    const { serializeLearningMemory } = await import("../core/learning-memory");
+    const { atomicWriteText } = await import("../core/fs-utils");
+    const mem = seedLearningMemory(cwd);
+    atomicWriteText(memPath, serializeLearningMemory(mem));
+  }
 }

--- a/src/commands/reflect.ts
+++ b/src/commands/reflect.ts
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync } from "fs";
+import { parseLearningMemory, serializeLearningMemory } from "../core/learning-memory";
+import { reflectMemory } from "../core/reflection";
+import { atomicWriteText, safeReadJson } from "../core/fs-utils";
+import type { ReflectionResult } from "../types/learning-memory";
+import type { ProjectConfig } from "../types/file-index";
+
+const DEFAULT_TOKEN_BUDGET = 2000;
+
+export function reflect(
+  projectDir: string,
+  memoryPath: string,
+  configPath: string
+): ReflectionResult | null {
+  if (!existsSync(memoryPath)) {
+    console.log("[mink] no learning memory found");
+    return null;
+  }
+
+  const markdown = readFileSync(memoryPath, "utf-8");
+  const mem = parseLearningMemory(markdown);
+
+  const config = safeReadJson(configPath) as ProjectConfig | null;
+  const tokenBudget = config?.learningMemoryTokenBudget ?? DEFAULT_TOKEN_BUDGET;
+
+  const { memory: updated, result } = reflectMemory(mem, tokenBudget);
+
+  if (result.mergedCount > 0 || result.trimmedCount > 0) {
+    atomicWriteText(memoryPath, serializeLearningMemory(updated));
+  }
+
+  console.log(
+    `[mink] reflect: ${result.beforeTokens} → ${result.afterTokens} tokens` +
+      ` | merged: ${result.mergedCount} | trimmed: ${result.trimmedCount}` +
+      ` | within budget: ${result.withinBudget}`
+  );
+
+  return result;
+}

--- a/src/commands/session-stop.ts
+++ b/src/commands/session-stop.ts
@@ -1,7 +1,8 @@
-import { statSync } from "fs";
+import { statSync, existsSync } from "fs";
 import { join, dirname } from "path";
 import { safeReadJson, atomicWriteJson } from "../core/fs-utils";
 import { isSessionState, buildSummary } from "../core/session";
+import { reflect } from "./reflect";
 import type { SessionState, SessionFinalizer } from "../types/session";
 
 const noopFinalizer: SessionFinalizer = {
@@ -21,8 +22,7 @@ function getEditCounts(state: SessionState): Record<string, number> {
   return counts;
 }
 
-function isLearningMemoryStale(projectDir: string): boolean {
-  const memoryPath = join(projectDir, "learning-memory.md");
+function isLearningMemoryStale(memoryPath: string): boolean {
   try {
     const stat = statSync(memoryPath);
     const ageMs = Date.now() - stat.mtimeMs;
@@ -70,9 +70,16 @@ export function sessionStop(
     }
   }
 
-  // Check if learning memory is stale (>24h since last update)
+  // Run reflection to merge duplicates and prune oversized memory
   const projDir = dirname(sessionFile);
-  if (isLearningMemoryStale(projDir)) {
+  const memoryPath = join(projDir, "learning-memory.md");
+  const cfgPath = join(projDir, "config.json");
+  if (existsSync(memoryPath)) {
+    reflect(projDir, memoryPath, cfgPath);
+  }
+
+  // Check if learning memory is stale (>24h since last update)
+  if (isLearningMemoryStale(memoryPath)) {
     onReminder(
       "[mink] learning memory hasn't been updated in 24+ hours — consider reviewing it"
     );

--- a/src/core/fs-utils.ts
+++ b/src/core/fs-utils.ts
@@ -8,6 +8,13 @@ export function atomicWriteJson(filePath: string, data: unknown): void {
   renameSync(tmp, filePath);
 }
 
+export function atomicWriteText(filePath: string, content: string): void {
+  const tmp = filePath + ".tmp";
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(tmp, content);
+  renameSync(tmp, filePath);
+}
+
 export function safeReadJson(filePath: string): unknown | null {
   try {
     const raw = readFileSync(filePath, "utf-8");

--- a/src/core/learning-memory.ts
+++ b/src/core/learning-memory.ts
@@ -9,7 +9,7 @@ const SECTION_ORDER: SectionName[] = [
 
 const RECOGNIZED_SECTIONS = new Set<string>(SECTION_ORDER);
 
-function emptysections(): Record<SectionName, string[]> {
+function emptySections(): Record<SectionName, string[]> {
   return {
     "User Preferences": [],
     "Key Learnings": [],
@@ -21,12 +21,12 @@ function emptysections(): Record<SectionName, string[]> {
 export function createEmptyLearningMemory(projectName: string): LearningMemory {
   return {
     projectName,
-    sections: emptysections(),
+    sections: emptySections(),
   };
 }
 
 export function parseLearningMemory(markdown: string): LearningMemory {
-  const sections = emptysections();
+  const sections = emptySections();
   let projectName = "unknown";
 
   if (!markdown || markdown.trim() === "") {
@@ -109,7 +109,7 @@ export function getEntries(
   mem: LearningMemory,
   section: SectionName
 ): string[] {
-  return mem.sections[section];
+  return [...mem.sections[section]];
 }
 
 export function totalEntryCount(mem: LearningMemory): number {

--- a/src/core/learning-memory.ts
+++ b/src/core/learning-memory.ts
@@ -1,0 +1,120 @@
+import type { LearningMemory, SectionName } from "../types/learning-memory";
+
+const SECTION_ORDER: SectionName[] = [
+  "User Preferences",
+  "Key Learnings",
+  "Do-Not-Repeat",
+  "Decision Log",
+];
+
+const RECOGNIZED_SECTIONS = new Set<string>(SECTION_ORDER);
+
+function emptysections(): Record<SectionName, string[]> {
+  return {
+    "User Preferences": [],
+    "Key Learnings": [],
+    "Do-Not-Repeat": [],
+    "Decision Log": [],
+  };
+}
+
+export function createEmptyLearningMemory(projectName: string): LearningMemory {
+  return {
+    projectName,
+    sections: emptysections(),
+  };
+}
+
+export function parseLearningMemory(markdown: string): LearningMemory {
+  const sections = emptysections();
+  let projectName = "unknown";
+
+  if (!markdown || markdown.trim() === "") {
+    return { projectName, sections };
+  }
+
+  const lines = markdown.split("\n");
+  let currentSection: SectionName | null = null;
+
+  for (const line of lines) {
+    // Check for title line: # Learning Memory — <name>
+    const titleMatch = line.match(/^#\s+Learning Memory\s+[—–-]+\s+(.+)$/);
+    if (titleMatch) {
+      projectName = titleMatch[1].trim();
+      currentSection = null;
+      continue;
+    }
+
+    // Check for section heading: ## Section Name
+    const sectionMatch = line.match(/^##\s+(.+)$/);
+    if (sectionMatch) {
+      const sectionName = sectionMatch[1].trim();
+      if (RECOGNIZED_SECTIONS.has(sectionName)) {
+        currentSection = sectionName as SectionName;
+      } else {
+        currentSection = null;
+      }
+      continue;
+    }
+
+    // Check for entry line: - entry
+    if (currentSection !== null) {
+      const entryMatch = line.match(/^-\s+(.+)$/);
+      if (entryMatch) {
+        sections[currentSection].push(entryMatch[1]);
+      }
+    }
+  }
+
+  return { projectName, sections };
+}
+
+export function serializeLearningMemory(mem: LearningMemory): string {
+  const lines: string[] = [];
+
+  lines.push(`# Learning Memory — ${mem.projectName}`);
+
+  for (const section of SECTION_ORDER) {
+    lines.push("");
+    lines.push(`## ${section}`);
+    for (const entry of mem.sections[section]) {
+      lines.push(`- ${entry}`);
+    }
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+export function addEntry(
+  mem: LearningMemory,
+  section: SectionName,
+  entry: string
+): void {
+  mem.sections[section].push(entry);
+}
+
+export function removeEntry(
+  mem: LearningMemory,
+  section: SectionName,
+  index: number
+): void {
+  const entries = mem.sections[section];
+  if (index < 0 || index >= entries.length) {
+    return;
+  }
+  entries.splice(index, 1);
+}
+
+export function getEntries(
+  mem: LearningMemory,
+  section: SectionName
+): string[] {
+  return mem.sections[section];
+}
+
+export function totalEntryCount(mem: LearningMemory): number {
+  return SECTION_ORDER.reduce(
+    (sum, section) => sum + mem.sections[section].length,
+    0
+  );
+}

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -24,3 +24,7 @@ export function fileIndexPath(cwd: string): string {
 export function configPath(cwd: string): string {
   return join(projectDir(cwd), "config.json");
 }
+
+export function learningMemoryPath(cwd: string): string {
+  return join(projectDir(cwd), "learning-memory.md");
+}

--- a/src/core/pattern-engine.ts
+++ b/src/core/pattern-engine.ts
@@ -3,28 +3,22 @@ import type { ExtractedPattern, PatternMatch } from "../types/learning-memory";
 // Triggers for phrase-based word-boundary patterns
 const PHRASE_TRIGGERS = [
   /never\s+use\s+/i,
-  /avoid\s+/i,
+  /\bavoid\s+/i,
 ];
 
 // Stop characters/sequences that end a phrase
-const PHRASE_STOP_RE = /[—–\-.]|$/;
+const PHRASE_STOP_RE = /[—–\-.]|\s+(?:in|for|with|on|by|from|to|when|if|because|since|after|before|during|until)\s+|$/;
 
 export function extractPatterns(entries: string[]): ExtractedPattern[] {
   const results: ExtractedPattern[] = [];
 
   for (const entry of entries) {
-    const quotedRanges: Array<{ start: number; end: number; text: string }> = [];
     const quotedPatterns: ExtractedPattern[] = [];
 
     // 1. Extract quoted strings (double and single quotes)
     const quoteRe = /["']([^"']+)["']/g;
     let qMatch: RegExpExecArray | null;
     while ((qMatch = quoteRe.exec(entry)) !== null) {
-      quotedRanges.push({
-        start: qMatch.index,
-        end: qMatch.index + qMatch[0].length,
-        text: qMatch[1],
-      });
       quotedPatterns.push({
         type: "literal",
         pattern: qMatch[1],

--- a/src/core/pattern-engine.ts
+++ b/src/core/pattern-engine.ts
@@ -1,0 +1,114 @@
+import type { ExtractedPattern, PatternMatch } from "../types/learning-memory";
+
+// Triggers for phrase-based word-boundary patterns
+const PHRASE_TRIGGERS = [
+  /never\s+use\s+/i,
+  /avoid\s+/i,
+];
+
+// Stop characters/sequences that end a phrase
+const PHRASE_STOP_RE = /[—–\-.]|$/;
+
+export function extractPatterns(entries: string[]): ExtractedPattern[] {
+  const results: ExtractedPattern[] = [];
+
+  for (const entry of entries) {
+    const quotedRanges: Array<{ start: number; end: number; text: string }> = [];
+    const quotedPatterns: ExtractedPattern[] = [];
+
+    // 1. Extract quoted strings (double and single quotes)
+    const quoteRe = /["']([^"']+)["']/g;
+    let qMatch: RegExpExecArray | null;
+    while ((qMatch = quoteRe.exec(entry)) !== null) {
+      quotedRanges.push({
+        start: qMatch.index,
+        end: qMatch.index + qMatch[0].length,
+        text: qMatch[1],
+      });
+      quotedPatterns.push({
+        type: "literal",
+        pattern: qMatch[1],
+        sourceEntry: entry,
+      });
+    }
+
+    results.push(...quotedPatterns);
+
+    // 2. Extract phrase-based word-boundary patterns
+    for (const triggerRe of PHRASE_TRIGGERS) {
+      // Build a combined regex that finds the trigger and captures the rest
+      const fullRe = new RegExp(triggerRe.source, "gi");
+      let triggerMatch: RegExpExecArray | null;
+
+      while ((triggerMatch = fullRe.exec(entry)) !== null) {
+        const afterTrigger = entry.slice(triggerMatch.index + triggerMatch[0].length);
+
+        // Remove any quoted portions from the remaining text before finding stop
+        let cleaned = afterTrigger;
+        // Replace quoted content with spaces to preserve indices
+        cleaned = cleaned.replace(/["'][^"']*["']/g, (m) => " ".repeat(m.length));
+
+        // Find stop position
+        const stopMatch = PHRASE_STOP_RE.exec(cleaned);
+        const phraseLength = stopMatch && stopMatch.index > 0 ? stopMatch.index : cleaned.length;
+
+        let phrase = afterTrigger.slice(0, phraseLength).trim();
+
+        // Remove quoted substrings from phrase
+        phrase = phrase.replace(/["'][^"']*["']/g, "").trim();
+        // Collapse multiple spaces
+        phrase = phrase.replace(/\s+/g, " ").trim();
+
+        if (phrase.length > 0) {
+          results.push({
+            type: "word-boundary",
+            pattern: phrase,
+            sourceEntry: entry,
+          });
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+export function matchPatterns(
+  patterns: ExtractedPattern[],
+  content: string
+): PatternMatch[] {
+  if (!content || patterns.length === 0) {
+    return [];
+  }
+
+  const matches: PatternMatch[] = [];
+
+  for (const pat of patterns) {
+    if (pat.type === "literal") {
+      // Case-sensitive includes check
+      let idx = content.indexOf(pat.pattern);
+      while (idx !== -1) {
+        matches.push({
+          pattern: pat,
+          matchedText: pat.pattern,
+          index: idx,
+        });
+        idx = content.indexOf(pat.pattern, idx + 1);
+      }
+    } else {
+      // Word-boundary, case-insensitive
+      const escaped = pat.pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const re = new RegExp(`\\b${escaped}\\b`, "gi");
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(content)) !== null) {
+        matches.push({
+          pattern: pat,
+          matchedText: m[0],
+          index: m.index,
+        });
+      }
+    }
+  }
+
+  return matches;
+}

--- a/src/core/reflection.ts
+++ b/src/core/reflection.ts
@@ -1,0 +1,269 @@
+import type { LearningMemory, SectionName, ReflectionResult } from "../types/learning-memory";
+import { serializeLearningMemory } from "./learning-memory";
+import { estimateTokens } from "./token-estimate";
+
+// Trim order: Decision Log first → Key Learnings → User Preferences → Do-Not-Repeat last
+const TRIM_ORDER: SectionName[] = [
+  "Decision Log",
+  "Key Learnings",
+  "User Preferences",
+  "Do-Not-Repeat",
+];
+
+function normalizeWhitespace(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Extract the quoted pattern from a Do-Not-Repeat entry, e.g.
+ * `Don't use "var" in code` → `var`
+ * Only matches double-quoted strings to avoid matching apostrophes in contractions.
+ * Returns null if no double-quoted pattern found.
+ */
+function extractQuotedPattern(entry: string): string | null {
+  const m = entry.match(/"([^"]+)"/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Extract date from an entry in the form `[YYYY-MM-DD]`
+ * Returns the date string or null.
+ */
+function extractDate(entry: string): string | null {
+  const m = entry.match(/\[(\d{4}-\d{2}-\d{2})\]/);
+  return m ? m[1] : null;
+}
+
+function deepCopy(mem: LearningMemory): LearningMemory {
+  return {
+    projectName: mem.projectName,
+    sections: {
+      "User Preferences": [...mem.sections["User Preferences"]],
+      "Key Learnings": [...mem.sections["Key Learnings"]],
+      "Do-Not-Repeat": [...mem.sections["Do-Not-Repeat"]],
+      "Decision Log": [...mem.sections["Decision Log"]],
+    },
+  };
+}
+
+/**
+ * Merge duplicates within each section.
+ * - Exact duplicates (normalized whitespace) → keep one
+ * - Do-Not-Repeat: entries sharing same quoted pattern → merge, keep newer date
+ * Returns a new LearningMemory (does not mutate input).
+ */
+export function mergeDuplicates(mem: LearningMemory): LearningMemory {
+  const result = deepCopy(mem);
+
+  const sectionNames: SectionName[] = [
+    "User Preferences",
+    "Key Learnings",
+    "Do-Not-Repeat",
+    "Decision Log",
+  ];
+
+  for (const section of sectionNames) {
+    const entries = result.sections[section];
+
+    if (section === "Do-Not-Repeat") {
+      // First pass: group by quoted pattern (where it exists)
+      const byQuotedPattern = new Map<string, string[]>();
+      const noPattern: string[] = [];
+
+      for (const entry of entries) {
+        const qp = extractQuotedPattern(entry);
+        if (qp !== null) {
+          if (!byQuotedPattern.has(qp)) {
+            byQuotedPattern.set(qp, []);
+          }
+          byQuotedPattern.get(qp)!.push(entry);
+        } else {
+          noPattern.push(entry);
+        }
+      }
+
+      const merged: string[] = [];
+
+      // For each quoted pattern group, keep the one with the newer date (or last entry)
+      for (const [, group] of byQuotedPattern) {
+        if (group.length === 1) {
+          merged.push(group[0]);
+        } else {
+          // Find the entry with the newest date
+          let best = group[0];
+          let bestDate = extractDate(group[0]);
+          for (let i = 1; i < group.length; i++) {
+            const d = extractDate(group[i]);
+            if (d !== null && (bestDate === null || d > bestDate)) {
+              best = group[i];
+              bestDate = d;
+            } else if (d === null && bestDate === null) {
+              // No dates — keep last (newer = later in list)
+              best = group[i];
+            }
+          }
+          merged.push(best);
+        }
+      }
+
+      // For entries without quoted patterns, deduplicate by normalized whitespace
+      const seenNoPattern = new Set<string>();
+      for (const entry of noPattern) {
+        const norm = normalizeWhitespace(entry);
+        if (!seenNoPattern.has(norm)) {
+          seenNoPattern.add(norm);
+          merged.push(entry);
+        }
+      }
+
+      result.sections[section] = merged;
+    } else {
+      // Standard deduplication: normalize whitespace and deduplicate
+      const seen = new Set<string>();
+      const deduped: string[] = [];
+      for (const entry of entries) {
+        const norm = normalizeWhitespace(entry);
+        if (!seen.has(norm)) {
+          seen.add(norm);
+          deduped.push(entry);
+        }
+      }
+      result.sections[section] = deduped;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Trim oldest entries from sections in the given order.
+ * Trim order: Decision Log → Key Learnings → User Preferences → Do-Not-Repeat
+ * Within each section, remove oldest (first) entries.
+ * Returns a new LearningMemory (does not mutate input).
+ */
+export function trimOldest(mem: LearningMemory, trimCount: number): LearningMemory {
+  if (trimCount <= 0) {
+    return deepCopy(mem);
+  }
+
+  const result = deepCopy(mem);
+  let remaining = trimCount;
+
+  for (const section of TRIM_ORDER) {
+    if (remaining <= 0) break;
+    const entries = result.sections[section];
+    const toRemove = Math.min(remaining, entries.length);
+    result.sections[section] = entries.slice(toRemove);
+    remaining -= toRemove;
+  }
+
+  return result;
+}
+
+/**
+ * Reflect memory against a token budget: merge duplicates then trim oldest until within budget.
+ * If budget <= 0, skip pruning.
+ */
+export function reflectMemory(
+  mem: LearningMemory,
+  tokenBudget: number
+): { memory: LearningMemory; result: ReflectionResult } {
+  const serialized = serializeLearningMemory(mem);
+  const beforeTokens = estimateTokens(serialized, "learning-memory.md");
+
+  if (tokenBudget <= 0) {
+    return {
+      memory: deepCopy(mem),
+      result: {
+        beforeTokens,
+        afterTokens: beforeTokens,
+        mergedCount: 0,
+        trimmedCount: 0,
+        withinBudget: true,
+      },
+    };
+  }
+
+  if (beforeTokens <= tokenBudget) {
+    return {
+      memory: deepCopy(mem),
+      result: {
+        beforeTokens,
+        afterTokens: beforeTokens,
+        mergedCount: 0,
+        trimmedCount: 0,
+        withinBudget: true,
+      },
+    };
+  }
+
+  // Step 1: Merge duplicates
+  const beforeMergeCount = countEntries(mem);
+  const afterMerge = mergeDuplicates(mem);
+  const afterMergeCount = countEntries(afterMerge);
+  const mergedCount = beforeMergeCount - afterMergeCount;
+
+  const afterMergeSerialized = serializeLearningMemory(afterMerge);
+  const afterMergeTokens = estimateTokens(afterMergeSerialized, "learning-memory.md");
+
+  if (afterMergeTokens <= tokenBudget) {
+    return {
+      memory: afterMerge,
+      result: {
+        beforeTokens,
+        afterTokens: afterMergeTokens,
+        mergedCount,
+        trimmedCount: 0,
+        withinBudget: true,
+      },
+    };
+  }
+
+  // Step 2: Trim oldest one at a time until within budget or empty
+  let current = afterMerge;
+  let trimmedCount = 0;
+
+  while (true) {
+    const currentSerialized = serializeLearningMemory(current);
+    const currentTokens = estimateTokens(currentSerialized, "learning-memory.md");
+
+    if (currentTokens <= tokenBudget) {
+      return {
+        memory: current,
+        result: {
+          beforeTokens,
+          afterTokens: currentTokens,
+          mergedCount,
+          trimmedCount,
+          withinBudget: true,
+        },
+      };
+    }
+
+    const total = countEntries(current);
+    if (total === 0) {
+      return {
+        memory: current,
+        result: {
+          beforeTokens,
+          afterTokens: currentTokens,
+          mergedCount,
+          trimmedCount,
+          withinBudget: false,
+        },
+      };
+    }
+
+    current = trimOldest(current, 1);
+    trimmedCount += 1;
+  }
+}
+
+function countEntries(mem: LearningMemory): number {
+  return (
+    mem.sections["User Preferences"].length +
+    mem.sections["Key Learnings"].length +
+    mem.sections["Do-Not-Repeat"].length +
+    mem.sections["Decision Log"].length
+  );
+}

--- a/src/core/reflection.ts
+++ b/src/core/reflection.ts
@@ -184,20 +184,7 @@ export function reflectMemory(
     };
   }
 
-  if (beforeTokens <= tokenBudget) {
-    return {
-      memory: deepCopy(mem),
-      result: {
-        beforeTokens,
-        afterTokens: beforeTokens,
-        mergedCount: 0,
-        trimmedCount: 0,
-        withinBudget: true,
-      },
-    };
-  }
-
-  // Step 1: Merge duplicates
+  // Step 1: Always merge duplicates (regardless of budget)
   const beforeMergeCount = countEntries(mem);
   const afterMerge = mergeDuplicates(mem);
   const afterMergeCount = countEntries(afterMerge);

--- a/src/core/seed.ts
+++ b/src/core/seed.ts
@@ -1,4 +1,4 @@
-import { basename } from "path";
+import { basename, join } from "path";
 import { readFileSync, existsSync } from "fs";
 import type { LearningMemory, SeedInfo } from "../types/learning-memory";
 import { createEmptyLearningMemory, addEntry } from "./learning-memory";
@@ -196,8 +196,6 @@ export function parseGoMod(filePath: string): SeedInfo | null {
 // ─── Seed ─────────────────────────────────────────────────────────────────────
 
 export function seedLearningMemory(projectRoot: string): LearningMemory {
-  const { join } = require("path");
-
   const parsers: Array<() => SeedInfo | null> = [
     () => parsePackageJson(join(projectRoot, "package.json")),
     () => parsePyprojectToml(join(projectRoot, "pyproject.toml")),

--- a/src/core/seed.ts
+++ b/src/core/seed.ts
@@ -1,0 +1,241 @@
+import { basename } from "path";
+import { readFileSync, existsSync } from "fs";
+import type { LearningMemory, SeedInfo } from "../types/learning-memory";
+import { createEmptyLearningMemory, addEntry } from "./learning-memory";
+
+// ─── Framework detection maps ─────────────────────────────────────────────────
+
+const NPM_FRAMEWORKS: Record<string, string> = {
+  react: "React",
+  "react-dom": "React",
+  next: "Next.js",
+  vue: "Vue",
+  nuxt: "Nuxt",
+  svelte: "Svelte",
+  "@sveltejs/kit": "SvelteKit",
+  angular: "Angular",
+  "@angular/core": "Angular",
+  express: "Express",
+  fastify: "Fastify",
+  hono: "Hono",
+  koa: "Koa",
+  "@nestjs/core": "NestJS",
+  typescript: "TypeScript",
+  jest: "Jest",
+  vitest: "Vitest",
+  mocha: "Mocha",
+  tailwindcss: "Tailwind CSS",
+  prisma: "Prisma",
+  "@prisma/client": "Prisma",
+  "drizzle-orm": "Drizzle",
+};
+
+const PYTHON_FRAMEWORKS: Record<string, string> = {
+  fastapi: "FastAPI",
+  flask: "Flask",
+  django: "Django",
+  sqlalchemy: "SQLAlchemy",
+  pytest: "pytest",
+  pydantic: "Pydantic",
+  celery: "Celery",
+  httpx: "HTTPX",
+  uvicorn: "Uvicorn",
+};
+
+const CARGO_FRAMEWORKS: Record<string, string> = {
+  "actix-web": "Actix Web",
+  axum: "Axum",
+  tokio: "Tokio",
+  serde: "Serde",
+  diesel: "Diesel",
+  sqlx: "SQLx",
+  warp: "Warp",
+  rocket: "Rocket",
+};
+
+const GO_FRAMEWORKS: Record<string, string> = {
+  "github.com/gin-gonic/gin": "Gin",
+  "github.com/gofiber/fiber": "Fiber",
+  "github.com/labstack/echo": "Echo",
+  "gorm.io/gorm": "GORM",
+  "github.com/gorilla/mux": "Gorilla Mux",
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function readFile(filePath: string): string | null {
+  if (!existsSync(filePath)) return null;
+  try {
+    return readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function dedupeOrdered(arr: string[]): string[] {
+  return [...new Set(arr)];
+}
+
+function detectFromKeys(
+  keys: string[],
+  map: Record<string, string>
+): string[] {
+  const found: string[] = [];
+  for (const key of keys) {
+    if (map[key]) found.push(map[key]);
+  }
+  return dedupeOrdered(found);
+}
+
+// ─── Parsers ──────────────────────────────────────────────────────────────────
+
+export function parsePackageJson(filePath: string): SeedInfo | null {
+  const raw = readFile(filePath);
+  if (raw === null) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) return null;
+
+  const obj = parsed as Record<string, unknown>;
+  const projectName = typeof obj.name === "string" ? obj.name : "";
+  const description = typeof obj.description === "string" ? obj.description : "";
+
+  const deps: Record<string, unknown> =
+    typeof obj.dependencies === "object" && obj.dependencies !== null
+      ? (obj.dependencies as Record<string, unknown>)
+      : {};
+  const devDeps: Record<string, unknown> =
+    typeof obj.devDependencies === "object" && obj.devDependencies !== null
+      ? (obj.devDependencies as Record<string, unknown>)
+      : {};
+
+  const allKeys = [...Object.keys(deps), ...Object.keys(devDeps)];
+  const frameworks = detectFromKeys(allKeys, NPM_FRAMEWORKS);
+
+  return { projectName, description, frameworks };
+}
+
+export function parsePyprojectToml(filePath: string): SeedInfo | null {
+  const raw = readFile(filePath);
+  if (raw === null) return null;
+
+  // Extract [project] section name
+  const nameMatch = raw.match(/\[project\][^\[]*\bname\s*=\s*"([^"]+)"/s);
+  const descMatch = raw.match(
+    /\[project\][^\[]*\bdescription\s*=\s*"([^"]+)"/s
+  );
+
+  const projectName = nameMatch ? nameMatch[1] : "";
+  const description = descMatch ? descMatch[1] : "";
+
+  // Simple string-match for framework detection across the whole file
+  const frameworks: string[] = [];
+  for (const [key, label] of Object.entries(PYTHON_FRAMEWORKS)) {
+    if (raw.includes(key)) {
+      frameworks.push(label);
+    }
+  }
+
+  return { projectName, description, frameworks: dedupeOrdered(frameworks) };
+}
+
+export function parseCargoToml(filePath: string): SeedInfo | null {
+  const raw = readFile(filePath);
+  if (raw === null) return null;
+
+  // Extract [package] section name and description
+  const nameMatch = raw.match(/\[package\][^\[]*\bname\s*=\s*"([^"]+)"/s);
+  const descMatch = raw.match(
+    /\[package\][^\[]*\bdescription\s*=\s*"([^"]+)"/s
+  );
+
+  const projectName = nameMatch ? nameMatch[1] : "";
+  const description = descMatch ? descMatch[1] : "";
+
+  // Simple string-match across file
+  const frameworks: string[] = [];
+  for (const [key, label] of Object.entries(CARGO_FRAMEWORKS)) {
+    if (raw.includes(key)) {
+      frameworks.push(label);
+    }
+  }
+
+  return { projectName, description, frameworks: dedupeOrdered(frameworks) };
+}
+
+export function parseGoMod(filePath: string): SeedInfo | null {
+  const raw = readFile(filePath);
+  if (raw === null) return null;
+
+  // Extract module path — last path segment is the project name
+  const moduleMatch = raw.match(/^module\s+(\S+)/m);
+  const modulePath = moduleMatch ? moduleMatch[1] : "";
+  const projectName = modulePath ? basename(modulePath) : "";
+
+  // String-match require block for framework detection
+  const frameworks: string[] = [];
+  for (const [key, label] of Object.entries(GO_FRAMEWORKS)) {
+    if (raw.includes(key)) {
+      frameworks.push(label);
+    }
+  }
+
+  return {
+    projectName,
+    description: "",
+    frameworks: dedupeOrdered(frameworks),
+  };
+}
+
+// ─── Seed ─────────────────────────────────────────────────────────────────────
+
+export function seedLearningMemory(projectRoot: string): LearningMemory {
+  const { join } = require("path");
+
+  const parsers: Array<() => SeedInfo | null> = [
+    () => parsePackageJson(join(projectRoot, "package.json")),
+    () => parsePyprojectToml(join(projectRoot, "pyproject.toml")),
+    () => parseCargoToml(join(projectRoot, "Cargo.toml")),
+    () => parseGoMod(join(projectRoot, "go.mod")),
+  ];
+
+  const infos: SeedInfo[] = parsers
+    .map((fn) => fn())
+    .filter((info): info is SeedInfo => info !== null);
+
+  // Pick first non-empty project name; fallback to directory basename
+  const projectName =
+    infos.find((i) => i.projectName)?.projectName ?? basename(projectRoot);
+
+  const mem = createEmptyLearningMemory(projectName);
+
+  // Add project description if available
+  const infoWithDesc = infos.find((i) => i.description);
+  if (infoWithDesc?.description) {
+    addEntry(
+      mem,
+      "Key Learnings",
+      `Project: ${projectName} — ${infoWithDesc.description}`
+    );
+  } else {
+    addEntry(mem, "Key Learnings", `Project: ${projectName}`);
+  }
+
+  // Collect all detected frameworks across all parsers
+  const allFrameworks = dedupeOrdered(infos.flatMap((i) => i.frameworks));
+  if (allFrameworks.length > 0) {
+    addEntry(
+      mem,
+      "Key Learnings",
+      `Detected frameworks: ${allFrameworks.join(", ")}`
+    );
+  }
+
+  return mem;
+}

--- a/src/types/file-index.ts
+++ b/src/types/file-index.ts
@@ -21,6 +21,7 @@ export interface FileIndex {
 export interface ProjectConfig {
   excludePatterns?: string[];
   maxFiles?: number;
+  learningMemoryTokenBudget?: number;
 }
 
 export interface StalenessReport {

--- a/src/types/learning-memory.ts
+++ b/src/types/learning-memory.ts
@@ -1,0 +1,36 @@
+export type SectionName =
+  | "User Preferences"
+  | "Key Learnings"
+  | "Do-Not-Repeat"
+  | "Decision Log";
+
+export interface LearningMemory {
+  projectName: string;
+  sections: Record<SectionName, string[]>;
+}
+
+export interface ExtractedPattern {
+  type: "literal" | "word-boundary";
+  pattern: string;
+  sourceEntry: string;
+}
+
+export interface PatternMatch {
+  pattern: ExtractedPattern;
+  matchedText: string;
+  index: number;
+}
+
+export interface ReflectionResult {
+  beforeTokens: number;
+  afterTokens: number;
+  mergedCount: number;
+  trimmedCount: number;
+  withinBudget: boolean;
+}
+
+export interface SeedInfo {
+  projectName: string;
+  description: string;
+  frameworks: string[];
+}

--- a/tests/integration/learning-memory.test.ts
+++ b/tests/integration/learning-memory.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { atomicWriteText, atomicWriteJson } from "../../src/core/fs-utils";
+import { seedLearningMemory } from "../../src/core/seed";
+import {
+  parseLearningMemory,
+  serializeLearningMemory,
+  addEntry,
+  createEmptyLearningMemory,
+} from "../../src/core/learning-memory";
+import { extractPatterns, matchPatterns } from "../../src/core/pattern-engine";
+import { reflect } from "../../src/commands/reflect";
+
+describe("learning memory integration", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mink-lm-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // ─── Test 1: Full lifecycle ──────────────────────────────────────────────────
+
+  test("full lifecycle: seed → add entries → reflect → verify round-trip", () => {
+    // Write a package.json with name, description, and express+typescript deps
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        name: "my-api",
+        description: "A REST API built with Express",
+        dependencies: {
+          express: "^4.18.0",
+        },
+        devDependencies: {
+          typescript: "^5.0.0",
+        },
+      })
+    );
+
+    // Seed learning memory from project metadata
+    const mem = seedLearningMemory(dir);
+
+    expect(mem.projectName).toBe("my-api");
+    const klEntries = mem.sections["Key Learnings"];
+    // Should have detected Express and TypeScript frameworks
+    const frameworkEntry = klEntries.find((e) => e.includes("Detected frameworks"));
+    expect(frameworkEntry).toBeDefined();
+    expect(frameworkEntry).toContain("Express");
+    expect(frameworkEntry).toContain("TypeScript");
+
+    // Add entries across different sections
+    addEntry(mem, "User Preferences", "Always use async/await over callbacks");
+    addEntry(
+      mem,
+      "Do-Not-Repeat",
+      '[2026-04-10] Never use "var" — always use const or let'
+    );
+    addEntry(
+      mem,
+      "Decision Log",
+      "[2026-04-10] Chose Express over Fastify for ecosystem familiarity"
+    );
+
+    // Serialize and write to file atomically
+    const memPath = join(dir, "learning-memory.md");
+    atomicWriteText(memPath, serializeLearningMemory(mem));
+
+    expect(existsSync(memPath)).toBe(true);
+
+    // Read back and parse
+    const raw = readFileSync(memPath, "utf-8");
+    const parsed = parseLearningMemory(raw);
+
+    // Verify round-trip integrity
+    expect(parsed.projectName).toBe("my-api");
+    expect(parsed.sections["User Preferences"]).toContain(
+      "Always use async/await over callbacks"
+    );
+    expect(parsed.sections["Do-Not-Repeat"]).toContain(
+      '[2026-04-10] Never use "var" — always use const or let'
+    );
+    expect(parsed.sections["Decision Log"]).toContain(
+      "[2026-04-10] Chose Express over Fastify for ecosystem familiarity"
+    );
+    // Key Learnings should still have seeded entries
+    expect(parsed.sections["Key Learnings"].length).toBeGreaterThan(0);
+  });
+
+  // ─── Test 2: Pattern extraction → matching end-to-end ───────────────────────
+
+  test("pattern extraction → matching end-to-end", () => {
+    const mem = createEmptyLearningMemory("test-project");
+
+    // Add Do-Not-Repeat entries with quoted patterns and phrase triggers
+    addEntry(
+      mem,
+      "Do-Not-Repeat",
+      '[2026-04-10] Never use "var" — always const'
+    );
+    addEntry(
+      mem,
+      "Do-Not-Repeat",
+      "[2026-04-10] Avoid mocking the database in integration tests"
+    );
+
+    const entries = mem.sections["Do-Not-Repeat"];
+    const patterns = extractPatterns(entries);
+
+    expect(patterns.length).toBeGreaterThan(0);
+
+    // Match against code containing "var"
+    const codeWithVar = `function hello() {\n  var x = 1;\n  return x;\n}`;
+    const varMatches = matchPatterns(patterns, codeWithVar);
+    expect(varMatches.length).toBeGreaterThan(0);
+    const varMatch = varMatches.find((m) => m.matchedText === "var");
+    expect(varMatch).toBeDefined();
+
+    // Match against test code with "mocking the database"
+    const testCode = `describe('auth', () => {\n  // mocking the database here\n  it('works', () => {});\n})`;
+    const dbMatches = matchPatterns(patterns, testCode);
+    expect(dbMatches.length).toBeGreaterThan(0);
+
+    // Match against clean code → no matches
+    const cleanCode = `const x = 5;\nconst db = connectReal();`;
+    const cleanMatches = matchPatterns(patterns, cleanCode);
+    expect(cleanMatches).toHaveLength(0);
+  });
+
+  // ─── Test 3: Reflect prunes bloated memory via file ─────────────────────────
+
+  test("reflect command prunes bloated memory via file", () => {
+    const mem = createEmptyLearningMemory("big-project");
+
+    // Add 30 Decision Log entries
+    for (let i = 0; i < 30; i++) {
+      addEntry(
+        mem,
+        "Decision Log",
+        `[2026-04-${String(i + 1).padStart(2, "0")}] Decision number ${i + 1} regarding architecture choice for module ${i + 1}`
+      );
+    }
+
+    // Add a single Do-Not-Repeat entry (should survive trimming — trimmed last)
+    addEntry(
+      mem,
+      "Do-Not-Repeat",
+      '[2026-04-10] Never use "eval" in production code'
+    );
+
+    // Write memory to file
+    const memPath = join(dir, "learning-memory.md");
+    atomicWriteText(memPath, serializeLearningMemory(mem));
+
+    // Write config with a very low token budget to force trimming
+    const configPath = join(dir, "config.json");
+    atomicWriteJson(configPath, { learningMemoryTokenBudget: 200 });
+
+    // Call reflect
+    const result = reflect(dir, memPath, configPath);
+
+    expect(result).not.toBeNull();
+    expect(result!.withinBudget).toBe(true);
+    expect(result!.trimmedCount).toBeGreaterThan(0);
+
+    // Verify Do-Not-Repeat survived (trimmed last)
+    const raw = readFileSync(memPath, "utf-8");
+    const updated = parseLearningMemory(raw);
+    expect(updated.sections["Do-Not-Repeat"]).toContain(
+      '[2026-04-10] Never use "eval" in production code'
+    );
+  });
+
+  // ─── Test 4: Corrupted learning memory handled gracefully ───────────────────
+
+  test("corrupted learning memory handled gracefully", () => {
+    const garbled = `{{{not markdown at all}}}\x00\x01\x02binary garbage here!!!`;
+
+    // Write corrupted content directly
+    writeFileSync(join(dir, "learning-memory.md"), garbled);
+    const raw = readFileSync(join(dir, "learning-memory.md"), "utf-8");
+
+    // parseLearningMemory should not throw
+    let parsed: ReturnType<typeof parseLearningMemory> | undefined;
+    expect(() => {
+      parsed = parseLearningMemory(raw);
+    }).not.toThrow();
+
+    // Should return projectName "unknown" with empty sections
+    expect(parsed!.projectName).toBe("unknown");
+    expect(parsed!.sections["User Preferences"]).toHaveLength(0);
+    expect(parsed!.sections["Key Learnings"]).toHaveLength(0);
+    expect(parsed!.sections["Do-Not-Repeat"]).toHaveLength(0);
+    expect(parsed!.sections["Decision Log"]).toHaveLength(0);
+  });
+
+  // ─── Test 5: Empty project seeds with directory name only ───────────────────
+
+  test("empty project seeds with directory name only", () => {
+    // No package.json or other metadata files in dir
+    const mem = seedLearningMemory(dir);
+
+    // projectName should be the basename of the temp dir (truthy)
+    expect(mem.projectName).toBeTruthy();
+    expect(mem.projectName).toBe(require("path").basename(dir));
+
+    // Key Learnings should have at least the project line but no framework entry
+    const klEntries = mem.sections["Key Learnings"];
+    const frameworkEntry = klEntries.find((e) => e.includes("Detected frameworks"));
+    expect(frameworkEntry).toBeUndefined();
+
+    // Do-Not-Repeat, User Preferences, Decision Log should be empty
+    expect(mem.sections["Do-Not-Repeat"]).toHaveLength(0);
+    expect(mem.sections["User Preferences"]).toHaveLength(0);
+    expect(mem.sections["Decision Log"]).toHaveLength(0);
+  });
+});

--- a/tests/unit/fs-utils.test.ts
+++ b/tests/unit/fs-utils.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { atomicWriteJson, safeReadJson } from "../../src/core/fs-utils";
+import { atomicWriteJson, atomicWriteText, safeReadJson } from "../../src/core/fs-utils";
 
 describe("atomicWriteJson", () => {
   let dir: string;
@@ -35,6 +35,47 @@ describe("atomicWriteJson", () => {
     atomicWriteJson(filePath, { key: "value" });
     const files = Bun.file(filePath + ".tmp");
     expect(files.size).toBe(0);
+  });
+});
+
+describe("atomicWriteText", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mink-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("writes text content to file", () => {
+    const filePath = join(dir, "test.md");
+    atomicWriteText(filePath, "hello world");
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toBe("hello world");
+  });
+
+  test("overwrites existing file", () => {
+    const filePath = join(dir, "test.md");
+    atomicWriteText(filePath, "first content");
+    atomicWriteText(filePath, "second content");
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toBe("second content");
+  });
+
+  test("creates parent directories if they do not exist", () => {
+    const filePath = join(dir, "nested", "deep", "test.md");
+    atomicWriteText(filePath, "nested content");
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toBe("nested content");
+  });
+
+  test("does not leave .tmp file on success", () => {
+    const filePath = join(dir, "test.md");
+    atomicWriteText(filePath, "data");
+    const tmpFile = Bun.file(filePath + ".tmp");
+    expect(tmpFile.size).toBe(0);
   });
 });
 

--- a/tests/unit/init.test.ts
+++ b/tests/unit/init.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { safeReadJson } from "../../src/core/fs-utils";
-import { buildHooksConfig, mergeHooksIntoSettings } from "../../src/commands/init";
+import { buildHooksConfig, mergeHooksIntoSettings, init } from "../../src/commands/init";
+import { learningMemoryPath } from "../../src/core/paths";
 
 describe("buildHooksConfig", () => {
   test("uses bun when bun is the detected runtime", () => {
@@ -96,5 +97,54 @@ describe("mergeHooksIntoSettings", () => {
     const sessionStartHooks = allHooks.SessionStart;
     expect(sessionStartHooks).toHaveLength(1);
     expect(sessionStartHooks[0].command).toContain("/new/path/cli.js");
+  });
+});
+
+describe("init", () => {
+  let projectDir: string;
+  let memPath: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "mink-init-test-"));
+    memPath = learningMemoryPath(projectDir);
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+    // Clean up the mink project dir created by init
+    if (existsSync(memPath)) {
+      const minkProjDir = join(memPath, "..");
+      rmSync(minkProjDir, { recursive: true, force: true });
+    }
+  });
+
+  test("seeds learning-memory.md on init", async () => {
+    // Create a package.json so seed can detect project name and frameworks
+    writeFileSync(
+      join(projectDir, "package.json"),
+      JSON.stringify({
+        name: "my-test-project",
+        dependencies: { react: "^18.0.0", typescript: "^5.0.0" },
+      })
+    );
+
+    await init(projectDir);
+
+    expect(existsSync(memPath)).toBe(true);
+    const content = readFileSync(memPath, "utf-8");
+    expect(content).toContain("my-test-project");
+    expect(content).toContain("React");
+    expect(content).toContain("TypeScript");
+  });
+
+  test("does not overwrite existing learning-memory.md on re-init", async () => {
+    const minkProjDir = join(memPath, "..");
+    mkdirSync(minkProjDir, { recursive: true });
+    writeFileSync(memPath, "# Existing Memory\n\nCustom content");
+
+    await init(projectDir);
+
+    const content = readFileSync(memPath, "utf-8");
+    expect(content).toContain("Custom content");
   });
 });

--- a/tests/unit/learning-memory.test.ts
+++ b/tests/unit/learning-memory.test.ts
@@ -1,0 +1,253 @@
+import { describe, test, expect } from "bun:test";
+import {
+  createEmptyLearningMemory,
+  parseLearningMemory,
+  serializeLearningMemory,
+  addEntry,
+  removeEntry,
+  getEntries,
+  totalEntryCount,
+} from "../../src/core/learning-memory";
+import type { LearningMemory } from "../../src/types/learning-memory";
+
+const WELL_FORMED_MARKDOWN = `# Learning Memory — my-project
+
+## User Preferences
+- Prefer single quotes
+- 2-space indentation
+
+## Key Learnings
+- Bun test runner uses bun:test
+
+## Do-Not-Repeat
+- Don't use var
+
+## Decision Log
+- Chose Bun over Node for speed
+`;
+
+describe("createEmptyLearningMemory", () => {
+  test("creates memory with given project name", () => {
+    const mem = createEmptyLearningMemory("my-project");
+    expect(mem.projectName).toBe("my-project");
+  });
+
+  test("creates all four sections as empty arrays", () => {
+    const mem = createEmptyLearningMemory("x");
+    expect(mem.sections["User Preferences"]).toEqual([]);
+    expect(mem.sections["Key Learnings"]).toEqual([]);
+    expect(mem.sections["Do-Not-Repeat"]).toEqual([]);
+    expect(mem.sections["Decision Log"]).toEqual([]);
+  });
+});
+
+describe("parseLearningMemory", () => {
+  test("parses well-formed markdown", () => {
+    const mem = parseLearningMemory(WELL_FORMED_MARKDOWN);
+    expect(mem.projectName).toBe("my-project");
+    expect(mem.sections["User Preferences"]).toEqual([
+      "Prefer single quotes",
+      "2-space indentation",
+    ]);
+    expect(mem.sections["Key Learnings"]).toEqual([
+      "Bun test runner uses bun:test",
+    ]);
+    expect(mem.sections["Do-Not-Repeat"]).toEqual(["Don't use var"]);
+    expect(mem.sections["Decision Log"]).toEqual([
+      "Chose Bun over Node for speed",
+    ]);
+  });
+
+  test("parses empty sections", () => {
+    const md = `# Learning Memory — proj
+
+## User Preferences
+
+## Key Learnings
+
+## Do-Not-Repeat
+
+## Decision Log
+`;
+    const mem = parseLearningMemory(md);
+    expect(mem.projectName).toBe("proj");
+    expect(mem.sections["User Preferences"]).toEqual([]);
+    expect(mem.sections["Key Learnings"]).toEqual([]);
+    expect(mem.sections["Do-Not-Repeat"]).toEqual([]);
+    expect(mem.sections["Decision Log"]).toEqual([]);
+  });
+
+  test("uses 'unknown' for missing title", () => {
+    const md = `## User Preferences
+- some entry
+`;
+    const mem = parseLearningMemory(md);
+    expect(mem.projectName).toBe("unknown");
+    expect(mem.sections["User Preferences"]).toEqual(["some entry"]);
+  });
+
+  test("ignores content outside recognized sections", () => {
+    const md = `# Learning Memory — proj
+
+Some free-form text here.
+
+## Unknown Section
+- this should be ignored
+
+## User Preferences
+- kept entry
+
+More text
+`;
+    const mem = parseLearningMemory(md);
+    expect(mem.sections["User Preferences"]).toEqual(["kept entry"]);
+    expect(totalEntryCount(mem)).toBe(1);
+  });
+
+  test("handles empty string input", () => {
+    const mem = parseLearningMemory("");
+    expect(mem.projectName).toBe("unknown");
+    expect(totalEntryCount(mem)).toBe(0);
+  });
+
+  test("handles whitespace-only input", () => {
+    const mem = parseLearningMemory("   \n   ");
+    expect(mem.projectName).toBe("unknown");
+    expect(totalEntryCount(mem)).toBe(0);
+  });
+
+  test("round-trip: parse → serialize → parse produces same result", () => {
+    const original = parseLearningMemory(WELL_FORMED_MARKDOWN);
+    const serialized = serializeLearningMemory(original);
+    const reparsed = parseLearningMemory(serialized);
+    expect(reparsed.projectName).toBe(original.projectName);
+    expect(reparsed.sections).toEqual(original.sections);
+  });
+});
+
+describe("serializeLearningMemory", () => {
+  test("produces markdown with correct title", () => {
+    const mem = createEmptyLearningMemory("test-project");
+    const out = serializeLearningMemory(mem);
+    expect(out).toContain("# Learning Memory — test-project");
+  });
+
+  test("produces sections in fixed order", () => {
+    const mem = createEmptyLearningMemory("proj");
+    const out = serializeLearningMemory(mem);
+    const prefIdx = out.indexOf("## User Preferences");
+    const klIdx = out.indexOf("## Key Learnings");
+    const dnrIdx = out.indexOf("## Do-Not-Repeat");
+    const dlIdx = out.indexOf("## Decision Log");
+    expect(prefIdx).toBeLessThan(klIdx);
+    expect(klIdx).toBeLessThan(dnrIdx);
+    expect(dnrIdx).toBeLessThan(dlIdx);
+  });
+
+  test("ends with a single newline", () => {
+    const mem = createEmptyLearningMemory("proj");
+    const out = serializeLearningMemory(mem);
+    expect(out.endsWith("\n")).toBe(true);
+    expect(out.endsWith("\n\n")).toBe(false);
+  });
+
+  test("serializes entries as bullet list items", () => {
+    const mem = createEmptyLearningMemory("proj");
+    mem.sections["Key Learnings"].push("entry one");
+    mem.sections["Key Learnings"].push("entry two");
+    const out = serializeLearningMemory(mem);
+    expect(out).toContain("- entry one");
+    expect(out).toContain("- entry two");
+  });
+});
+
+describe("addEntry", () => {
+  test("appends entry to the specified section", () => {
+    const mem = createEmptyLearningMemory("proj");
+    addEntry(mem, "User Preferences", "new entry");
+    expect(mem.sections["User Preferences"]).toEqual(["new entry"]);
+  });
+
+  test("appends multiple entries in order", () => {
+    const mem = createEmptyLearningMemory("proj");
+    addEntry(mem, "Do-Not-Repeat", "first");
+    addEntry(mem, "Do-Not-Repeat", "second");
+    expect(mem.sections["Do-Not-Repeat"]).toEqual(["first", "second"]);
+  });
+});
+
+describe("removeEntry", () => {
+  test("removes entry at valid index", () => {
+    const mem = createEmptyLearningMemory("proj");
+    addEntry(mem, "Key Learnings", "alpha");
+    addEntry(mem, "Key Learnings", "beta");
+    addEntry(mem, "Key Learnings", "gamma");
+    removeEntry(mem, "Key Learnings", 1);
+    expect(mem.sections["Key Learnings"]).toEqual(["alpha", "gamma"]);
+  });
+
+  test("removes first entry", () => {
+    const mem = createEmptyLearningMemory("proj");
+    addEntry(mem, "Decision Log", "first");
+    addEntry(mem, "Decision Log", "second");
+    removeEntry(mem, "Decision Log", 0);
+    expect(mem.sections["Decision Log"]).toEqual(["second"]);
+  });
+
+  test("removes last entry", () => {
+    const mem = createEmptyLearningMemory("proj");
+    addEntry(mem, "Decision Log", "first");
+    addEntry(mem, "Decision Log", "second");
+    removeEntry(mem, "Decision Log", 1);
+    expect(mem.sections["Decision Log"]).toEqual(["first"]);
+  });
+
+  test("no-op when index is out of bounds (too high)", () => {
+    const mem = createEmptyLearningMemory("proj");
+    addEntry(mem, "User Preferences", "only");
+    removeEntry(mem, "User Preferences", 5);
+    expect(mem.sections["User Preferences"]).toEqual(["only"]);
+  });
+
+  test("no-op when index is negative", () => {
+    const mem = createEmptyLearningMemory("proj");
+    addEntry(mem, "User Preferences", "only");
+    removeEntry(mem, "User Preferences", -1);
+    expect(mem.sections["User Preferences"]).toEqual(["only"]);
+  });
+
+  test("no-op on empty section", () => {
+    const mem = createEmptyLearningMemory("proj");
+    removeEntry(mem, "Key Learnings", 0);
+    expect(mem.sections["Key Learnings"]).toEqual([]);
+  });
+});
+
+describe("getEntries", () => {
+  test("returns entries for a section", () => {
+    const mem = createEmptyLearningMemory("proj");
+    addEntry(mem, "Do-Not-Repeat", "rule one");
+    expect(getEntries(mem, "Do-Not-Repeat")).toEqual(["rule one"]);
+  });
+
+  test("returns empty array for empty section", () => {
+    const mem = createEmptyLearningMemory("proj");
+    expect(getEntries(mem, "Key Learnings")).toEqual([]);
+  });
+});
+
+describe("totalEntryCount", () => {
+  test("returns 0 for empty memory", () => {
+    const mem = createEmptyLearningMemory("proj");
+    expect(totalEntryCount(mem)).toBe(0);
+  });
+
+  test("counts entries across all sections", () => {
+    const mem = createEmptyLearningMemory("proj");
+    addEntry(mem, "User Preferences", "a");
+    addEntry(mem, "User Preferences", "b");
+    addEntry(mem, "Key Learnings", "c");
+    addEntry(mem, "Decision Log", "d");
+    expect(totalEntryCount(mem)).toBe(4);
+  });
+});

--- a/tests/unit/pattern-engine.test.ts
+++ b/tests/unit/pattern-engine.test.ts
@@ -1,0 +1,201 @@
+import { describe, test, expect } from "bun:test";
+import { extractPatterns, matchPatterns } from "../../src/core/pattern-engine";
+import type { ExtractedPattern } from "../../src/types/learning-memory";
+
+// ─── extractPatterns ────────────────────────────────────────────────────────
+
+describe("extractPatterns", () => {
+  test("extracts double-quoted string as literal", () => {
+    const results = extractPatterns(['[2026-04-10] Never use "var"']);
+    const literals = results.filter((p) => p.type === "literal");
+    expect(literals).toHaveLength(1);
+    expect(literals[0].pattern).toBe("var");
+  });
+
+  test("extracts single-quoted string as literal", () => {
+    const results = extractPatterns(["Avoid using 'eval' at all costs"]);
+    const literals = results.filter((p) => p.type === "literal");
+    expect(literals).toHaveLength(1);
+    expect(literals[0].pattern).toBe("eval");
+  });
+
+  test("extracts multiple quoted strings from one entry as literals", () => {
+    const results = extractPatterns(['Use "const" not "var" ever']);
+    const literals = results.filter((p) => p.type === "literal");
+    expect(literals).toHaveLength(2);
+    const patterns = literals.map((p) => p.pattern);
+    expect(patterns).toContain("const");
+    expect(patterns).toContain("var");
+  });
+
+  test("extracts 'never use' phrase as word-boundary", () => {
+    const results = extractPatterns(["Never use default exports"]);
+    const wb = results.filter((p) => p.type === "word-boundary");
+    expect(wb).toHaveLength(1);
+    expect(wb[0].pattern).toBe("default exports");
+  });
+
+  test("extracts 'avoid' phrase as word-boundary", () => {
+    const results = extractPatterns([
+      "Avoid mocking the database in integration tests",
+    ]);
+    const wb = results.filter((p) => p.type === "word-boundary");
+    expect(wb).toHaveLength(1);
+    expect(wb[0].pattern).toBe("mocking the database in integration tests");
+  });
+
+  test("phrase stops at em-dash (—)", () => {
+    const results = extractPatterns(["Never use var — it causes hoisting issues"]);
+    const wb = results.filter((p) => p.type === "word-boundary");
+    expect(wb.length).toBeGreaterThan(0);
+    // The phrase should not include content after the dash
+    for (const p of wb) {
+      expect(p.pattern).not.toContain("hoisting");
+    }
+  });
+
+  test("phrase stops at hyphen (-)", () => {
+    const results = extractPatterns(["Avoid callbacks - prefer promises instead"]);
+    const wb = results.filter((p) => p.type === "word-boundary");
+    expect(wb.length).toBeGreaterThan(0);
+    for (const p of wb) {
+      expect(p.pattern).not.toContain("prefer");
+    }
+  });
+
+  test("phrase stops at period (.)", () => {
+    const results = extractPatterns(["Never use var. It causes bugs."]);
+    const wb = results.filter((p) => p.type === "word-boundary");
+    expect(wb.length).toBeGreaterThan(0);
+    for (const p of wb) {
+      expect(p.pattern).not.toContain("It causes");
+    }
+  });
+
+  test("both quoted and phrase patterns come from one entry", () => {
+    const results = extractPatterns(['Never use "var" in any module']);
+    const literals = results.filter((p) => p.type === "literal");
+    const wb = results.filter((p) => p.type === "word-boundary");
+    // Quoted portion extracted as literal
+    expect(literals).toHaveLength(1);
+    expect(literals[0].pattern).toBe("var");
+    // Phrase extracted (minus quoted content) as word-boundary
+    expect(wb).toHaveLength(1);
+    expect(wb[0].pattern).not.toContain('"var"');
+  });
+
+  test("entry with no extractable pattern produces nothing", () => {
+    const results = extractPatterns(["This is just a general note"]);
+    expect(results).toHaveLength(0);
+  });
+
+  test("multiple entries processed independently", () => {
+    const results = extractPatterns([
+      'Never use "eval"',
+      "Avoid global state",
+      "Some general note",
+    ]);
+    const literals = results.filter((p) => p.type === "literal");
+    const wb = results.filter((p) => p.type === "word-boundary");
+    expect(literals).toHaveLength(1);
+    expect(literals[0].pattern).toBe("eval");
+    expect(wb).toHaveLength(1);
+    expect(wb[0].pattern).toBe("global state");
+  });
+
+  test("empty input array returns empty array", () => {
+    expect(extractPatterns([])).toEqual([]);
+  });
+
+  test("sourceEntry is set to the original entry string", () => {
+    const entry = 'Never use "var"';
+    const results = extractPatterns([entry]);
+    for (const p of results) {
+      expect(p.sourceEntry).toBe(entry);
+    }
+  });
+});
+
+// ─── matchPatterns ───────────────────────────────────────────────────────────
+
+describe("matchPatterns", () => {
+  const literalPat: ExtractedPattern = {
+    type: "literal",
+    pattern: "var",
+    sourceEntry: 'Never use "var"',
+  };
+
+  const wbPat: ExtractedPattern = {
+    type: "word-boundary",
+    pattern: "default exports",
+    sourceEntry: "Never use default exports",
+  };
+
+  test("literal pattern matches in content (case-sensitive)", () => {
+    const matches = matchPatterns([literalPat], "let x = var + 1;");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].matchedText).toBe("var");
+    expect(matches[0].index).toBe(8);
+  });
+
+  test("literal pattern misses on different case", () => {
+    const matches = matchPatterns([literalPat], "let x = VAR + 1;");
+    expect(matches).toHaveLength(0);
+  });
+
+  test("word-boundary pattern matches case-insensitively", () => {
+    const matches = matchPatterns(
+      [wbPat],
+      "You should not use Default Exports in this module"
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].matchedText.toLowerCase()).toBe("default exports");
+  });
+
+  test("no match when pattern is absent", () => {
+    const matches = matchPatterns([literalPat], "const x = 1;");
+    expect(matches).toHaveLength(0);
+  });
+
+  test("multiple patterns match same content", () => {
+    const pat2: ExtractedPattern = {
+      type: "literal",
+      pattern: "eval",
+      sourceEntry: 'Never use "eval"',
+    };
+    const matches = matchPatterns(
+      [literalPat, pat2],
+      "Never use var or eval in production"
+    );
+    expect(matches).toHaveLength(2);
+    const texts = matches.map((m) => m.matchedText);
+    expect(texts).toContain("var");
+    expect(texts).toContain("eval");
+  });
+
+  test("empty content returns empty array", () => {
+    const matches = matchPatterns([literalPat], "");
+    expect(matches).toHaveLength(0);
+  });
+
+  test("empty patterns array returns empty array", () => {
+    const matches = matchPatterns([], "some content with var");
+    expect(matches).toHaveLength(0);
+  });
+
+  test("pattern match carries reference to original pattern", () => {
+    const matches = matchPatterns([literalPat], "use var here");
+    expect(matches[0].pattern).toBe(literalPat);
+  });
+
+  test("word-boundary does not match substring within word", () => {
+    // "var" as word-boundary should not match inside "variable"
+    const wbVarPat: ExtractedPattern = {
+      type: "word-boundary",
+      pattern: "var",
+      sourceEntry: "Never use var",
+    };
+    const matches = matchPatterns([wbVarPat], "avoid variables");
+    expect(matches).toHaveLength(0);
+  });
+});

--- a/tests/unit/pattern-engine.test.ts
+++ b/tests/unit/pattern-engine.test.ts
@@ -41,7 +41,7 @@ describe("extractPatterns", () => {
     ]);
     const wb = results.filter((p) => p.type === "word-boundary");
     expect(wb).toHaveLength(1);
-    expect(wb[0].pattern).toBe("mocking the database in integration tests");
+    expect(wb[0].pattern).toBe("mocking the database");
   });
 
   test("phrase stops at em-dash (—)", () => {

--- a/tests/unit/reflect-command.test.ts
+++ b/tests/unit/reflect-command.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { reflect } from "../../src/commands/reflect";
+import { createEmptyLearningMemory, addEntry, serializeLearningMemory } from "../../src/core/learning-memory";
+import { atomicWriteJson, atomicWriteText } from "../../src/core/fs-utils";
+import { estimateTokens } from "../../src/core/token-estimate";
+import type { ProjectConfig } from "../../src/types/file-index";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = join("/tmp", `mink-reflect-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function memoryPath(): string {
+  return join(tmpDir, "learning-memory.md");
+}
+
+function confPath(): string {
+  return join(tmpDir, "config.json");
+}
+
+describe("reflect command", () => {
+  test("returns null when learning memory file does not exist", () => {
+    const result = reflect(tmpDir, memoryPath(), confPath());
+    expect(result).toBeNull();
+  });
+
+  test("prunes duplicates and saves file", () => {
+    const mem = createEmptyLearningMemory("proj");
+    const dupEntry = "always check for null before accessing properties";
+    for (let i = 0; i < 10; i++) {
+      addEntry(mem, "Key Learnings", dupEntry);
+    }
+    const content = serializeLearningMemory(mem);
+    atomicWriteText(memoryPath(), content);
+
+    // Use a config budget that forces dedup (tight budget, but single copy fits)
+    // 10 copies create ~155 tokens; set budget to 30 so single copy (~15 tokens base + entry) passes
+    const singleMem = createEmptyLearningMemory("proj");
+    addEntry(singleMem, "Key Learnings", dupEntry);
+    const singleTokens = estimateTokens(serializeLearningMemory(singleMem), "learning-memory.md");
+    const config: ProjectConfig = { learningMemoryTokenBudget: singleTokens + 5 };
+    atomicWriteJson(confPath(), config);
+
+    const result = reflect(tmpDir, memoryPath(), confPath());
+    expect(result).not.toBeNull();
+    expect(result!.mergedCount).toBeGreaterThan(0);
+
+    const savedContent = readFileSync(memoryPath(), "utf-8");
+    // After dedup, only 1 copy should exist
+    const occurrences = (savedContent.match(new RegExp(dupEntry, "g")) || []).length;
+    expect(occurrences).toBe(1);
+  });
+
+  test("uses default budget of 2000 when no config file", () => {
+    // Create a small memory well under the default 2000 token budget
+    const mem = createEmptyLearningMemory("proj");
+    addEntry(mem, "Key Learnings", "entry one");
+    addEntry(mem, "Key Learnings", "entry two");
+    const content = serializeLearningMemory(mem);
+    atomicWriteText(memoryPath(), content);
+
+    const result = reflect(tmpDir, memoryPath(), confPath());
+    expect(result).not.toBeNull();
+    expect(result!.withinBudget).toBe(true);
+    expect(result!.trimmedCount).toBe(0);
+  });
+
+  test("reads custom budget from config file", () => {
+    // Create a memory that exceeds the custom budget
+    const mem = createEmptyLearningMemory("proj");
+    for (let i = 0; i < 100; i++) {
+      addEntry(mem, "Decision Log", `Decision ${i}: we selected approach A because it is more maintainable`);
+    }
+    atomicWriteText(memoryPath(), serializeLearningMemory(mem));
+
+    // Set a very small budget
+    const config: ProjectConfig = { learningMemoryTokenBudget: 50 };
+    atomicWriteJson(confPath(), config);
+
+    const result = reflect(tmpDir, memoryPath(), confPath());
+    expect(result).not.toBeNull();
+    expect(result!.trimmedCount).toBeGreaterThan(0);
+    expect(result!.afterTokens).toBeLessThanOrEqual(50);
+  });
+
+  test("does not modify file if already within budget and no duplicates", () => {
+    const mem = createEmptyLearningMemory("proj");
+    addEntry(mem, "Key Learnings", "unique entry one");
+    addEntry(mem, "Key Learnings", "unique entry two");
+    const content = serializeLearningMemory(mem);
+    atomicWriteText(memoryPath(), content);
+
+    // Record modification time before reflect
+    const statBefore = Bun.file(memoryPath()).lastModified;
+
+    // Small delay to ensure mtime would change if file were written
+    // Using sync approach: check content is same
+    const result = reflect(tmpDir, memoryPath(), confPath());
+    expect(result).not.toBeNull();
+    expect(result!.mergedCount).toBe(0);
+    expect(result!.trimmedCount).toBe(0);
+
+    const contentAfter = readFileSync(memoryPath(), "utf-8");
+    expect(contentAfter).toBe(content);
+  });
+
+  test("returns ReflectionResult with correct stats", () => {
+    const mem = createEmptyLearningMemory("proj");
+    addEntry(mem, "Key Learnings", "entry");
+    const content = serializeLearningMemory(mem);
+    atomicWriteText(memoryPath(), content);
+
+    const result = reflect(tmpDir, memoryPath(), confPath());
+    expect(result).not.toBeNull();
+    expect(typeof result!.beforeTokens).toBe("number");
+    expect(typeof result!.afterTokens).toBe("number");
+    expect(result!.beforeTokens).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/reflection.test.ts
+++ b/tests/unit/reflection.test.ts
@@ -1,0 +1,302 @@
+import { describe, test, expect } from "bun:test";
+import { mergeDuplicates, trimOldest, reflectMemory } from "../../src/core/reflection";
+import { createEmptyLearningMemory, addEntry, serializeLearningMemory } from "../../src/core/learning-memory";
+import { estimateTokens } from "../../src/core/token-estimate";
+import type { LearningMemory } from "../../src/types/learning-memory";
+
+function makeMemory(overrides: Partial<Record<string, string[]>> = {}): LearningMemory {
+  const mem = createEmptyLearningMemory("test-project");
+  if (overrides["User Preferences"]) mem.sections["User Preferences"] = [...overrides["User Preferences"]];
+  if (overrides["Key Learnings"]) mem.sections["Key Learnings"] = [...overrides["Key Learnings"]];
+  if (overrides["Do-Not-Repeat"]) mem.sections["Do-Not-Repeat"] = [...overrides["Do-Not-Repeat"]];
+  if (overrides["Decision Log"]) mem.sections["Decision Log"] = [...overrides["Decision Log"]];
+  return mem;
+}
+
+// ─── mergeDuplicates ─────────────────────────────────────────────────────────
+
+describe("mergeDuplicates", () => {
+  test("removes exact duplicates within a section", () => {
+    const mem = makeMemory({
+      "Key Learnings": ["use async/await", "use async/await", "other entry"],
+    });
+    const result = mergeDuplicates(mem);
+    expect(result.sections["Key Learnings"]).toEqual(["use async/await", "other entry"]);
+  });
+
+  test("removes whitespace-normalized duplicates", () => {
+    const mem = makeMemory({
+      "User Preferences": ["prefer  single  quotes", "prefer single quotes"],
+    });
+    const result = mergeDuplicates(mem);
+    expect(result.sections["User Preferences"]).toHaveLength(1);
+  });
+
+  test("DNR: entries sharing same quoted pattern keep newer date", () => {
+    const mem = makeMemory({
+      "Do-Not-Repeat": [
+        `Don't use "var" [2024-01-01]`,
+        `Avoid "var" usage [2024-06-15]`,
+      ],
+    });
+    const result = mergeDuplicates(mem);
+    expect(result.sections["Do-Not-Repeat"]).toHaveLength(1);
+    expect(result.sections["Do-Not-Repeat"][0]).toContain("2024-06-15");
+  });
+
+  test("DNR: entries sharing same quoted pattern - older entry kept when newer has no date", () => {
+    const mem = makeMemory({
+      "Do-Not-Repeat": [
+        `Don't use "var" [2024-01-01]`,
+        `Also avoid "var"`,
+      ],
+    });
+    const result = mergeDuplicates(mem);
+    // The one with a date should win since non-date entries don't bump "best"
+    expect(result.sections["Do-Not-Repeat"]).toHaveLength(1);
+    expect(result.sections["Do-Not-Repeat"][0]).toContain("2024-01-01");
+  });
+
+  test("DNR: entries with different quoted patterns are NOT merged", () => {
+    const mem = makeMemory({
+      "Do-Not-Repeat": [
+        `Don't use "var" [2024-01-01]`,
+        `Don't use "let" [2024-01-01]`,
+      ],
+    });
+    const result = mergeDuplicates(mem);
+    expect(result.sections["Do-Not-Repeat"]).toHaveLength(2);
+  });
+
+  test("no duplicates returns unchanged entries", () => {
+    const mem = makeMemory({
+      "Key Learnings": ["entry one", "entry two", "entry three"],
+    });
+    const result = mergeDuplicates(mem);
+    expect(result.sections["Key Learnings"]).toEqual(["entry one", "entry two", "entry three"]);
+  });
+
+  test("same text in two different sections is preserved in both", () => {
+    const mem = makeMemory({
+      "Key Learnings": ["use strict mode"],
+      "User Preferences": ["use strict mode"],
+    });
+    const result = mergeDuplicates(mem);
+    expect(result.sections["Key Learnings"]).toEqual(["use strict mode"]);
+    expect(result.sections["User Preferences"]).toEqual(["use strict mode"]);
+  });
+
+  test("does not mutate input", () => {
+    const mem = makeMemory({
+      "Key Learnings": ["dup", "dup"],
+    });
+    const before = [...mem.sections["Key Learnings"]];
+    mergeDuplicates(mem);
+    expect(mem.sections["Key Learnings"]).toEqual(before);
+  });
+
+  test("empty sections remain empty", () => {
+    const mem = makeMemory();
+    const result = mergeDuplicates(mem);
+    expect(result.sections["Key Learnings"]).toEqual([]);
+    expect(result.sections["Do-Not-Repeat"]).toEqual([]);
+  });
+});
+
+// ─── trimOldest ──────────────────────────────────────────────────────────────
+
+describe("trimOldest", () => {
+  test("trims from Decision Log first", () => {
+    const mem = makeMemory({
+      "Decision Log": ["dl-1", "dl-2"],
+      "Key Learnings": ["kl-1"],
+      "User Preferences": ["up-1"],
+      "Do-Not-Repeat": ["dnr-1"],
+    });
+    const result = trimOldest(mem, 1);
+    expect(result.sections["Decision Log"]).toEqual(["dl-2"]);
+    expect(result.sections["Key Learnings"]).toEqual(["kl-1"]);
+    expect(result.sections["User Preferences"]).toEqual(["up-1"]);
+    expect(result.sections["Do-Not-Repeat"]).toEqual(["dnr-1"]);
+  });
+
+  test("trims Key Learnings after Decision Log is empty", () => {
+    const mem = makeMemory({
+      "Decision Log": ["dl-1"],
+      "Key Learnings": ["kl-1", "kl-2"],
+      "User Preferences": ["up-1"],
+      "Do-Not-Repeat": ["dnr-1"],
+    });
+    // trim 2: remove dl-1 then kl-1
+    const result = trimOldest(mem, 2);
+    expect(result.sections["Decision Log"]).toEqual([]);
+    expect(result.sections["Key Learnings"]).toEqual(["kl-2"]);
+    expect(result.sections["User Preferences"]).toEqual(["up-1"]);
+    expect(result.sections["Do-Not-Repeat"]).toEqual(["dnr-1"]);
+  });
+
+  test("trims User Preferences after Decision Log and Key Learnings are empty", () => {
+    const mem = makeMemory({
+      "Decision Log": ["dl-1"],
+      "Key Learnings": ["kl-1"],
+      "User Preferences": ["up-1", "up-2"],
+      "Do-Not-Repeat": ["dnr-1"],
+    });
+    // trim 3: remove dl-1, kl-1, up-1
+    const result = trimOldest(mem, 3);
+    expect(result.sections["Decision Log"]).toEqual([]);
+    expect(result.sections["Key Learnings"]).toEqual([]);
+    expect(result.sections["User Preferences"]).toEqual(["up-2"]);
+    expect(result.sections["Do-Not-Repeat"]).toEqual(["dnr-1"]);
+  });
+
+  test("trims Do-Not-Repeat last", () => {
+    const mem = makeMemory({
+      "Decision Log": ["dl-1"],
+      "Key Learnings": ["kl-1"],
+      "User Preferences": ["up-1"],
+      "Do-Not-Repeat": ["dnr-1", "dnr-2"],
+    });
+    // trim 4: remove dl-1, kl-1, up-1, dnr-1
+    const result = trimOldest(mem, 4);
+    expect(result.sections["Decision Log"]).toEqual([]);
+    expect(result.sections["Key Learnings"]).toEqual([]);
+    expect(result.sections["User Preferences"]).toEqual([]);
+    expect(result.sections["Do-Not-Repeat"]).toEqual(["dnr-2"]);
+  });
+
+  test("no-op for trimCount 0", () => {
+    const mem = makeMemory({
+      "Decision Log": ["dl-1"],
+      "Key Learnings": ["kl-1"],
+    });
+    const result = trimOldest(mem, 0);
+    expect(result.sections["Decision Log"]).toEqual(["dl-1"]);
+    expect(result.sections["Key Learnings"]).toEqual(["kl-1"]);
+  });
+
+  test("handles trimming more than total entries", () => {
+    const mem = makeMemory({
+      "Decision Log": ["dl-1"],
+      "Key Learnings": ["kl-1"],
+    });
+    const result = trimOldest(mem, 100);
+    expect(result.sections["Decision Log"]).toEqual([]);
+    expect(result.sections["Key Learnings"]).toEqual([]);
+    expect(result.sections["User Preferences"]).toEqual([]);
+    expect(result.sections["Do-Not-Repeat"]).toEqual([]);
+  });
+
+  test("does not mutate input", () => {
+    const mem = makeMemory({ "Decision Log": ["dl-1", "dl-2"] });
+    trimOldest(mem, 1);
+    expect(mem.sections["Decision Log"]).toEqual(["dl-1", "dl-2"]);
+  });
+});
+
+// ─── reflectMemory ───────────────────────────────────────────────────────────
+
+describe("reflectMemory", () => {
+  function makeLargeMemory(): LearningMemory {
+    const mem = createEmptyLearningMemory("big-project");
+    for (let i = 0; i < 50; i++) {
+      addEntry(mem, "Decision Log", `Decision number ${i}: we chose option A over option B because it was faster and safer`);
+    }
+    for (let i = 0; i < 50; i++) {
+      addEntry(mem, "Key Learnings", `Learning number ${i}: always check for null values before accessing properties`);
+    }
+    return mem;
+  }
+
+  test("under budget is a no-op — returns same entries and withinBudget=true", () => {
+    const mem = makeMemory({ "Key Learnings": ["small entry"] });
+    const { memory, result } = reflectMemory(mem, 10000);
+    expect(result.withinBudget).toBe(true);
+    expect(result.mergedCount).toBe(0);
+    expect(result.trimmedCount).toBe(0);
+    expect(memory.sections["Key Learnings"]).toEqual(["small entry"]);
+  });
+
+  test("merge dups gets under budget", () => {
+    // Create a memory where duplicates are causing the oversize, budget tight enough
+    const mem = createEmptyLearningMemory("proj");
+    const longEntry = "This is a somewhat long entry that repeats a lot of tokens in the budget analysis";
+    // Add many duplicates
+    for (let i = 0; i < 20; i++) {
+      addEntry(mem, "Key Learnings", longEntry);
+    }
+    // With duplicates: ~20 copies. Serialized tokens should exceed a small budget
+    const serialized = serializeLearningMemory(mem);
+    const totalTokens = estimateTokens(serialized, "learning-memory.md");
+    // Budget that is tight but achievable by deduplication (1 copy)
+    const singleCopySerialized = serializeLearningMemory(
+      makeMemory({ "Key Learnings": [longEntry] })
+    );
+    const singleCopyTokens = estimateTokens(singleCopySerialized, "learning-memory.md");
+
+    if (totalTokens > singleCopyTokens) {
+      const budget = singleCopyTokens + 10;
+      const { memory, result } = reflectMemory(mem, budget);
+      expect(result.mergedCount).toBeGreaterThan(0);
+      expect(result.withinBudget).toBe(true);
+      expect(memory.sections["Key Learnings"]).toHaveLength(1);
+    }
+  });
+
+  test("trim when merge insufficient", () => {
+    const mem = makeLargeMemory();
+    const serialized = serializeLearningMemory(mem);
+    const tokens = estimateTokens(serialized, "learning-memory.md");
+    // Set budget to a small fraction — needs trimming
+    const budget = Math.floor(tokens / 5);
+    const { result } = reflectMemory(mem, budget);
+    expect(result.trimmedCount).toBeGreaterThan(0);
+    expect(result.beforeTokens).toBeGreaterThan(result.afterTokens);
+  });
+
+  test("returns updated memory with fewer entries after trimming", () => {
+    const mem = makeLargeMemory();
+    const serialized = serializeLearningMemory(mem);
+    const tokens = estimateTokens(serialized, "learning-memory.md");
+    const budget = Math.floor(tokens / 3);
+    const { memory, result } = reflectMemory(mem, budget);
+    const before = mem.sections["Decision Log"].length + mem.sections["Key Learnings"].length;
+    const after =
+      memory.sections["Decision Log"].length + memory.sections["Key Learnings"].length;
+    expect(after).toBeLessThan(before);
+    expect(result.trimmedCount).toBeGreaterThan(0);
+  });
+
+  test("zero budget skips pruning and returns withinBudget=true", () => {
+    const mem = makeLargeMemory();
+    const { result } = reflectMemory(mem, 0);
+    expect(result.withinBudget).toBe(true);
+    expect(result.mergedCount).toBe(0);
+    expect(result.trimmedCount).toBe(0);
+  });
+
+  test("negative budget skips pruning and returns withinBudget=true", () => {
+    const mem = makeLargeMemory();
+    const { result } = reflectMemory(mem, -100);
+    expect(result.withinBudget).toBe(true);
+    expect(result.mergedCount).toBe(0);
+    expect(result.trimmedCount).toBe(0);
+  });
+
+  test("beforeTokens is populated correctly", () => {
+    const mem = makeMemory({ "Key Learnings": ["entry one", "entry two"] });
+    const serialized = serializeLearningMemory(mem);
+    const expected = estimateTokens(serialized, "learning-memory.md");
+    const { result } = reflectMemory(mem, 10000);
+    expect(result.beforeTokens).toBe(expected);
+  });
+
+  test("does not mutate the input memory", () => {
+    const mem = makeLargeMemory();
+    const originalDLCount = mem.sections["Decision Log"].length;
+    const serialized = serializeLearningMemory(mem);
+    const tokens = estimateTokens(serialized, "learning-memory.md");
+    reflectMemory(mem, Math.floor(tokens / 3));
+    expect(mem.sections["Decision Log"].length).toBe(originalDLCount);
+  });
+});

--- a/tests/unit/seed.test.ts
+++ b/tests/unit/seed.test.ts
@@ -1,0 +1,314 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  parsePackageJson,
+  parsePyprojectToml,
+  parseCargoToml,
+  parseGoMod,
+  seedLearningMemory,
+} from "../../src/core/seed";
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mink-seed-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeTmp(filename: string, content: string): string {
+  const filePath = join(tmpDir, filename);
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+// ─── parsePackageJson ─────────────────────────────────────────────────────────
+
+describe("parsePackageJson", () => {
+  test("extracts name, description, and frameworks", () => {
+    const filePath = writeTmp(
+      "package.json",
+      JSON.stringify({
+        name: "my-app",
+        description: "A cool app",
+        dependencies: {
+          react: "^18.0.0",
+          express: "^4.0.0",
+        },
+        devDependencies: {
+          typescript: "^5.0.0",
+          vitest: "^1.0.0",
+        },
+      })
+    );
+
+    const info = parsePackageJson(filePath);
+    expect(info).not.toBeNull();
+    expect(info!.projectName).toBe("my-app");
+    expect(info!.description).toBe("A cool app");
+    expect(info!.frameworks).toContain("React");
+    expect(info!.frameworks).toContain("Express");
+    expect(info!.frameworks).toContain("TypeScript");
+    expect(info!.frameworks).toContain("Vitest");
+  });
+
+  test("handles missing description", () => {
+    const filePath = writeTmp(
+      "package.json",
+      JSON.stringify({
+        name: "no-desc",
+        dependencies: { next: "^14.0.0" },
+      })
+    );
+
+    const info = parsePackageJson(filePath);
+    expect(info).not.toBeNull();
+    expect(info!.projectName).toBe("no-desc");
+    expect(info!.description).toBe("");
+    expect(info!.frameworks).toContain("Next.js");
+  });
+
+  test("returns null for missing file", () => {
+    const info = parsePackageJson(join(tmpDir, "nonexistent.json"));
+    expect(info).toBeNull();
+  });
+
+  test("returns null for malformed JSON", () => {
+    const filePath = writeTmp("package.json", "{ not valid json }}}");
+    const info = parsePackageJson(filePath);
+    expect(info).toBeNull();
+  });
+
+  test("handles missing dependencies gracefully", () => {
+    const filePath = writeTmp(
+      "package.json",
+      JSON.stringify({ name: "bare", description: "bare project" })
+    );
+    const info = parsePackageJson(filePath);
+    expect(info).not.toBeNull();
+    expect(info!.frameworks).toEqual([]);
+  });
+
+  test("deduplicates frameworks (react and react-dom both map to React)", () => {
+    const filePath = writeTmp(
+      "package.json",
+      JSON.stringify({
+        name: "dedupe-test",
+        dependencies: { react: "^18", "react-dom": "^18" },
+      })
+    );
+    const info = parsePackageJson(filePath);
+    expect(info!.frameworks.filter((f) => f === "React")).toHaveLength(1);
+  });
+});
+
+// ─── parsePyprojectToml ───────────────────────────────────────────────────────
+
+describe("parsePyprojectToml", () => {
+  test("extracts name, description, and frameworks from [project] section", () => {
+    const filePath = writeTmp(
+      "pyproject.toml",
+      `[project]
+name = "my-python-app"
+description = "A FastAPI service"
+dependencies = [
+  "fastapi>=0.100",
+  "sqlalchemy>=2.0",
+  "uvicorn",
+]
+`
+    );
+
+    const info = parsePyprojectToml(filePath);
+    expect(info).not.toBeNull();
+    expect(info!.projectName).toBe("my-python-app");
+    expect(info!.description).toBe("A FastAPI service");
+    expect(info!.frameworks).toContain("FastAPI");
+    expect(info!.frameworks).toContain("SQLAlchemy");
+    expect(info!.frameworks).toContain("Uvicorn");
+  });
+
+  test("returns null for missing file", () => {
+    const info = parsePyprojectToml(join(tmpDir, "pyproject.toml"));
+    expect(info).toBeNull();
+  });
+
+  test("returns empty strings when fields are absent", () => {
+    const filePath = writeTmp("pyproject.toml", `[build-system]\nrequires = []\n`);
+    const info = parsePyprojectToml(filePath);
+    expect(info).not.toBeNull();
+    expect(info!.projectName).toBe("");
+    expect(info!.description).toBe("");
+  });
+});
+
+// ─── parseCargoToml ───────────────────────────────────────────────────────────
+
+describe("parseCargoToml", () => {
+  test("extracts name, description, and frameworks from [package] section", () => {
+    const filePath = writeTmp(
+      "Cargo.toml",
+      `[package]
+name = "my-rust-app"
+description = "An Axum service"
+version = "0.1.0"
+
+[dependencies]
+axum = "0.7"
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+`
+    );
+
+    const info = parseCargoToml(filePath);
+    expect(info).not.toBeNull();
+    expect(info!.projectName).toBe("my-rust-app");
+    expect(info!.description).toBe("An Axum service");
+    expect(info!.frameworks).toContain("Axum");
+    expect(info!.frameworks).toContain("Tokio");
+    expect(info!.frameworks).toContain("Serde");
+  });
+
+  test("returns null for missing file", () => {
+    const info = parseCargoToml(join(tmpDir, "Cargo.toml"));
+    expect(info).toBeNull();
+  });
+
+  test("returns empty strings when fields are absent", () => {
+    const filePath = writeTmp("Cargo.toml", `[workspace]\nmembers = []\n`);
+    const info = parseCargoToml(filePath);
+    expect(info).not.toBeNull();
+    expect(info!.projectName).toBe("");
+    expect(info!.description).toBe("");
+  });
+});
+
+// ─── parseGoMod ───────────────────────────────────────────────────────────────
+
+describe("parseGoMod", () => {
+  test("extracts module name (last segment) and frameworks", () => {
+    const filePath = writeTmp(
+      "go.mod",
+      `module github.com/acme/my-service
+
+go 1.21
+
+require (
+  github.com/gin-gonic/gin v1.9.0
+  gorm.io/gorm v1.25.0
+)
+`
+    );
+
+    const info = parseGoMod(filePath);
+    expect(info).not.toBeNull();
+    expect(info!.projectName).toBe("my-service");
+    expect(info!.frameworks).toContain("Gin");
+    expect(info!.frameworks).toContain("GORM");
+  });
+
+  test("returns null for missing file", () => {
+    const info = parseGoMod(join(tmpDir, "go.mod"));
+    expect(info).toBeNull();
+  });
+
+  test("handles simple module path (no slashes)", () => {
+    const filePath = writeTmp("go.mod", `module mymodule\n\ngo 1.21\n`);
+    const info = parseGoMod(filePath);
+    expect(info).not.toBeNull();
+    expect(info!.projectName).toBe("mymodule");
+  });
+
+  test("description is always empty string", () => {
+    const filePath = writeTmp(
+      "go.mod",
+      `module github.com/acme/svc\n\ngo 1.21\n`
+    );
+    const info = parseGoMod(filePath);
+    expect(info!.description).toBe("");
+  });
+});
+
+// ─── seedLearningMemory ───────────────────────────────────────────────────────
+
+describe("seedLearningMemory", () => {
+  test("seeds from package.json", () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({
+        name: "seed-app",
+        description: "My seeded app",
+        dependencies: { react: "^18", next: "^14" },
+      })
+    );
+
+    const mem = seedLearningMemory(tmpDir);
+    expect(mem.projectName).toBe("seed-app");
+    const kl = mem.sections["Key Learnings"];
+    expect(kl.some((e) => e.includes("seed-app"))).toBe(true);
+    expect(kl.some((e) => e.includes("My seeded app"))).toBe(true);
+    expect(kl.some((e) => e.includes("React"))).toBe(true);
+    expect(kl.some((e) => e.includes("Next.js"))).toBe(true);
+  });
+
+  test("seeds from multiple project files, deduplicates frameworks", () => {
+    // Write both package.json and Cargo.toml to test multi-file merging
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({
+        name: "multi-project",
+        description: "Hybrid app",
+        dependencies: { express: "^4" },
+      })
+    );
+    writeFileSync(
+      join(tmpDir, "Cargo.toml"),
+      `[package]\nname = "multi-project-rs"\ndescription = "Rust side"\n\n[dependencies]\naxum = "0.7"\n`
+    );
+
+    const mem = seedLearningMemory(tmpDir);
+    // First parser with a name wins
+    expect(mem.projectName).toBe("multi-project");
+    const kl = mem.sections["Key Learnings"];
+    // Frameworks from both parsers should appear
+    expect(kl.some((e) => e.includes("Express"))).toBe(true);
+    expect(kl.some((e) => e.includes("Axum"))).toBe(true);
+  });
+
+  test("falls back to directory name when no project files found", () => {
+    // tmpDir has no package.json, pyproject.toml, Cargo.toml, or go.mod
+    const mem = seedLearningMemory(tmpDir);
+    // Project name should be the directory basename
+    const dirName = require("path").basename(tmpDir);
+    expect(mem.projectName).toBe(dirName);
+    const kl = mem.sections["Key Learnings"];
+    expect(kl.some((e) => e.includes(dirName))).toBe(true);
+  });
+
+  test("no Detected frameworks entry when none detected", () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "empty-deps", description: "No deps" })
+    );
+
+    const mem = seedLearningMemory(tmpDir);
+    const kl = mem.sections["Key Learnings"];
+    expect(kl.some((e) => e.startsWith("Detected frameworks:"))).toBe(false);
+  });
+
+  test("returns a LearningMemory with correct structure", () => {
+    const mem = seedLearningMemory(tmpDir);
+    expect(mem).toHaveProperty("projectName");
+    expect(mem).toHaveProperty("sections");
+    expect(mem.sections).toHaveProperty("User Preferences");
+    expect(mem.sections).toHaveProperty("Key Learnings");
+    expect(mem.sections).toHaveProperty("Do-Not-Repeat");
+    expect(mem.sections).toHaveProperty("Decision Log");
+  });
+});

--- a/tests/unit/session-stop.test.ts
+++ b/tests/unit/session-stop.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, utimesSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, utimesSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { atomicWriteJson, safeReadJson } from "../../src/core/fs-utils";
@@ -158,5 +158,39 @@ describe("sessionStop", () => {
     sessionStop(sessionFile, undefined, (msg: string) => reminders.push(msg));
 
     expect(reminders.some((r) => r.includes("learning memory"))).toBe(false);
+  });
+
+  test("calls reflect on session stop", () => {
+    const state = createSessionState();
+    recordRead(state, "/src/a.ts", 100, true);
+    const sessionFile = setupSession(dir, state);
+
+    // Create a learning memory with duplicates
+    const memPath = join(dir, "learning-memory.md");
+    writeFileSync(
+      memPath,
+      [
+        "# Learning Memory — test",
+        "",
+        "## User Preferences",
+        "",
+        "- Duplicate",
+        "- Duplicate",
+        "",
+        "## Key Learnings",
+        "",
+        "## Do-Not-Repeat",
+        "",
+        "## Decision Log",
+        "",
+      ].join("\n")
+    );
+
+    sessionStop(sessionFile);
+
+    // Verify duplicates were merged
+    const saved = readFileSync(memPath, "utf-8");
+    const occurrences = saved.split("- Duplicate").length - 1;
+    expect(occurrences).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- Implements spec 03 (Learning Memory) — a persistent markdown document with four structured sections: User Preferences, Key Learnings, Do-Not-Repeat, and Decision Log
- Adds pattern engine for extracting enforceable rules from Do-Not-Repeat entries (quoted strings → literal match, "never use"/"avoid" → word-boundary match)
- Multi-ecosystem initialization seeding from `package.json`, `pyproject.toml`, `Cargo.toml`, and `go.mod`
- `mink reflect` CLI command for pruning: merge duplicates first, then trim oldest entries (Decision Log first, Do-Not-Repeat last) to stay within configurable token budget (default 2000)
- Session-stop automatically runs reflection on learning memory
- `mink init` seeds learning memory from project metadata

## Test plan

- [ ] 267 tests passing across 17 files (110 new tests added)
- [ ] Unit tests for: parse/serialize/CRUD, pattern extraction, pattern matching, seeding (4 ecosystems), reflection (merge + trim), reflect command
- [ ] Integration tests for: full lifecycle (seed → add → reflect → verify), pattern matching end-to-end, bloated memory pruning, corrupted file handling
- [ ] E2E smoke test: `mink init` creates seeded learning memory, `mink reflect` reports token budget status

🤖 Generated with [Claude Code](https://claude.com/claude-code)