### PR TITLE
feat: implement spec 06 write enforcement hooks

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,8 +47,20 @@ switch (command) {
     break;
   }
 
+  case "pre-write": {
+    const { preWrite } = await import("./commands/pre-write");
+    await preWrite(cwd);
+    break;
+  }
+
+  case "post-write": {
+    const { postWrite } = await import("./commands/post-write");
+    await postWrite(cwd);
+    break;
+  }
+
   default:
     console.error(`[mink] unknown command: ${command}`);
-    console.error("Usage: mink <session-start|session-stop|init|scan|reflect|pre-read|post-read>");
+    console.error("Usage: mink <session-start|session-stop|init|scan|reflect|pre-read|post-read|pre-write|post-write>");
     process.exit(1);
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -29,8 +29,16 @@ export function buildHooksConfig(
   return {
     SessionStart: [{ matcher: "", command: `${prefix} session-start` }],
     Stop: [{ matcher: "", command: `${prefix} session-stop` }],
-    PreToolUse: [{ matcher: "Read", command: `${prefix} pre-read` }],
-    PostToolUse: [{ matcher: "Read", command: `${prefix} post-read` }],
+    PreToolUse: [
+      { matcher: "Read", command: `${prefix} pre-read` },
+      { matcher: "Edit", command: `${prefix} pre-write` },
+      { matcher: "Write", command: `${prefix} pre-write` },
+    ],
+    PostToolUse: [
+      { matcher: "Read", command: `${prefix} post-read` },
+      { matcher: "Edit", command: `${prefix} post-write` },
+      { matcher: "Write", command: `${prefix} post-write` },
+    ],
   };
 }
 
@@ -40,7 +48,9 @@ function isMinkHook(entry: HookEntry): boolean {
     (entry.command.includes("session-start") ||
       entry.command.includes("session-stop") ||
       entry.command.includes("pre-read") ||
-      entry.command.includes("post-read"))
+      entry.command.includes("post-read") ||
+      entry.command.includes("pre-write") ||
+      entry.command.includes("post-write"))
   );
 }
 

--- a/src/commands/post-write.ts
+++ b/src/commands/post-write.ts
@@ -1,0 +1,146 @@
+import { relative } from "path";
+import { readFileSync } from "fs";
+import { readStdinJson } from "../core/stdin";
+import { sessionPath, fileIndexPath } from "../core/paths";
+import { safeReadJson, atomicWriteJson } from "../core/fs-utils";
+import { createSessionState, isSessionState, recordWrite } from "../core/session";
+import {
+  isFileIndex,
+  lookupEntry,
+  upsertEntry,
+  createEmptyIndex,
+} from "../core/index-store";
+import { extractDescription } from "../core/description";
+import { estimateTokens, isBinaryFile } from "../core/token-estimate";
+import { isWriteExcluded } from "../core/write-exclusions";
+import type { SessionState } from "../types/session";
+import type { FileIndex, FileIndexEntry } from "../types/file-index";
+import type { PostToolUseInput } from "../types/hook-input";
+
+export interface PostWriteResult {
+  excluded: boolean;
+  action: "create" | "edit";
+  estimatedTokens: number;
+  description: string;
+  indexEntry: FileIndexEntry | null;
+}
+
+export function analyzePostWrite(
+  filePath: string,
+  fileContent: string | null,
+  index: FileIndex | null
+): PostWriteResult {
+  // Check exclusions
+  if (isWriteExcluded(filePath)) {
+    return {
+      excluded: true,
+      action: "edit",
+      estimatedTokens: 0,
+      description: "",
+      indexEntry: null,
+    };
+  }
+
+  // Determine action from index presence
+  const existingEntry = index ? lookupEntry(index, filePath) : null;
+  const action: "create" | "edit" = existingEntry ? "edit" : "create";
+
+  // Handle binary or unreadable content
+  if (fileContent === null || isBinaryFile(filePath, fileContent)) {
+    return {
+      excluded: false,
+      action,
+      estimatedTokens: 0,
+      description: "",
+      indexEntry: null,
+    };
+  }
+
+  // Extract description and estimate tokens
+  const description = extractDescription(filePath, fileContent);
+  const tokens = estimateTokens(fileContent, filePath);
+
+  // Build index entry
+  const now = new Date().toISOString();
+  const indexEntry: FileIndexEntry = {
+    filePath,
+    description,
+    estimatedTokens: tokens,
+    lastModified: now,
+    lastIndexed: now,
+  };
+
+  return {
+    excluded: false,
+    action,
+    estimatedTokens: tokens,
+    description,
+    indexEntry,
+  };
+}
+
+function isPostToolUseInput(value: unknown): value is PostToolUseInput {
+  if (value === null || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.tool_name !== "string") return false;
+  if (typeof obj.tool_input !== "object" || obj.tool_input === null) return false;
+  return true;
+}
+
+export async function postWrite(cwd: string): Promise<void> {
+  // 10-second safety timeout (longer due to file I/O + index updates)
+  const timer = setTimeout(() => process.exit(0), 10000);
+
+  try {
+    const input = await readStdinJson();
+    if (!isPostToolUseInput(input)) return;
+    if (input.tool_name !== "Write" && input.tool_name !== "Edit") return;
+
+    const absolutePath = input.tool_input.file_path;
+    if (!absolutePath) return;
+
+    const filePath = relative(cwd, absolutePath);
+
+    // Read file content from disk (post-write — file now exists)
+    let fileContent: string | null = null;
+    try {
+      fileContent = readFileSync(absolutePath, "utf-8");
+    } catch {
+      // File unreadable (permissions, race condition) — continue with null
+    }
+
+    // Load session state
+    const rawState = safeReadJson(sessionPath(cwd));
+    const state: SessionState = isSessionState(rawState)
+      ? rawState
+      : createSessionState();
+
+    // Load file index
+    const rawIndex = safeReadJson(fileIndexPath(cwd));
+    const index: FileIndex = isFileIndex(rawIndex) ? rawIndex : createEmptyIndex();
+
+    const result = analyzePostWrite(filePath, fileContent, index);
+
+    if (result.excluded) return;
+
+    // 1. File index update
+    if (result.indexEntry) {
+      upsertEntry(index, result.indexEntry);
+    }
+
+    // 2. Action log entry (stub — spec 08 not yet implemented)
+    // TODO: When spec 08 is implemented, append timestamped entry to action log:
+    // { filePath, action: result.action, estimatedTokens: result.estimatedTokens }
+
+    // 3. Session state update
+    recordWrite(state, filePath, result.action, result.estimatedTokens);
+
+    // Persist state changes
+    atomicWriteJson(sessionPath(cwd), state);
+    atomicWriteJson(fileIndexPath(cwd), index);
+  } catch {
+    // Never crash — exit silently
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/commands/pre-write.ts
+++ b/src/commands/pre-write.ts
@@ -1,0 +1,114 @@
+import { relative } from "path";
+import { readFileSync } from "fs";
+import { readStdinJson } from "../core/stdin";
+import { sessionPath, learningMemoryPath } from "../core/paths";
+import { safeReadJson, atomicWriteJson } from "../core/fs-utils";
+import { createSessionState, isSessionState } from "../core/session";
+import { parseLearningMemory, getEntries } from "../core/learning-memory";
+import { extractPatterns, matchPatterns } from "../core/pattern-engine";
+import type { SessionState } from "../types/session";
+import type { PatternMatch } from "../types/learning-memory";
+import type { PreToolUseInput } from "../types/hook-input";
+
+export interface PreWriteResult {
+  warnings: string[];
+  patternMatches: PatternMatch[];
+  bugSummary: string | null;
+}
+
+export function analyzePreWrite(
+  filePath: string,
+  writeContent: string,
+  doNotRepeatEntries: string[]
+): PreWriteResult {
+  const warnings: string[] = [];
+  const allMatches: PatternMatch[] = [];
+
+  // 1. Learning memory enforcement
+  if (doNotRepeatEntries.length > 0 && writeContent.length > 0) {
+    const patterns = extractPatterns(doNotRepeatEntries);
+    const matches = matchPatterns(patterns, writeContent);
+    allMatches.push(...matches);
+
+    for (const match of matches) {
+      warnings.push(
+        `[mink] Do-Not-Repeat violation: "${match.matchedText}" — from: ${match.pattern.sourceEntry}`
+      );
+    }
+  }
+
+  // 2. Bug memory lookup (stub — spec 07 not yet implemented)
+  // TODO: When spec 07 is implemented, search bug log for entries
+  // related to filePath, compute similarity, and emit summary if > 0.3.
+  const bugSummary: string | null = null;
+
+  return { warnings, patternMatches: allMatches, bugSummary };
+}
+
+function isPreToolUseInput(value: unknown): value is PreToolUseInput {
+  if (value === null || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.tool_name !== "string") return false;
+  if (typeof obj.tool_input !== "object" || obj.tool_input === null) return false;
+  return true;
+}
+
+function extractWriteContent(input: PreToolUseInput): string {
+  const ti = input.tool_input;
+  if (input.tool_name === "Write" && typeof ti.content === "string") {
+    return ti.content;
+  }
+  if (input.tool_name === "Edit" && typeof ti.new_string === "string") {
+    return ti.new_string;
+  }
+  return "";
+}
+
+export async function preWrite(cwd: string): Promise<void> {
+  // 5-second safety timeout
+  const timer = setTimeout(() => process.exit(0), 5000);
+
+  try {
+    const input = await readStdinJson();
+    if (!isPreToolUseInput(input)) return;
+    if (input.tool_name !== "Write" && input.tool_name !== "Edit") return;
+
+    const absolutePath = input.tool_input.file_path;
+    if (!absolutePath) return;
+
+    const filePath = relative(cwd, absolutePath);
+    const writeContent = extractWriteContent(input);
+
+    // Load learning memory Do-Not-Repeat entries
+    let doNotRepeatEntries: string[] = [];
+    try {
+      const markdown = readFileSync(learningMemoryPath(cwd), "utf-8");
+      const mem = parseLearningMemory(markdown);
+      doNotRepeatEntries = getEntries(mem, "Do-Not-Repeat");
+    } catch {
+      // Learning memory not found or corrupt — skip enforcement
+    }
+
+    const result = analyzePreWrite(filePath, writeContent, doNotRepeatEntries);
+
+    // Emit warnings to stderr (advisory only)
+    for (const warning of result.warnings) {
+      process.stderr.write(warning + "\n");
+    }
+
+    // Update session counters if there were pattern matches
+    if (result.patternMatches.length > 0) {
+      const rawState = safeReadJson(sessionPath(cwd));
+      const state: SessionState = isSessionState(rawState)
+        ? rawState
+        : createSessionState();
+
+      state.counters.learnedRuleWarnings += result.patternMatches.length;
+      atomicWriteJson(sessionPath(cwd), state);
+    }
+  } catch {
+    // Never crash — exit silently
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/core/write-exclusions.ts
+++ b/src/core/write-exclusions.ts
@@ -1,0 +1,24 @@
+import { basename } from "path";
+
+/**
+ * Returns true if the file should be excluded from write tracking.
+ * Excluded: .env* files, files inside the .mink state directory.
+ */
+export function isWriteExcluded(relativePath: string): boolean {
+  // Skip .mink state directory files
+  if (
+    relativePath === ".mink" ||
+    relativePath.startsWith(".mink/") ||
+    relativePath.startsWith(".mink\\")
+  ) {
+    return true;
+  }
+
+  // Skip .env files
+  const name = basename(relativePath);
+  if (name === ".env" || name.startsWith(".env.")) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/types/hook-input.ts
+++ b/src/types/hook-input.ts
@@ -2,6 +2,11 @@ export interface PreToolUseInput {
   tool_name: string;
   tool_input: {
     file_path?: string;
+    // Write tool
+    content?: string;
+    // Edit tool
+    old_string?: string;
+    new_string?: string;
   };
 }
 
@@ -9,6 +14,11 @@ export interface PostToolUseInput {
   tool_name: string;
   tool_input: {
     file_path?: string;
+    // Write tool
+    content?: string;
+    // Edit tool
+    old_string?: string;
+    new_string?: string;
   };
   tool_output?: {
     content?: string;

--- a/tests/integration/write-enforcement.test.ts
+++ b/tests/integration/write-enforcement.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { atomicWriteJson, safeReadJson } from "../../src/core/fs-utils";
+import { atomicWriteText } from "../../src/core/fs-utils";
+import { createSessionState } from "../../src/core/session";
+import { isSessionState, recordWrite } from "../../src/core/session";
+import { createEmptyIndex, upsertEntry } from "../../src/core/index-store";
+import { serializeLearningMemory, createEmptyLearningMemory, addEntry } from "../../src/core/learning-memory";
+import { analyzePreWrite } from "../../src/commands/pre-write";
+import { analyzePostWrite } from "../../src/commands/post-write";
+import { getEntries, parseLearningMemory } from "../../src/core/learning-memory";
+import type { SessionState } from "../../src/types/session";
+import type { FileIndex, FileIndexEntry } from "../../src/types/file-index";
+
+function makeEntry(filePath: string, description: string, estimatedTokens: number): FileIndexEntry {
+  return {
+    filePath,
+    description,
+    estimatedTokens,
+    lastModified: new Date().toISOString(),
+    lastIndexed: new Date().toISOString(),
+  };
+}
+
+describe("write enforcement integration", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mink-write-enforce-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("pre-write detects DNR violation from learning memory", () => {
+    // Set up learning memory with a DNR entry
+    const mem = createEmptyLearningMemory("test-project");
+    addEntry(mem, "Do-Not-Repeat", '[2026-03-10] Never use "var"');
+    const memPath = join(dir, "learning-memory.md");
+    atomicWriteText(memPath, serializeLearningMemory(mem));
+
+    // Load DNR entries as the pre-write hook would
+    const markdown = serializeLearningMemory(mem);
+    const parsed = parseLearningMemory(markdown);
+    const dnrEntries = getEntries(parsed, "Do-Not-Repeat");
+
+    // Simulate pre-write with matching content
+    const result = analyzePreWrite("src/app.ts", "var x = 1;", dnrEntries);
+
+    expect(result.patternMatches).toHaveLength(1);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("var");
+    expect(result.warnings[0]).toContain("Do-Not-Repeat");
+  });
+
+  test("pre-write with no DNR entries emits no warnings", () => {
+    const mem = createEmptyLearningMemory("test-project");
+    const markdown = serializeLearningMemory(mem);
+    const parsed = parseLearningMemory(markdown);
+    const dnrEntries = getEntries(parsed, "Do-Not-Repeat");
+
+    const result = analyzePreWrite("src/app.ts", "const x = 1;", dnrEntries);
+
+    expect(result.patternMatches).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  test("post-write creates new file index entry for new file", () => {
+    const sessionFile = join(dir, "session.json");
+    const indexFile = join(dir, "file-index.json");
+
+    // Setup empty state
+    const state = createSessionState();
+    atomicWriteJson(sessionFile, state);
+    const index = createEmptyIndex();
+    atomicWriteJson(indexFile, index);
+
+    // Simulate post-write for a new file
+    const fileContent = "export function format(s: string) { return s.trim(); }";
+    const result = analyzePostWrite("src/utils/format.ts", fileContent, index);
+
+    expect(result.excluded).toBe(false);
+    expect(result.action).toBe("create");
+    expect(result.indexEntry).not.toBeNull();
+    expect(result.indexEntry!.filePath).toBe("src/utils/format.ts");
+    expect(result.indexEntry!.estimatedTokens).toBeGreaterThan(0);
+
+    // Persist as the hook would
+    upsertEntry(index, result.indexEntry!);
+    recordWrite(state, "src/utils/format.ts", result.action, result.estimatedTokens);
+    atomicWriteJson(sessionFile, state);
+    atomicWriteJson(indexFile, index);
+
+    // Verify persisted state
+    const finalState = safeReadJson(sessionFile) as SessionState;
+    expect(finalState.writes).toHaveLength(1);
+    expect(finalState.writes[0].filePath).toBe("src/utils/format.ts");
+    expect(finalState.writes[0].action).toBe("create");
+
+    const finalIndex = safeReadJson(indexFile) as FileIndex;
+    expect(finalIndex.entries["src/utils/format.ts"]).toBeDefined();
+    expect(finalIndex.header.totalFiles).toBe(1);
+  });
+
+  test("post-write updates existing file index entry for edited file", () => {
+    const index = createEmptyIndex();
+    upsertEntry(index, makeEntry("src/app.ts", "Old description", 100));
+
+    // Simulate edit with new content
+    const newContent = "export function main() { console.log('updated'); }";
+    const result = analyzePostWrite("src/app.ts", newContent, index);
+
+    expect(result.action).toBe("edit");
+    expect(result.indexEntry).not.toBeNull();
+    expect(result.indexEntry!.description).not.toBe("Old description");
+
+    // Persist
+    upsertEntry(index, result.indexEntry!);
+    expect(index.entries["src/app.ts"].description).toBe(result.description);
+    expect(index.header.totalFiles).toBe(1); // still just 1 file
+  });
+
+  test("excluded files skip all tracking", () => {
+    const state = createSessionState();
+    const index = createEmptyIndex();
+
+    const result = analyzePostWrite(".env.local", "SECRET=abc", index);
+
+    expect(result.excluded).toBe(true);
+
+    // Verify nothing was mutated
+    expect(Object.keys(index.entries)).toHaveLength(0);
+    expect(state.writes).toHaveLength(0);
+  });
+
+  test("missing learning memory does not crash pre-write", () => {
+    // No learning memory file — dnrEntries would be empty
+    const result = analyzePreWrite("src/app.ts", "const x = 1;", []);
+
+    expect(result.patternMatches).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  test("multiple writes accumulate in session state", () => {
+    const state = createSessionState();
+    const index = createEmptyIndex();
+
+    // First write (new file)
+    const result1 = analyzePostWrite("src/a.ts", "export const a = 1;", index);
+    if (result1.indexEntry) upsertEntry(index, result1.indexEntry);
+    recordWrite(state, "src/a.ts", result1.action, result1.estimatedTokens);
+
+    // Second write (another new file)
+    const result2 = analyzePostWrite("src/b.ts", "export const b = 2;", index);
+    if (result2.indexEntry) upsertEntry(index, result2.indexEntry);
+    recordWrite(state, "src/b.ts", result2.action, result2.estimatedTokens);
+
+    // Third write (edit first file)
+    const result3 = analyzePostWrite("src/a.ts", "export const a = 'updated';", index);
+    if (result3.indexEntry) upsertEntry(index, result3.indexEntry);
+    recordWrite(state, "src/a.ts", result3.action, result3.estimatedTokens);
+
+    expect(state.writes).toHaveLength(3);
+    expect(state.writes[0].action).toBe("create");
+    expect(state.writes[1].action).toBe("create");
+    expect(state.writes[2].action).toBe("edit"); // now in index
+    expect(index.header.totalFiles).toBe(2);
+  });
+
+  test("performance: post-write on 500-entry index completes quickly", () => {
+    const index = createEmptyIndex();
+    for (let i = 0; i < 500; i++) {
+      upsertEntry(index, makeEntry(`src/file-${i}.ts`, `File ${i}`, 100 + i));
+    }
+
+    const content = "export function newFunc() { return 42; }";
+    const start = performance.now();
+    const result = analyzePostWrite("src/new-file.ts", content, index);
+    const elapsed = performance.now() - start;
+
+    expect(result.action).toBe("create");
+    expect(elapsed).toBeLessThan(10000); // well under 10 seconds
+  });
+});

--- a/tests/unit/init.test.ts
+++ b/tests/unit/init.test.ts
@@ -44,6 +44,24 @@ describe("buildHooksConfig", () => {
     expect(nodeHooks.PreToolUse[0].command).toContain("node ");
     expect(nodeHooks.PostToolUse[0].command).toContain("node ");
   });
+
+  test("includes Edit and Write matchers for pre-write and post-write", () => {
+    const hooks = buildHooksConfig("bun", "/path/to/cli.js");
+
+    // PreToolUse: Read (pre-read) + Edit (pre-write) + Write (pre-write)
+    expect(hooks.PreToolUse).toHaveLength(3);
+    expect(hooks.PreToolUse[1].matcher).toBe("Edit");
+    expect(hooks.PreToolUse[1].command).toContain("pre-write");
+    expect(hooks.PreToolUse[2].matcher).toBe("Write");
+    expect(hooks.PreToolUse[2].command).toContain("pre-write");
+
+    // PostToolUse: Read (post-read) + Edit (post-write) + Write (post-write)
+    expect(hooks.PostToolUse).toHaveLength(3);
+    expect(hooks.PostToolUse[1].matcher).toBe("Edit");
+    expect(hooks.PostToolUse[1].command).toContain("post-write");
+    expect(hooks.PostToolUse[2].matcher).toBe("Write");
+    expect(hooks.PostToolUse[2].command).toContain("post-write");
+  });
 });
 
 describe("mergeHooksIntoSettings", () => {
@@ -88,10 +106,11 @@ describe("mergeHooksIntoSettings", () => {
 
     const settings = safeReadJson(settingsPath) as Record<string, unknown>;
     const allHooks = settings.hooks as Record<string, Array<{ command: string }>>;
-    // Non-mink hook preserved + mink hook added
-    expect(allHooks.PreToolUse).toHaveLength(2);
+    // Non-mink hook preserved + 3 mink hooks added (Read, Edit, Write)
+    expect(allHooks.PreToolUse).toHaveLength(4);
     expect(allHooks.PreToolUse.some((h) => h.command === "existing-hook")).toBe(true);
     expect(allHooks.PreToolUse.some((h) => h.command.includes("pre-read"))).toBe(true);
+    expect(allHooks.PreToolUse.some((h) => h.command.includes("pre-write"))).toBe(true);
     expect(allHooks.SessionStart).toBeDefined();
     expect(allHooks.Stop).toBeDefined();
     expect(allHooks.PostToolUse).toBeDefined();
@@ -111,9 +130,13 @@ describe("mergeHooksIntoSettings", () => {
           ],
           PreToolUse: [
             { matcher: "Read", command: "bun run /old/path/cli.js pre-read" },
+            { matcher: "Edit", command: "bun run /old/path/cli.js pre-write" },
+            { matcher: "Write", command: "bun run /old/path/cli.js pre-write" },
           ],
           PostToolUse: [
             { matcher: "Read", command: "bun run /old/path/cli.js post-read" },
+            { matcher: "Edit", command: "bun run /old/path/cli.js post-write" },
+            { matcher: "Write", command: "bun run /old/path/cli.js post-write" },
           ],
         },
       })
@@ -128,13 +151,17 @@ describe("mergeHooksIntoSettings", () => {
     expect(allHooks.SessionStart).toHaveLength(1);
     expect(allHooks.SessionStart[0].command).toContain("/new/path/cli.js");
 
-    expect(allHooks.PreToolUse).toHaveLength(1);
-    expect(allHooks.PreToolUse[0].command).toContain("/new/path/cli.js");
-    expect(allHooks.PreToolUse[0].command).toContain("pre-read");
+    // PreToolUse: 3 entries (Read, Edit, Write) — all replaced with new path
+    expect(allHooks.PreToolUse).toHaveLength(3);
+    expect(allHooks.PreToolUse.every((h) => h.command.includes("/new/path/cli.js"))).toBe(true);
+    expect(allHooks.PreToolUse.some((h) => h.command.includes("pre-read"))).toBe(true);
+    expect(allHooks.PreToolUse.some((h) => h.command.includes("pre-write"))).toBe(true);
 
-    expect(allHooks.PostToolUse).toHaveLength(1);
-    expect(allHooks.PostToolUse[0].command).toContain("/new/path/cli.js");
-    expect(allHooks.PostToolUse[0].command).toContain("post-read");
+    // PostToolUse: 3 entries (Read, Edit, Write)
+    expect(allHooks.PostToolUse).toHaveLength(3);
+    expect(allHooks.PostToolUse.every((h) => h.command.includes("/new/path/cli.js"))).toBe(true);
+    expect(allHooks.PostToolUse.some((h) => h.command.includes("post-read"))).toBe(true);
+    expect(allHooks.PostToolUse.some((h) => h.command.includes("post-write"))).toBe(true);
   });
 });
 

--- a/tests/unit/post-write.test.ts
+++ b/tests/unit/post-write.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { analyzePostWrite } from "../../src/commands/post-write";
+import { createEmptyIndex, upsertEntry } from "../../src/core/index-store";
+import type { FileIndexEntry } from "../../src/types/file-index";
+
+function makeEntry(filePath: string, description: string, estimatedTokens: number): FileIndexEntry {
+  return {
+    filePath,
+    description,
+    estimatedTokens,
+    lastModified: new Date().toISOString(),
+    lastIndexed: new Date().toISOString(),
+  };
+}
+
+describe("analyzePostWrite", () => {
+  test("new file (not in index) has action 'create'", () => {
+    const index = createEmptyIndex();
+    const content = "export function hello() { return 'world'; }";
+
+    const result = analyzePostWrite("src/utils/format.ts", content, index);
+
+    expect(result.excluded).toBe(false);
+    expect(result.action).toBe("create");
+    expect(result.estimatedTokens).toBeGreaterThan(0);
+    expect(result.description.length).toBeGreaterThan(0);
+    expect(result.indexEntry).not.toBeNull();
+    expect(result.indexEntry!.filePath).toBe("src/utils/format.ts");
+  });
+
+  test("existing file (in index) has action 'edit'", () => {
+    const index = createEmptyIndex();
+    upsertEntry(index, makeEntry("src/app.ts", "App entry", 200));
+    const content = "export function main() { console.log('updated'); }";
+
+    const result = analyzePostWrite("src/app.ts", content, index);
+
+    expect(result.excluded).toBe(false);
+    expect(result.action).toBe("edit");
+    expect(result.indexEntry).not.toBeNull();
+  });
+
+  test(".env file is excluded", () => {
+    const result = analyzePostWrite(".env", "SECRET=abc123", null);
+
+    expect(result.excluded).toBe(true);
+    expect(result.indexEntry).toBeNull();
+  });
+
+  test(".env.local file is excluded", () => {
+    const result = analyzePostWrite(".env.local", "DB_HOST=localhost", null);
+
+    expect(result.excluded).toBe(true);
+  });
+
+  test(".mink/session.json is excluded", () => {
+    const result = analyzePostWrite(".mink/session.json", "{}", null);
+
+    expect(result.excluded).toBe(true);
+  });
+
+  test("non-excluded file has excluded false", () => {
+    const result = analyzePostWrite("src/app.ts", "const x = 1;", null);
+
+    expect(result.excluded).toBe(false);
+  });
+
+  test("empty file content produces entry with 0 tokens", () => {
+    const index = createEmptyIndex();
+    const result = analyzePostWrite("src/empty.ts", "", index);
+
+    expect(result.excluded).toBe(false);
+    expect(result.action).toBe("create");
+    expect(result.description).toContain("empty file");
+    expect(result.estimatedTokens).toBe(0);
+    // extractDescription returns "empty.ts — empty file" for empty content
+    // estimateTokens returns 0 for empty content
+    expect(result.indexEntry).not.toBeNull();
+    expect(result.indexEntry!.estimatedTokens).toBe(0);
+  });
+
+  test("binary file by extension returns 0 tokens and no entry", () => {
+    const result = analyzePostWrite("assets/logo.png", "fake binary", null);
+
+    expect(result.excluded).toBe(false);
+    expect(result.estimatedTokens).toBe(0);
+    expect(result.indexEntry).toBeNull();
+  });
+
+  test("binary file by null byte content returns 0 tokens", () => {
+    const content = "hello\0world";
+    const result = analyzePostWrite("src/data.bin", content, null);
+
+    expect(result.estimatedTokens).toBe(0);
+    expect(result.indexEntry).toBeNull();
+  });
+
+  test("null content (unreadable file) returns 0 tokens", () => {
+    const result = analyzePostWrite("src/app.ts", null, null);
+
+    expect(result.excluded).toBe(false);
+    expect(result.estimatedTokens).toBe(0);
+    expect(result.indexEntry).toBeNull();
+  });
+
+  test("null index treats file as new (create action)", () => {
+    const content = "export const x = 1;";
+    const result = analyzePostWrite("src/new.ts", content, null);
+
+    expect(result.action).toBe("create");
+    expect(result.indexEntry).not.toBeNull();
+  });
+
+  test("token estimation uses correct ratio for code files", () => {
+    const content = "a".repeat(3500);
+    const result = analyzePostWrite("src/app.ts", content, null);
+
+    // 3500 / 3.5 = 1000 tokens
+    expect(result.estimatedTokens).toBe(1000);
+  });
+
+  test("token estimation uses correct ratio for prose files", () => {
+    const content = "a".repeat(4000);
+    const result = analyzePostWrite("docs/readme.md", content, null);
+
+    // 4000 / 4.0 = 1000 tokens
+    expect(result.estimatedTokens).toBe(1000);
+  });
+});

--- a/tests/unit/pre-write.test.ts
+++ b/tests/unit/pre-write.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { analyzePreWrite } from "../../src/commands/pre-write";
+
+describe("analyzePreWrite", () => {
+  test("DNR literal match triggers warning", () => {
+    const entries = ['[2026-03-10] Never use "var"'];
+    const content = "var x = 1;";
+
+    const result = analyzePreWrite("src/app.ts", content, entries);
+
+    expect(result.patternMatches).toHaveLength(1);
+    expect(result.patternMatches[0].matchedText).toBe("var");
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("var");
+    expect(result.warnings[0]).toContain("Do-Not-Repeat");
+  });
+
+  test("DNR word-boundary match triggers warning", () => {
+    const entries = ["[2026-03-11] Avoid console.log"];
+    const content = "function debug() { console.log('test'); }";
+
+    const result = analyzePreWrite("src/app.ts", content, entries);
+
+    expect(result.patternMatches.length).toBeGreaterThanOrEqual(1);
+    expect(result.warnings.length).toBeGreaterThanOrEqual(1);
+    expect(result.warnings[0]).toContain("Do-Not-Repeat");
+  });
+
+  test("empty DNR entries produce no warnings", () => {
+    const result = analyzePreWrite("src/app.ts", "const x = 1;", []);
+
+    expect(result.patternMatches).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  test("empty write content produces no matches", () => {
+    const entries = ['[2026-03-10] Never use "var"'];
+    const result = analyzePreWrite("src/app.ts", "", entries);
+
+    expect(result.patternMatches).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  test("multiple DNR entries can produce multiple matches", () => {
+    const entries = [
+      '[2026-03-10] Never use "var"',
+      '[2026-03-11] Never use "any"',
+    ];
+    const content = "var x: any = 1;";
+
+    const result = analyzePreWrite("src/app.ts", content, entries);
+
+    expect(result.patternMatches.length).toBeGreaterThanOrEqual(2);
+    expect(result.warnings.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("vague DNR entry with no extractable pattern produces no warnings", () => {
+    const entries = ["Be careful with auth"];
+    const content = "const auth = new AuthService();";
+
+    const result = analyzePreWrite("src/app.ts", content, entries);
+
+    // "Be careful with auth" has no quoted strings and no "never use"/"avoid" trigger
+    expect(result.patternMatches).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  test("bug summary stub returns null", () => {
+    const result = analyzePreWrite("src/app.ts", "const x = 1;", []);
+
+    expect(result.bugSummary).toBeNull();
+  });
+
+  test("pattern matching works on partial content from Edit tool", () => {
+    const entries = ['[2026-03-10] Never use "var"'];
+    // Simulates new_string from an Edit tool — just a small replacement
+    const content = "var newVal = oldVal + 1;";
+
+    const result = analyzePreWrite("src/app.ts", content, entries);
+
+    expect(result.patternMatches).toHaveLength(1);
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  test("non-matching content produces no warnings", () => {
+    const entries = ['[2026-03-10] Never use "var"'];
+    const content = "const x = 1;\nlet y = 2;";
+
+    const result = analyzePreWrite("src/app.ts", content, entries);
+
+    expect(result.patternMatches).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/tests/unit/write-exclusions.test.ts
+++ b/tests/unit/write-exclusions.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { isWriteExcluded } from "../../src/core/write-exclusions";
+
+describe("isWriteExcluded", () => {
+  test(".env is excluded", () => {
+    expect(isWriteExcluded(".env")).toBe(true);
+  });
+
+  test(".env.local is excluded", () => {
+    expect(isWriteExcluded(".env.local")).toBe(true);
+  });
+
+  test(".env.production is excluded", () => {
+    expect(isWriteExcluded(".env.production")).toBe(true);
+  });
+
+  test(".env in subdirectory is excluded", () => {
+    expect(isWriteExcluded("config/.env")).toBe(true);
+  });
+
+  test(".mink/session.json is excluded", () => {
+    expect(isWriteExcluded(".mink/session.json")).toBe(true);
+  });
+
+  test(".mink/file-index.json is excluded", () => {
+    expect(isWriteExcluded(".mink/file-index.json")).toBe(true);
+  });
+
+  test(".mink itself is excluded", () => {
+    expect(isWriteExcluded(".mink")).toBe(true);
+  });
+
+  test("src/app.ts is not excluded", () => {
+    expect(isWriteExcluded("src/app.ts")).toBe(false);
+  });
+
+  test("src/.env-utils.ts is not excluded (not an actual .env file)", () => {
+    expect(isWriteExcluded("src/.env-utils.ts")).toBe(false);
+  });
+
+  test(".minkish/something.ts is not excluded", () => {
+    expect(isWriteExcluded(".minkish/something.ts")).toBe(false);
+  });
+
+  test("package.json is not excluded", () => {
+    expect(isWriteExcluded("package.json")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add pre-write and post-write hooks that intercept `Edit` and `Write` tool operations
- **Pre-write**: enforces Do-Not-Repeat rules from learning memory via the pattern engine, emitting advisory warnings to stderr. Bug memory lookup stubbed for spec 07.
- **Post-write**: reads the written file, extracts a smart description, estimates tokens, upserts the file index, and records the write in session state. Action log append stubbed for spec 08. Excludes `.env*` files and `.mink/` state directory.
- Registers 4 new hook entries in `init.ts` (Edit/Write matchers for both PreToolUse and PostToolUse)
- 42 new tests (unit + integration), 392 total passing, 0 regressions

## New files
- `src/core/write-exclusions.ts` — exclusion check utility
- `src/commands/pre-write.ts` — pre-write hook command + `analyzePreWrite` pure logic
- `src/commands/post-write.ts` — post-write hook command + `analyzePostWrite` pure logic
- `tests/unit/write-exclusions.test.ts`, `tests/unit/pre-write.test.ts`, `tests/unit/post-write.test.ts`
- `tests/integration/write-enforcement.test.ts`

## Modified files
- `src/types/hook-input.ts` — added `content`, `old_string`, `new_string` fields
- `src/commands/init.ts` — registers Edit/Write matchers, updated `isMinkHook`
- `src/cli.ts` — wired `pre-write` and `post-write` commands
- `tests/unit/init.test.ts` — updated for 6 hook entries

## Test plan
- [x] Unit: DNR literal and word-boundary pattern matching against write content
- [x] Unit: write exclusion for `.env*` and `.mink/` files
- [x] Unit: post-write create vs edit action determination from file index
- [x] Unit: binary/empty/null content handling
- [x] Unit: hook registration includes Edit and Write matchers
- [x] Integration: full pre-write flow with learning memory DNR violation
- [x] Integration: full post-write flow for new and edited files
- [x] Integration: excluded files skip all tracking
- [x] Integration: performance on 500-entry index
- [x] Full suite: `bun test` — 392 pass, 0 fail

https://claude.ai/code/session_01L5ew65hBsSFB9k2NEwHHBt