### PR TITLE
feat: implement spec 07 bug memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tmp

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,8 +59,35 @@ switch (command) {
     break;
   }
 
+  case "bug-search": {
+    const query = process.argv.slice(3).join(" ");
+    if (!query) {
+      console.error("Usage: mink bug-search <query>");
+      process.exit(1);
+    }
+    const { loadBugMemory, searchBugs } = await import("./core/bug-memory");
+    const { bugMemoryPath } = await import("./core/paths");
+    const memory = loadBugMemory(bugMemoryPath(cwd));
+    const results = searchBugs(memory, query);
+    if (results.length === 0) {
+      console.log("No matching bugs found.");
+    } else {
+      for (const match of results) {
+        const e = match.entry;
+        console.log(`${e.id} (score: ${match.score.toFixed(2)}) — ${e.errorMessage}`);
+        console.log(`  File: ${e.filePath}${e.lineNumber ? `:${e.lineNumber}` : ""}`);
+        console.log(`  Root cause: ${e.rootCause}`);
+        console.log(`  Fix: ${e.fixDescription}`);
+        if (e.tags.length > 0) console.log(`  Tags: ${e.tags.join(", ")}`);
+        if (e.occurrenceCount > 1) console.log(`  Seen ${e.occurrenceCount} times`);
+        console.log();
+      }
+    }
+    break;
+  }
+
   default:
     console.error(`[mink] unknown command: ${command}`);
-    console.error("Usage: mink <session-start|session-stop|init|scan|reflect|pre-read|post-read|pre-write|post-write>");
+    console.error("Usage: mink <session-start|session-stop|init|scan|reflect|pre-read|post-read|pre-write|post-write|bug-search>");
     process.exit(1);
 }

--- a/src/commands/pre-write.ts
+++ b/src/commands/pre-write.ts
@@ -1,13 +1,19 @@
 import { relative } from "path";
 import { readFileSync } from "fs";
 import { readStdinJson } from "../core/stdin";
-import { sessionPath, learningMemoryPath } from "../core/paths";
+import { sessionPath, learningMemoryPath, bugMemoryPath } from "../core/paths";
 import { safeReadJson, atomicWriteJson } from "../core/fs-utils";
 import { createSessionState, isSessionState } from "../core/session";
 import { parseLearningMemory, getEntries } from "../core/learning-memory";
 import { extractPatterns, matchPatterns } from "../core/pattern-engine";
+import {
+  loadBugMemory,
+  lookupBugsForFile,
+  formatBugSummary,
+} from "../core/bug-memory";
 import type { SessionState } from "../types/session";
 import type { PatternMatch } from "../types/learning-memory";
+import type { BugMemory } from "../types/bug-memory";
 import type { PreToolUseInput } from "../types/hook-input";
 
 export interface PreWriteResult {
@@ -19,7 +25,8 @@ export interface PreWriteResult {
 export function analyzePreWrite(
   filePath: string,
   writeContent: string,
-  doNotRepeatEntries: string[]
+  doNotRepeatEntries: string[],
+  bugMemory?: BugMemory
 ): PreWriteResult {
   const warnings: string[] = [];
   const allMatches: PatternMatch[] = [];
@@ -37,10 +44,12 @@ export function analyzePreWrite(
     }
   }
 
-  // 2. Bug memory lookup (stub — spec 07 not yet implemented)
-  // TODO: When spec 07 is implemented, search bug log for entries
-  // related to filePath, compute similarity, and emit summary if > 0.3.
-  const bugSummary: string | null = null;
+  // 2. Bug memory lookup — surface known bugs for this file
+  let bugSummary: string | null = null;
+  if (bugMemory) {
+    const bugEntries = lookupBugsForFile(bugMemory, filePath);
+    bugSummary = formatBugSummary(bugEntries);
+  }
 
   return { warnings, patternMatches: allMatches, bugSummary };
 }
@@ -89,11 +98,24 @@ export async function preWrite(cwd: string): Promise<void> {
       // Learning memory not found or corrupt — skip enforcement
     }
 
-    const result = analyzePreWrite(filePath, writeContent, doNotRepeatEntries);
+    // Load bug memory for this file
+    let bugMemory: BugMemory | undefined;
+    try {
+      bugMemory = loadBugMemory(bugMemoryPath(cwd));
+    } catch {
+      // Bug memory not found or corrupt — skip lookup
+    }
+
+    const result = analyzePreWrite(filePath, writeContent, doNotRepeatEntries, bugMemory);
 
     // Emit warnings to stderr (advisory only)
     for (const warning of result.warnings) {
       process.stderr.write(warning + "\n");
+    }
+
+    // Emit bug summary to stderr if there are known bugs for this file
+    if (result.bugSummary) {
+      process.stderr.write(result.bugSummary + "\n");
     }
 
     // Update session counters if there were pattern matches

--- a/src/commands/session-stop.ts
+++ b/src/commands/session-stop.ts
@@ -4,6 +4,7 @@ import { safeReadJson, atomicWriteJson } from "../core/fs-utils";
 import { isSessionState, buildSummary } from "../core/session";
 import { reflect } from "./reflect";
 import { createLedgerFinalizer } from "../core/token-ledger";
+import { loadBugMemory, hasBugForFileInSession } from "../core/bug-memory";
 import type { SessionState, SessionFinalizer } from "../types/session";
 
 function hasActivity(state: SessionState): boolean {
@@ -59,13 +60,23 @@ export function sessionStop(
     }
   }
 
-  // Check for files edited 3+ times
+  // Check for files edited 3+ times without a corresponding bug entry
   const editCounts = getEditCounts(state);
+  const bugMemoryFile = join(projDir, "bug-memory.json");
+  const bugMemory = loadBugMemory(bugMemoryFile);
+
   for (const [filePath, count] of Object.entries(editCounts)) {
     if (count >= 3) {
-      onReminder(
-        `[mink] ${filePath} was edited ${count} times — consider logging a bug`
+      const hasBug = hasBugForFileInSession(
+        bugMemory,
+        filePath,
+        state.startTimestamp
       );
+      if (!hasBug) {
+        onReminder(
+          `[mink] ${filePath} was edited ${count} times — consider logging a bug`
+        );
+      }
     }
   }
 

--- a/src/core/bug-memory.ts
+++ b/src/core/bug-memory.ts
@@ -1,0 +1,223 @@
+import { safeReadJson, atomicWriteJson } from "./fs-utils";
+import type { BugEntry, BugMemory, SimilarityMatch } from "../types/bug-memory";
+
+export function createEmptyBugMemory(): BugMemory {
+  return { entries: [], nextId: 1 };
+}
+
+export function loadBugMemory(path: string): BugMemory {
+  const raw = safeReadJson(path);
+  if (raw !== null && isBugMemory(raw)) return raw;
+  return createEmptyBugMemory();
+}
+
+export function saveBugMemory(path: string, memory: BugMemory): void {
+  atomicWriteJson(path, memory);
+}
+
+export function isBugMemory(value: unknown): value is BugMemory {
+  if (value === null || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  return Array.isArray(obj.entries) && typeof obj.nextId === "number";
+}
+
+export function generateBugId(nextId: number): string {
+  return `bug-${String(nextId).padStart(3, "0")}`;
+}
+
+export function findDuplicate(
+  memory: BugMemory,
+  errorMessage: string,
+  filePath: string
+): BugEntry | null {
+  return (
+    memory.entries.find(
+      (e) => e.errorMessage === errorMessage && e.filePath === filePath
+    ) ?? null
+  );
+}
+
+export function addBugEntry(
+  memory: BugMemory,
+  fields: Omit<BugEntry, "id" | "createdAt" | "lastSeenAt" | "occurrenceCount">
+): BugMemory {
+  const existing = findDuplicate(memory, fields.errorMessage, fields.filePath);
+  if (existing) {
+    return updateOccurrence(memory, existing.id);
+  }
+
+  const now = new Date().toISOString();
+  const entry: BugEntry = {
+    id: generateBugId(memory.nextId),
+    createdAt: now,
+    lastSeenAt: now,
+    occurrenceCount: 1,
+    ...fields,
+  };
+
+  return {
+    entries: [...memory.entries, entry],
+    nextId: memory.nextId + 1,
+  };
+}
+
+export function updateOccurrence(memory: BugMemory, id: string): BugMemory {
+  const now = new Date().toISOString();
+  return {
+    ...memory,
+    entries: memory.entries.map((e) =>
+      e.id === id
+        ? { ...e, occurrenceCount: e.occurrenceCount + 1, lastSeenAt: now }
+        : e
+    ),
+  };
+}
+
+// --- Similarity scoring ---
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/\W+/)
+      .filter((w) => w.length > 0)
+  );
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 0;
+  let intersection = 0;
+  for (const word of a) {
+    if (b.has(word)) intersection++;
+  }
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+export function computeSimilarity(
+  query: string,
+  entry: BugEntry
+): SimilarityMatch {
+  const matchReasons: string[] = [];
+  let score = 0;
+
+  // 1. Exact substring match on error message
+  if (
+    entry.errorMessage.length > 0 &&
+    entry.errorMessage.includes(query)
+  ) {
+    score += 1.0;
+    matchReasons.push("exact_error_match");
+  }
+
+  // 2. Word overlap (Jaccard) across searchable fields
+  const queryTokens = tokenize(query);
+
+  const fields: [string, string][] = [
+    ["error_message", entry.errorMessage],
+    ["root_cause", entry.rootCause],
+    ["fix", entry.fixDescription],
+    ["tags", entry.tags.join(" ")],
+  ];
+
+  for (const [fieldName, fieldValue] of fields) {
+    const fieldTokens = tokenize(fieldValue);
+    const j = jaccard(queryTokens, fieldTokens);
+    if (j > 0) {
+      score += j * 0.5;
+      matchReasons.push(fieldName);
+    }
+  }
+
+  return { entry, score, matchReasons };
+}
+
+function hasFilePathMatch(entry: BugEntry, filePath?: string): boolean {
+  if (!filePath) return false;
+  return entry.filePath === filePath;
+}
+
+function hasTagOverlap(entry: BugEntry, query: string): boolean {
+  const queryTokens = tokenize(query);
+  return entry.tags.some((tag) => queryTokens.has(tag.toLowerCase()));
+}
+
+export function searchBugs(
+  memory: BugMemory,
+  query: string,
+  options?: { filePath?: string }
+): SimilarityMatch[] {
+  if (memory.entries.length === 0 || query.trim().length === 0) return [];
+
+  const results: SimilarityMatch[] = [];
+
+  for (const entry of memory.entries) {
+    const match = computeSimilarity(query, entry);
+
+    // False positive guard: require file-path match OR tag overlap
+    const fileMatch = hasFilePathMatch(entry, options?.filePath);
+    const tagMatch = hasTagOverlap(entry, query);
+    if (!fileMatch && !tagMatch && match.score <= 0.3) continue;
+
+    // Boost same-file matches
+    if (fileMatch) {
+      match.score += 0.2;
+      if (!match.matchReasons.includes("file_path")) {
+        match.matchReasons.push("file_path");
+      }
+    }
+
+    if (match.score > 0.3) {
+      results.push(match);
+    }
+  }
+
+  return results.sort((a, b) => b.score - a.score);
+}
+
+export function lookupBugsForFile(
+  memory: BugMemory,
+  filePath: string
+): BugEntry[] {
+  return memory.entries
+    .filter((e) => e.filePath === filePath)
+    .sort(
+      (a, b) =>
+        new Date(b.lastSeenAt).getTime() - new Date(a.lastSeenAt).getTime()
+    );
+}
+
+export function formatBugSummary(entries: BugEntry[]): string | null {
+  if (entries.length === 0) return null;
+
+  const lines: string[] = ["[mink] Known bugs for this file:"];
+  const shown = entries.slice(0, 3);
+
+  for (const e of shown) {
+    lines.push(`  ${e.id}: ${e.errorMessage}`);
+    lines.push(`    Root cause: ${e.rootCause}`);
+    lines.push(`    Fix: ${e.fixDescription}`);
+    if (e.occurrenceCount > 1) {
+      lines.push(`    Seen ${e.occurrenceCount} times (last: ${e.lastSeenAt})`);
+    }
+  }
+
+  if (entries.length > 3) {
+    lines.push(`  ... and ${entries.length - 3} more`);
+  }
+
+  return lines.join("\n");
+}
+
+export function hasBugForFileInSession(
+  memory: BugMemory,
+  filePath: string,
+  sessionStartTimestamp: string
+): boolean {
+  const sessionStart = new Date(sessionStartTimestamp).getTime();
+  return memory.entries.some(
+    (e) =>
+      e.filePath === filePath &&
+      new Date(e.createdAt).getTime() >= sessionStart
+  );
+}

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -36,3 +36,7 @@ export function tokenLedgerPath(cwd: string): string {
 export function tokenLedgerArchivePath(cwd: string): string {
   return join(projectDir(cwd), "token-ledger-archive.json");
 }
+
+export function bugMemoryPath(cwd: string): string {
+  return join(projectDir(cwd), "bug-memory.json");
+}

--- a/src/types/bug-memory.ts
+++ b/src/types/bug-memory.ts
@@ -1,0 +1,24 @@
+export interface BugEntry {
+  id: string;
+  createdAt: string;
+  lastSeenAt: string;
+  errorMessage: string;
+  filePath: string;
+  lineNumber?: number;
+  rootCause: string;
+  fixDescription: string;
+  tags: string[];
+  occurrenceCount: number;
+  relatedBugIds: string[];
+}
+
+export interface BugMemory {
+  entries: BugEntry[];
+  nextId: number;
+}
+
+export interface SimilarityMatch {
+  entry: BugEntry;
+  score: number;
+  matchReasons: string[];
+}

--- a/tests/integration/bug-memory.test.ts
+++ b/tests/integration/bug-memory.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { atomicWriteJson, safeReadJson } from "../../src/core/fs-utils";
+import {
+  createEmptyBugMemory,
+  loadBugMemory,
+  saveBugMemory,
+  addBugEntry,
+  lookupBugsForFile,
+  formatBugSummary,
+  searchBugs,
+  hasBugForFileInSession,
+} from "../../src/core/bug-memory";
+import { createSessionState, recordWrite } from "../../src/core/session";
+import { sessionStop } from "../../src/commands/session-stop";
+import { analyzePreWrite } from "../../src/commands/pre-write";
+import type { SessionState } from "../../src/types/session";
+
+describe("bug memory integration", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mink-bugmem-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("save and load round-trip", () => {
+    const path = join(dir, "bug-memory.json");
+    let mem = createEmptyBugMemory();
+    mem = addBugEntry(mem, {
+      errorMessage: "TypeError: null ref",
+      filePath: "src/api.ts",
+      rootCause: "API returned null",
+      fixDescription: "Added null check",
+      tags: ["null-check"],
+      relatedBugIds: [],
+    });
+    saveBugMemory(path, mem);
+
+    const loaded = loadBugMemory(path);
+    expect(loaded.entries).toHaveLength(1);
+    expect(loaded.entries[0].id).toBe("bug-001");
+    expect(loaded.entries[0].errorMessage).toBe("TypeError: null ref");
+    expect(loaded.nextId).toBe(2);
+  });
+
+  test("load returns empty memory when file does not exist", () => {
+    const path = join(dir, "nonexistent.json");
+    const mem = loadBugMemory(path);
+    expect(mem.entries).toEqual([]);
+    expect(mem.nextId).toBe(1);
+  });
+
+  test("load returns empty memory when file is corrupt", () => {
+    const path = join(dir, "bug-memory.json");
+    atomicWriteJson(path, "not valid bug memory");
+    const mem = loadBugMemory(path);
+    expect(mem.entries).toEqual([]);
+    expect(mem.nextId).toBe(1);
+  });
+
+  test("AI fixes bug → logs entry → edits same file → entry surfaced", () => {
+    const bugPath = join(dir, "bug-memory.json");
+
+    // Step 1: AI logs a bug after fixing it
+    let mem = createEmptyBugMemory();
+    mem = addBugEntry(mem, {
+      errorMessage: "TypeError: Cannot read property 'name' of null",
+      filePath: "src/api.ts",
+      rootCause: "API response was null",
+      fixDescription: "Added null check before accessing response.name",
+      tags: ["null-check", "api-response"],
+      relatedBugIds: [],
+    });
+    saveBugMemory(bugPath, mem);
+
+    // Step 2: AI begins editing the same file later
+    const loaded = loadBugMemory(bugPath);
+    const entries = lookupBugsForFile(loaded, "src/api.ts");
+    const summary = formatBugSummary(entries);
+
+    expect(entries).toHaveLength(1);
+    expect(summary).not.toBeNull();
+    expect(summary).toContain("bug-001");
+    expect(summary).toContain("null check");
+  });
+
+  test("analyzePreWrite surfaces bug summary when bug memory provided", () => {
+    let mem = createEmptyBugMemory();
+    mem = addBugEntry(mem, {
+      errorMessage: "ReferenceError: x is not defined",
+      filePath: "src/utils.ts",
+      rootCause: "Variable declared in wrong scope",
+      fixDescription: "Moved declaration to outer scope",
+      tags: ["scope"],
+      relatedBugIds: [],
+    });
+
+    const result = analyzePreWrite("src/utils.ts", "const y = x + 1;", [], mem);
+    expect(result.bugSummary).not.toBeNull();
+    expect(result.bugSummary).toContain("bug-001");
+    expect(result.bugSummary).toContain("ReferenceError");
+  });
+
+  test("analyzePreWrite returns null bugSummary when no bugs for file", () => {
+    let mem = createEmptyBugMemory();
+    mem = addBugEntry(mem, {
+      errorMessage: "Error in other file",
+      filePath: "src/other.ts",
+      rootCause: "cause",
+      fixDescription: "fix",
+      tags: [],
+      relatedBugIds: [],
+    });
+
+    const result = analyzePreWrite(
+      "src/unrelated.ts",
+      "some content",
+      [],
+      mem
+    );
+    expect(result.bugSummary).toBeNull();
+  });
+
+  test("file edited 3+ times with no bug → reminder emitted", () => {
+    const sessionFile = join(dir, "session.json");
+
+    const state = createSessionState();
+    recordWrite(state, "src/utils.ts", "edit", 100);
+    recordWrite(state, "src/utils.ts", "edit", 100);
+    recordWrite(state, "src/utils.ts", "edit", 100);
+    recordWrite(state, "src/utils.ts", "edit", 100);
+    atomicWriteJson(sessionFile, state);
+
+    const reminders: string[] = [];
+    const finalizer = {
+      appendSession() {},
+      updateSession() {},
+    };
+
+    sessionStop(sessionFile, finalizer, (msg) => reminders.push(msg));
+    expect(reminders.some((r) => r.includes("src/utils.ts"))).toBe(true);
+    expect(reminders.some((r) => r.includes("4 times"))).toBe(true);
+  });
+
+  test("file edited 3+ times with bug logged this session → no reminder", () => {
+    const sessionFile = join(dir, "session.json");
+    const bugPath = join(dir, "bug-memory.json");
+
+    const state = createSessionState();
+    recordWrite(state, "src/utils.ts", "edit", 100);
+    recordWrite(state, "src/utils.ts", "edit", 100);
+    recordWrite(state, "src/utils.ts", "edit", 100);
+    atomicWriteJson(sessionFile, state);
+
+    // Log a bug for this file during the current session
+    let mem = createEmptyBugMemory();
+    mem = addBugEntry(mem, {
+      errorMessage: "Something broke",
+      filePath: "src/utils.ts",
+      rootCause: "cause",
+      fixDescription: "fix",
+      tags: [],
+      relatedBugIds: [],
+    });
+    saveBugMemory(bugPath, mem);
+
+    const reminders: string[] = [];
+    const finalizer = {
+      appendSession() {},
+      updateSession() {},
+    };
+
+    sessionStop(sessionFile, finalizer, (msg) => reminders.push(msg));
+
+    // No reminder about utils.ts since a bug was logged
+    const utilsReminders = reminders.filter((r) => r.includes("src/utils.ts"));
+    expect(utilsReminders).toHaveLength(0);
+  });
+
+  test("search across 50 entries remains functional", () => {
+    let mem = createEmptyBugMemory();
+    for (let i = 0; i < 50; i++) {
+      mem = addBugEntry(mem, {
+        errorMessage: `Error ${i}: something went wrong in module ${i}`,
+        filePath: `src/module${i}.ts`,
+        rootCause: `Root cause for module ${i}`,
+        fixDescription: `Fix applied to module ${i}`,
+        tags: [i % 2 === 0 ? "even" : "odd", `mod-${i}`],
+        relatedBugIds: [],
+      });
+    }
+
+    const path = join(dir, "bug-memory.json");
+    saveBugMemory(path, mem);
+
+    const loaded = loadBugMemory(path);
+    expect(loaded.entries).toHaveLength(50);
+
+    const results = searchBugs(loaded, "module 25 went wrong", {
+      filePath: "src/module25.ts",
+    });
+    expect(results.length).toBeGreaterThan(0);
+    // The exact match (module25) should be among results
+    expect(results.some((r) => r.entry.filePath === "src/module25.ts")).toBe(
+      true
+    );
+  });
+
+  test("duplicate bug detection across save/load cycle", () => {
+    const path = join(dir, "bug-memory.json");
+
+    let mem = createEmptyBugMemory();
+    mem = addBugEntry(mem, {
+      errorMessage: "TypeError: null ref",
+      filePath: "src/api.ts",
+      rootCause: "null check missing",
+      fixDescription: "added check",
+      tags: ["null-check"],
+      relatedBugIds: [],
+    });
+    saveBugMemory(path, mem);
+
+    // Reload and add "same" bug again
+    let loaded = loadBugMemory(path);
+    loaded = addBugEntry(loaded, {
+      errorMessage: "TypeError: null ref",
+      filePath: "src/api.ts",
+      rootCause: "different cause text",
+      fixDescription: "different fix text",
+      tags: ["other"],
+      relatedBugIds: [],
+    });
+    saveBugMemory(path, loaded);
+
+    const final = loadBugMemory(path);
+    expect(final.entries).toHaveLength(1);
+    expect(final.entries[0].occurrenceCount).toBe(2);
+    expect(final.entries[0].rootCause).toBe("null check missing"); // original preserved
+    expect(final.nextId).toBe(2);
+  });
+});

--- a/tests/unit/bug-memory.test.ts
+++ b/tests/unit/bug-memory.test.ts
@@ -1,0 +1,534 @@
+import { describe, test, expect } from "bun:test";
+import {
+  createEmptyBugMemory,
+  generateBugId,
+  findDuplicate,
+  addBugEntry,
+  updateOccurrence,
+  computeSimilarity,
+  searchBugs,
+  lookupBugsForFile,
+  formatBugSummary,
+  hasBugForFileInSession,
+  isBugMemory,
+} from "../../src/core/bug-memory";
+import type { BugEntry, BugMemory } from "../../src/types/bug-memory";
+
+function makeBugEntry(overrides: Partial<BugEntry> = {}): BugEntry {
+  return {
+    id: "bug-001",
+    createdAt: "2026-04-10T10:00:00.000Z",
+    lastSeenAt: "2026-04-10T10:00:00.000Z",
+    errorMessage: "TypeError: Cannot read property 'name' of null",
+    filePath: "src/api.ts",
+    rootCause: "API response was null when network is down",
+    fixDescription: "Added null check before accessing response.name",
+    tags: ["null-check", "api-response"],
+    occurrenceCount: 1,
+    relatedBugIds: [],
+    ...overrides,
+  };
+}
+
+function makeMemoryWithEntries(entries: Partial<BugEntry>[]): BugMemory {
+  return {
+    entries: entries.map((e, i) =>
+      makeBugEntry({ id: `bug-${String(i + 1).padStart(3, "0")}`, ...e })
+    ),
+    nextId: entries.length + 1,
+  };
+}
+
+describe("createEmptyBugMemory", () => {
+  test("creates memory with empty entries and nextId 1", () => {
+    const mem = createEmptyBugMemory();
+    expect(mem.entries).toEqual([]);
+    expect(mem.nextId).toBe(1);
+  });
+});
+
+describe("isBugMemory", () => {
+  test("returns true for valid bug memory", () => {
+    expect(isBugMemory({ entries: [], nextId: 1 })).toBe(true);
+  });
+
+  test("returns false for null", () => {
+    expect(isBugMemory(null)).toBe(false);
+  });
+
+  test("returns false for non-object", () => {
+    expect(isBugMemory("string")).toBe(false);
+  });
+
+  test("returns false for missing entries", () => {
+    expect(isBugMemory({ nextId: 1 })).toBe(false);
+  });
+
+  test("returns false for missing nextId", () => {
+    expect(isBugMemory({ entries: [] })).toBe(false);
+  });
+});
+
+describe("generateBugId", () => {
+  test("generates zero-padded ID", () => {
+    expect(generateBugId(1)).toBe("bug-001");
+    expect(generateBugId(42)).toBe("bug-042");
+    expect(generateBugId(999)).toBe("bug-999");
+  });
+
+  test("handles IDs beyond 999", () => {
+    expect(generateBugId(1000)).toBe("bug-1000");
+  });
+});
+
+describe("findDuplicate", () => {
+  test("finds duplicate by error message and file path", () => {
+    const mem = makeMemoryWithEntries([
+      { errorMessage: "TypeError: x is null", filePath: "src/a.ts" },
+    ]);
+    const dup = findDuplicate(mem, "TypeError: x is null", "src/a.ts");
+    expect(dup).not.toBeNull();
+    expect(dup!.id).toBe("bug-001");
+  });
+
+  test("returns null when error matches but file differs", () => {
+    const mem = makeMemoryWithEntries([
+      { errorMessage: "TypeError: x is null", filePath: "src/a.ts" },
+    ]);
+    const dup = findDuplicate(mem, "TypeError: x is null", "src/b.ts");
+    expect(dup).toBeNull();
+  });
+
+  test("returns null when file matches but error differs", () => {
+    const mem = makeMemoryWithEntries([
+      { errorMessage: "TypeError: x is null", filePath: "src/a.ts" },
+    ]);
+    const dup = findDuplicate(mem, "ReferenceError: y", "src/a.ts");
+    expect(dup).toBeNull();
+  });
+
+  test("returns null on empty memory", () => {
+    const mem = createEmptyBugMemory();
+    expect(findDuplicate(mem, "anything", "any/file.ts")).toBeNull();
+  });
+});
+
+describe("addBugEntry", () => {
+  test("adds new entry with sequential ID", () => {
+    let mem = createEmptyBugMemory();
+    mem = addBugEntry(mem, {
+      errorMessage: "Error one",
+      filePath: "src/a.ts",
+      rootCause: "cause",
+      fixDescription: "fix",
+      tags: ["tag"],
+      relatedBugIds: [],
+    });
+    expect(mem.entries).toHaveLength(1);
+    expect(mem.entries[0].id).toBe("bug-001");
+    expect(mem.entries[0].occurrenceCount).toBe(1);
+    expect(mem.nextId).toBe(2);
+  });
+
+  test("assigns incrementing IDs", () => {
+    let mem = createEmptyBugMemory();
+    mem = addBugEntry(mem, {
+      errorMessage: "Error one",
+      filePath: "src/a.ts",
+      rootCause: "cause",
+      fixDescription: "fix",
+      tags: [],
+      relatedBugIds: [],
+    });
+    mem = addBugEntry(mem, {
+      errorMessage: "Error two",
+      filePath: "src/b.ts",
+      rootCause: "cause",
+      fixDescription: "fix",
+      tags: [],
+      relatedBugIds: [],
+    });
+    expect(mem.entries[0].id).toBe("bug-001");
+    expect(mem.entries[1].id).toBe("bug-002");
+    expect(mem.nextId).toBe(3);
+  });
+
+  test("updates occurrence count for duplicate (same error + file)", () => {
+    let mem = createEmptyBugMemory();
+    mem = addBugEntry(mem, {
+      errorMessage: "TypeError: null ref",
+      filePath: "src/api.ts",
+      rootCause: "null check missing",
+      fixDescription: "added check",
+      tags: ["null-check"],
+      relatedBugIds: [],
+    });
+    mem = addBugEntry(mem, {
+      errorMessage: "TypeError: null ref",
+      filePath: "src/api.ts",
+      rootCause: "different cause",
+      fixDescription: "different fix",
+      tags: ["other"],
+      relatedBugIds: [],
+    });
+    expect(mem.entries).toHaveLength(1);
+    expect(mem.entries[0].occurrenceCount).toBe(2);
+    expect(mem.entries[0].rootCause).toBe("null check missing"); // original preserved
+    expect(mem.nextId).toBe(2); // didn't increment
+  });
+
+  test("IDs are unique across entries", () => {
+    let mem = createEmptyBugMemory();
+    for (let i = 0; i < 10; i++) {
+      mem = addBugEntry(mem, {
+        errorMessage: `Error ${i}`,
+        filePath: `src/file${i}.ts`,
+        rootCause: "cause",
+        fixDescription: "fix",
+        tags: [],
+        relatedBugIds: [],
+      });
+    }
+    const ids = mem.entries.map((e) => e.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+});
+
+describe("updateOccurrence", () => {
+  test("increments count and updates lastSeenAt", () => {
+    const mem = makeMemoryWithEntries([
+      {
+        occurrenceCount: 1,
+        lastSeenAt: "2026-01-01T00:00:00.000Z",
+        rootCause: "original cause",
+        fixDescription: "original fix",
+      },
+    ]);
+    const updated = updateOccurrence(mem, "bug-001");
+    expect(updated.entries[0].occurrenceCount).toBe(2);
+    expect(updated.entries[0].lastSeenAt).not.toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  test("preserves all other fields", () => {
+    const original = makeBugEntry({
+      id: "bug-001",
+      errorMessage: "specific error",
+      rootCause: "specific cause",
+      fixDescription: "specific fix",
+      tags: ["tag1", "tag2"],
+      relatedBugIds: ["bug-002"],
+    });
+    const mem: BugMemory = { entries: [original], nextId: 2 };
+    const updated = updateOccurrence(mem, "bug-001");
+    const entry = updated.entries[0];
+    expect(entry.errorMessage).toBe("specific error");
+    expect(entry.rootCause).toBe("specific cause");
+    expect(entry.fixDescription).toBe("specific fix");
+    expect(entry.tags).toEqual(["tag1", "tag2"]);
+    expect(entry.relatedBugIds).toEqual(["bug-002"]);
+    expect(entry.createdAt).toBe(original.createdAt);
+  });
+
+  test("does not affect other entries", () => {
+    const mem = makeMemoryWithEntries([
+      { occurrenceCount: 1 },
+      { id: "bug-002", occurrenceCount: 5 },
+    ]);
+    const updated = updateOccurrence(mem, "bug-001");
+    expect(updated.entries[1].occurrenceCount).toBe(5);
+  });
+});
+
+describe("computeSimilarity", () => {
+  test("exact substring match on error message scores 1.0+", () => {
+    const entry = makeBugEntry({
+      errorMessage: "TypeError: Cannot read property 'name' of null",
+    });
+    const result = computeSimilarity(
+      "TypeError: Cannot read property 'name' of null",
+      entry
+    );
+    expect(result.score).toBeGreaterThanOrEqual(1.0);
+    expect(result.matchReasons).toContain("exact_error_match");
+  });
+
+  test("word overlap on root cause contributes to score", () => {
+    const entry = makeBugEntry({
+      errorMessage: "unrelated error",
+      rootCause: "database connection timeout after 30s",
+    });
+    const result = computeSimilarity("database connection timeout", entry);
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.matchReasons).toContain("root_cause");
+  });
+
+  test("word overlap on tags contributes to score", () => {
+    const entry = makeBugEntry({
+      errorMessage: "unrelated",
+      rootCause: "unrelated",
+      fixDescription: "unrelated",
+      tags: ["auth", "token-expiry"],
+    });
+    const result = computeSimilarity("auth token expiry", entry);
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.matchReasons).toContain("tags");
+  });
+
+  test("no match returns score 0", () => {
+    const entry = makeBugEntry({
+      errorMessage: "TypeError: null ref",
+      rootCause: "missing null check",
+      fixDescription: "added guard",
+      tags: ["null-check"],
+    });
+    const result = computeSimilarity("completely unrelated query xyz", entry);
+    expect(result.score).toBe(0);
+    expect(result.matchReasons).toEqual([]);
+  });
+
+  test("partial word overlap produces intermediate score", () => {
+    const entry = makeBugEntry({
+      errorMessage: "Failed to connect to database server",
+      rootCause: "Database host unreachable",
+      fixDescription: "Updated connection string",
+      tags: ["database", "connection"],
+    });
+    const result = computeSimilarity("database server error", entry);
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.score).toBeLessThan(1.0);
+  });
+});
+
+describe("searchBugs", () => {
+  test("returns empty array for empty memory", () => {
+    const mem = createEmptyBugMemory();
+    expect(searchBugs(mem, "anything")).toEqual([]);
+  });
+
+  test("returns empty array for empty query", () => {
+    const mem = makeMemoryWithEntries([{ errorMessage: "error" }]);
+    expect(searchBugs(mem, "")).toEqual([]);
+    expect(searchBugs(mem, "   ")).toEqual([]);
+  });
+
+  test("returns matches sorted by score descending", () => {
+    const mem = makeMemoryWithEntries([
+      {
+        errorMessage: "database connection timeout",
+        rootCause: "db host down",
+        tags: ["database"],
+      },
+      {
+        errorMessage: "database connection refused",
+        rootCause: "wrong port for database",
+        tags: ["database", "connection"],
+      },
+    ]);
+    const results = searchBugs(mem, "database connection timeout");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    // First result should be the exact or closer match
+    if (results.length >= 2) {
+      expect(results[0].score).toBeGreaterThanOrEqual(results[1].score);
+    }
+  });
+
+  test("filters out entries below 0.3 threshold", () => {
+    const mem = makeMemoryWithEntries([
+      {
+        errorMessage: "TypeError: Cannot read null",
+        rootCause: "null pointer",
+        tags: ["null-check"],
+        filePath: "src/api.ts",
+      },
+      {
+        errorMessage: "SyntaxError: unexpected token",
+        rootCause: "missing comma in json",
+        tags: ["syntax"],
+        filePath: "src/parser.ts",
+      },
+    ]);
+    // Search for something only matching the first entry
+    const results = searchBugs(mem, "null pointer TypeError", {
+      filePath: "src/api.ts",
+    });
+    // The null-check entry should match; the syntax entry should not
+    const ids = results.map((r) => r.entry.id);
+    expect(ids).toContain("bug-001");
+  });
+
+  test("boosts same-file matches", () => {
+    const mem = makeMemoryWithEntries([
+      {
+        errorMessage: "TypeError: undefined is not a function",
+        filePath: "src/other.ts",
+        tags: ["type-error"],
+      },
+      {
+        errorMessage: "TypeError: cannot call undefined",
+        filePath: "src/target.ts",
+        tags: ["type-error"],
+      },
+    ]);
+    const results = searchBugs(mem, "TypeError undefined", {
+      filePath: "src/target.ts",
+    });
+    // The target.ts entry should have a higher score due to file path boost
+    if (results.length >= 2) {
+      const targetMatch = results.find(
+        (r) => r.entry.filePath === "src/target.ts"
+      );
+      const otherMatch = results.find(
+        (r) => r.entry.filePath === "src/other.ts"
+      );
+      if (targetMatch && otherMatch) {
+        expect(targetMatch.score).toBeGreaterThan(otherMatch.score);
+      }
+    }
+  });
+
+  test("false positive guard: requires file or tag match for low scores", () => {
+    const mem = makeMemoryWithEntries([
+      {
+        errorMessage: "some vague error about things",
+        rootCause: "something happened",
+        tags: ["unrelated-tag"],
+        filePath: "src/unrelated.ts",
+      },
+    ]);
+    // Query that has minimal overlap and no file/tag match
+    const results = searchBugs(mem, "about things", {
+      filePath: "src/totally-different.ts",
+    });
+    // Should be filtered out due to false positive guard
+    for (const r of results) {
+      expect(r.score).toBeGreaterThan(0.3);
+    }
+  });
+});
+
+describe("lookupBugsForFile", () => {
+  test("returns entries for matching file path", () => {
+    const mem = makeMemoryWithEntries([
+      { filePath: "src/api.ts", errorMessage: "error 1" },
+      { filePath: "src/auth.ts", errorMessage: "error 2" },
+      { filePath: "src/api.ts", errorMessage: "error 3" },
+    ]);
+    const results = lookupBugsForFile(mem, "src/api.ts");
+    expect(results).toHaveLength(2);
+    expect(results.every((e) => e.filePath === "src/api.ts")).toBe(true);
+  });
+
+  test("returns empty array when no matches", () => {
+    const mem = makeMemoryWithEntries([{ filePath: "src/api.ts" }]);
+    expect(lookupBugsForFile(mem, "src/other.ts")).toEqual([]);
+  });
+
+  test("returns empty array for empty memory", () => {
+    const mem = createEmptyBugMemory();
+    expect(lookupBugsForFile(mem, "src/api.ts")).toEqual([]);
+  });
+
+  test("sorts by lastSeenAt descending", () => {
+    const mem = makeMemoryWithEntries([
+      {
+        filePath: "src/api.ts",
+        lastSeenAt: "2026-01-01T00:00:00.000Z",
+        errorMessage: "old",
+      },
+      {
+        filePath: "src/api.ts",
+        lastSeenAt: "2026-04-10T00:00:00.000Z",
+        errorMessage: "new",
+      },
+    ]);
+    const results = lookupBugsForFile(mem, "src/api.ts");
+    expect(results[0].errorMessage).toBe("new");
+    expect(results[1].errorMessage).toBe("old");
+  });
+});
+
+describe("formatBugSummary", () => {
+  test("returns null for empty entries", () => {
+    expect(formatBugSummary([])).toBeNull();
+  });
+
+  test("formats single entry", () => {
+    const entries = [makeBugEntry()];
+    const summary = formatBugSummary(entries);
+    expect(summary).not.toBeNull();
+    expect(summary).toContain("[mink] Known bugs for this file:");
+    expect(summary).toContain("bug-001");
+    expect(summary).toContain("Root cause:");
+    expect(summary).toContain("Fix:");
+  });
+
+  test("shows max 3 entries with overflow count", () => {
+    const entries = Array.from({ length: 5 }, (_, i) =>
+      makeBugEntry({ id: `bug-${String(i + 1).padStart(3, "0")}` })
+    );
+    const summary = formatBugSummary(entries)!;
+    expect(summary).toContain("bug-001");
+    expect(summary).toContain("bug-002");
+    expect(summary).toContain("bug-003");
+    expect(summary).not.toContain("bug-004");
+    expect(summary).toContain("... and 2 more");
+  });
+
+  test("shows occurrence count for entries seen multiple times", () => {
+    const entries = [makeBugEntry({ occurrenceCount: 5 })];
+    const summary = formatBugSummary(entries)!;
+    expect(summary).toContain("Seen 5 times");
+  });
+
+  test("does not show occurrence info for count 1", () => {
+    const entries = [makeBugEntry({ occurrenceCount: 1 })];
+    const summary = formatBugSummary(entries)!;
+    expect(summary).not.toContain("Seen");
+  });
+});
+
+describe("hasBugForFileInSession", () => {
+  test("returns true when bug was created during session", () => {
+    const mem = makeMemoryWithEntries([
+      {
+        filePath: "src/api.ts",
+        createdAt: "2026-04-10T12:00:00.000Z",
+      },
+    ]);
+    expect(
+      hasBugForFileInSession(mem, "src/api.ts", "2026-04-10T10:00:00.000Z")
+    ).toBe(true);
+  });
+
+  test("returns false when bug was created before session", () => {
+    const mem = makeMemoryWithEntries([
+      {
+        filePath: "src/api.ts",
+        createdAt: "2026-04-09T08:00:00.000Z",
+      },
+    ]);
+    expect(
+      hasBugForFileInSession(mem, "src/api.ts", "2026-04-10T10:00:00.000Z")
+    ).toBe(false);
+  });
+
+  test("returns false when file has no bug entries", () => {
+    const mem = makeMemoryWithEntries([
+      {
+        filePath: "src/other.ts",
+        createdAt: "2026-04-10T12:00:00.000Z",
+      },
+    ]);
+    expect(
+      hasBugForFileInSession(mem, "src/api.ts", "2026-04-10T10:00:00.000Z")
+    ).toBe(false);
+  });
+
+  test("returns false for empty memory", () => {
+    const mem = createEmptyBugMemory();
+    expect(
+      hasBugForFileInSession(mem, "src/api.ts", "2026-04-10T10:00:00.000Z")
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Persistent, searchable log of bugs encountered across sessions.
Surfaces known bugs during pre-write hook and suppresses edit-count
reminders when a bug has already been logged for the file this session.

New files:
- src/types/bug-memory.ts — BugEntry, BugMemory, SimilarityMatch types
- src/core/bug-memory.ts — CRUD, similarity scoring (Jaccard + substring),
  search, duplicate detection, file lookup, session-aware checks
- tests/unit/bug-memory.test.ts — 43 unit tests
- tests/integration/bug-memory.test.ts — 10 integration tests

Modified files:
- src/core/paths.ts — add bugMemoryPath()
- src/commands/pre-write.ts — replace stub with real bug memory lookup
- src/commands/session-stop.ts — skip reminder when bug already logged
- src/cli.ts — add bug-search command

https://claude.ai/code/session_01WQm2XLcNhD5cmgSpX87JSF