### PR TITLE
fix: use correct Claude Code hooks format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,97 @@
+### macOS
+# Finder metadata
+.DS_Store
+
+# Thumbnails
+._*
+
+# Custom folder icons
+Icon
+
+# Volume root files
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+### VS Code
+# VSCode settings (keep shared configuration)
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### Go
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+
+# Go workspace file
+go.work.sum
+
+# env file
+.env
+
+### Node
+# Dependencies
+node_modules/
+
+# Logs
+*.log
+
+# Runtime data
+*.pid
+*.pid.lock
+
+# Coverage
+coverage/
+*.lcov
+.nyc_output
+
+# Build output
+dist/
+build/Release
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Framework build output and caches
+.cache
+.parcel-cache
+.next
+out/
+.nuxt
+
+# dotenv environment variable files
+.env
+.env.local
+.env.*.local
+
+# npm cache directory
+.npm
+*.tgz
+
+# yarn v2
+.yarn/cache
+.yarn/unplugged
+.yarn/install-state.gz
+.pnp.*

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,9 +5,14 @@ import { projectDir } from "../core/paths";
 import { generateProjectId } from "../core/project-id";
 import { atomicWriteJson, safeReadJson } from "../core/fs-utils";
 
+interface HookCommand {
+  type: "command";
+  command: string;
+}
+
 interface HookEntry {
   matcher: string;
-  command: string;
+  hooks: HookCommand[];
 }
 
 type HooksConfig = Record<string, HookEntry[]>;
@@ -26,18 +31,31 @@ export function buildHooksConfig(
   cliPath: string
 ): HooksConfig {
   const prefix = runtime === "bun" ? `bun run ${cliPath}` : `node ${cliPath}`;
+  const hook = (cmd: string): HookCommand[] => [{ type: "command", command: cmd }];
   return {
-    SessionStart: [{ matcher: "", command: `${prefix} session-start` }],
-    Stop: [{ matcher: "", command: `${prefix} session-stop` }],
+    SessionStart: [{ matcher: "", hooks: hook(`${prefix} session-start`) }],
+    Stop: [{ matcher: "", hooks: hook(`${prefix} session-stop`) }],
   };
 }
 
-function isMinkHook(entry: HookEntry): boolean {
+function isMinkCommand(cmd: string): boolean {
   return (
-    entry.command.includes("cli") &&
-    (entry.command.includes("session-start") ||
-      entry.command.includes("session-stop"))
+    cmd.includes("cli") &&
+    (cmd.includes("session-start") ||
+      cmd.includes("session-stop"))
   );
+}
+
+function isMinkHook(entry: HookEntry | Record<string, unknown>): boolean {
+  // Handle current format: { matcher, hooks: [{ type, command }] }
+  if (Array.isArray((entry as HookEntry).hooks)) {
+    return (entry as HookEntry).hooks.some((h) => isMinkCommand(h.command));
+  }
+  // Handle legacy format: { matcher, command }
+  if (typeof (entry as Record<string, unknown>).command === "string") {
+    return isMinkCommand((entry as Record<string, unknown>).command as string);
+  }
+  return false;
 }
 
 export function mergeHooksIntoSettings(

--- a/tests/unit/init.test.ts
+++ b/tests/unit/init.test.ts
@@ -9,20 +9,34 @@ import { learningMemoryPath } from "../../src/core/paths";
 describe("buildHooksConfig", () => {
   test("uses bun when bun is the detected runtime", () => {
     const hooks = buildHooksConfig("bun", "/usr/local/bin/mink/cli.js");
-    expect(hooks.SessionStart[0].command).toContain("bun run");
-    expect(hooks.Stop[0].command).toContain("bun run");
+    expect(hooks.SessionStart[0].hooks[0].command).toContain("bun run");
+    expect(hooks.Stop[0].hooks[0].command).toContain("bun run");
   });
 
   test("uses node when node is the detected runtime", () => {
     const hooks = buildHooksConfig("node", "/usr/local/bin/mink/cli.js");
-    expect(hooks.SessionStart[0].command).toContain("node ");
-    expect(hooks.Stop[0].command).toContain("node ");
+    expect(hooks.SessionStart[0].hooks[0].command).toContain("node ");
+    expect(hooks.Stop[0].hooks[0].command).toContain("node ");
   });
 
   test("includes correct commands", () => {
     const hooks = buildHooksConfig("bun", "/path/to/cli.js");
-    expect(hooks.SessionStart[0].command).toContain("session-start");
-    expect(hooks.Stop[0].command).toContain("session-stop");
+    expect(hooks.SessionStart[0].hooks[0].command).toContain("session-start");
+    expect(hooks.Stop[0].hooks[0].command).toContain("session-stop");
+  });
+
+  test("each hook entry has correct structure with type and command", () => {
+    const hooks = buildHooksConfig("bun", "/path/to/cli.js");
+    for (const entries of Object.values(hooks)) {
+      for (const entry of entries) {
+        expect(entry.matcher).toBeDefined();
+        expect(Array.isArray(entry.hooks)).toBe(true);
+        for (const h of entry.hooks) {
+          expect(h.type).toBe("command");
+          expect(typeof h.command).toBe("string");
+        }
+      }
+    }
   });
 });
 
@@ -57,7 +71,7 @@ describe("mergeHooksIntoSettings", () => {
       settingsPath,
       JSON.stringify({
         hooks: {
-          PreToolUse: [{ matcher: "", command: "existing-hook" }],
+          PreToolUse: [{ matcher: "", hooks: [{ type: "command", command: "existing-hook" }] }],
         },
         otherSetting: true,
       })
@@ -83,7 +97,7 @@ describe("mergeHooksIntoSettings", () => {
       JSON.stringify({
         hooks: {
           SessionStart: [
-            { matcher: "", command: "bun run /old/path/cli.js session-start" },
+            { matcher: "", hooks: [{ type: "command", command: "bun run /old/path/cli.js session-start" }] },
           ],
         },
       })
@@ -93,10 +107,42 @@ describe("mergeHooksIntoSettings", () => {
     mergeHooksIntoSettings(settingsPath, hooks);
 
     const settings = safeReadJson(settingsPath) as Record<string, unknown>;
-    const allHooks = settings.hooks as Record<string, Array<{ command: string }>>;
+    const allHooks = settings.hooks as Record<string, Array<{ hooks: Array<{ command: string }> }>>;
     const sessionStartHooks = allHooks.SessionStart;
     expect(sessionStartHooks).toHaveLength(1);
-    expect(sessionStartHooks[0].command).toContain("/new/path/cli.js");
+    expect(sessionStartHooks[0].hooks[0].command).toContain("/new/path/cli.js");
+  });
+
+  test("cleans up legacy flat-command format on re-init", () => {
+    const settingsDir = join(dir, ".claude");
+    mkdirSync(settingsDir, { recursive: true });
+    const settingsPath = join(settingsDir, "settings.json");
+    // Seed with old/legacy format (flat command, no hooks array)
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            { matcher: "", command: "bun run /old/path/cli.js session-start" },
+          ],
+          Stop: [
+            { matcher: "", command: "bun run /old/path/cli.js session-stop" },
+          ],
+        },
+      })
+    );
+
+    const hooks = buildHooksConfig("bun", "/new/path/cli.js");
+    mergeHooksIntoSettings(settingsPath, hooks);
+
+    const settings = safeReadJson(settingsPath) as Record<string, unknown>;
+    const allHooks = settings.hooks as Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+
+    // Legacy entries should be removed and replaced with new format
+    expect(allHooks.SessionStart).toHaveLength(1);
+    expect(allHooks.SessionStart[0].hooks[0].command).toContain("/new/path/cli.js");
+    expect(allHooks.Stop).toHaveLength(1);
+    expect(allHooks.Stop[0].hooks[0].command).toContain("/new/path/cli.js");
   });
 });
 


### PR DESCRIPTION
## Summary
- Fixed `buildHooksConfig` to use Claude Code's required `{ matcher, hooks: [{ type: "command", command }] }` format instead of the invalid flat `{ matcher, command }` format that caused a Settings Error on session start.
- Updated `isMinkHook` to handle both the new format and legacy flat-command entries, so `mink init` can clean up old invalid settings on re-init.
- Updated all tests to match the corrected format and added a test for legacy cleanup.

## Test plan
- [x] All existing init tests updated and passing (10 tests, 31 assertions)
- [ ] Run `mink init` and verify `.claude/settings.json` contains the correct hooks format
- [ ] Verify Claude Code starts without Settings Error

🤖 Generated with [Claude Code](https://claude.com/claude-code)