### PR TITLE
feat: implement spec 11 CLI interface

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,13 @@ switch (command) {
 
   case "init": {
     const { init } = await import("./commands/init");
-    init(cwd);
+    await init(cwd);
+    break;
+  }
+
+  case "status": {
+    const { status } = await import("./commands/status");
+    status(cwd);
     break;
   }
 
@@ -71,35 +77,86 @@ switch (command) {
     break;
   }
 
+  case "daemon": {
+    const { daemon } = await import("./commands/daemon");
+    await daemon(cwd, process.argv.slice(3));
+    break;
+  }
+
+  case "config": {
+    const { config } = await import("./commands/config");
+    await config(process.argv.slice(3));
+    break;
+  }
+
+  case "update": {
+    const { update } = await import("./commands/update");
+    await update(cwd, process.argv.slice(3));
+    break;
+  }
+
+  case "restore": {
+    const { restore } = await import("./commands/restore");
+    restore(cwd, process.argv.slice(3));
+    break;
+  }
+
+  case "designqc": {
+    const { designqc } = await import("./commands/designqc");
+    designqc(cwd, process.argv.slice(3));
+    break;
+  }
+
   case "bug-search": {
-    const query = process.argv.slice(3).join(" ");
-    if (!query) {
-      console.error("Usage: mink bug-search <query>");
-      process.exit(1);
-    }
-    const { loadBugMemory, searchBugs } = await import("./core/bug-memory");
-    const { bugMemoryPath } = await import("./core/paths");
-    const memory = loadBugMemory(bugMemoryPath(cwd));
-    const results = searchBugs(memory, query);
-    if (results.length === 0) {
-      console.log("No matching bugs found.");
+    const { bugSearch } = await import("./commands/bug-search");
+    bugSearch(cwd, process.argv.slice(3).join(" "));
+    break;
+  }
+
+  case "bug": {
+    if (process.argv[3] === "search") {
+      const { bugSearch } = await import("./commands/bug-search");
+      bugSearch(cwd, process.argv.slice(4).join(" "));
     } else {
-      for (const match of results) {
-        const e = match.entry;
-        console.log(`${e.id} (score: ${match.score.toFixed(2)}) — ${e.errorMessage}`);
-        console.log(`  File: ${e.filePath}${e.lineNumber ? `:${e.lineNumber}` : ""}`);
-        console.log(`  Root cause: ${e.rootCause}`);
-        console.log(`  Fix: ${e.fixDescription}`);
-        if (e.tags.length > 0) console.log(`  Tags: ${e.tags.join(", ")}`);
-        if (e.occurrenceCount > 1) console.log(`  Seen ${e.occurrenceCount} times`);
-        console.log();
-      }
+      console.error(
+        `[mink] unknown bug subcommand: ${process.argv[3] ?? "(none)"}`
+      );
+      console.error("Usage: mink bug search <term>");
+      process.exit(1);
     }
     break;
   }
 
+  case "help":
+  case "--help":
+  case "-h":
+    console.log("mink — a hidden presence that moves alongside the developer");
+    console.log();
+    console.log("Usage: mink <command> [options]");
+    console.log();
+    console.log("Commands:");
+    console.log("  init                    Initialize Mink in the current project");
+    console.log("  status                  Display project health at a glance");
+    console.log("  scan [--check]          Force a full file index rescan");
+    console.log("  config [key] [value]    Manage global user settings");
+    console.log("  daemon <cmd>            Manage the background daemon (start|stop|restart|logs)");
+    console.log("  cron <cmd> [id]         Manage scheduled tasks (list|run|retry)");
+    console.log("  update [options]        Update Mink across registered projects");
+    console.log("  restore [backup]        Restore state from a backup");
+    console.log("  bug search <term>       Search the bug log");
+    console.log("  detect-waste            Detect and flag wasteful patterns");
+    console.log("  reflect                 Generate learning memory reflections");
+    console.log("  designqc [target]       Capture design screenshots (spec 13)");
+    console.log();
+    console.log("Lifecycle hooks (internal):");
+    console.log("  session-start           Start session tracking");
+    console.log("  session-stop            Finalize session and log data");
+    console.log("  pre-read / post-read    File read hooks");
+    console.log("  pre-write / post-write  File write hooks");
+    break;
+
   default:
-    console.error(`[mink] unknown command: ${command}`);
-    console.error("Usage: mink <session-start|session-stop|init|scan|reflect|pre-read|post-read|pre-write|post-write|bug-search|detect-waste|cron>");
+    console.error(`[mink] unknown command: ${command ?? "(none)"}`);
+    console.error("Run 'mink help' for usage information.");
     process.exit(1);
 }

--- a/src/commands/bug-search.ts
+++ b/src/commands/bug-search.ts
@@ -1,0 +1,32 @@
+import { loadBugMemory, searchBugs } from "../core/bug-memory";
+import { bugMemoryPath } from "../core/paths";
+
+export function bugSearch(cwd: string, query: string): void {
+  if (!query) {
+    console.error("Usage: mink bug search <query>");
+    process.exit(1);
+  }
+
+  const memory = loadBugMemory(bugMemoryPath(cwd));
+  const results = searchBugs(memory, query);
+
+  if (results.length === 0) {
+    console.log("No matching bugs found.");
+    return;
+  }
+
+  for (const match of results) {
+    const e = match.entry;
+    console.log(
+      `${e.id} (score: ${match.score.toFixed(2)}) — ${e.errorMessage}`
+    );
+    console.log(
+      `  File: ${e.filePath}${e.lineNumber ? `:${e.lineNumber}` : ""}`
+    );
+    console.log(`  Root cause: ${e.rootCause}`);
+    console.log(`  Fix: ${e.fixDescription}`);
+    if (e.tags.length > 0) console.log(`  Tags: ${e.tags.join(", ")}`);
+    if (e.occurrenceCount > 1) console.log(`  Seen ${e.occurrenceCount} times`);
+    console.log();
+  }
+}

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,109 @@
+import {
+  CONFIG_KEYS,
+  isValidConfigKey,
+} from "../types/config";
+import {
+  resolveConfigValue,
+  resolveAllConfig,
+  setConfigValue,
+  resetConfigKey,
+  resetAllConfig,
+} from "../core/global-config";
+
+function printValidKeys(): void {
+  console.error("Valid keys:");
+  for (const meta of CONFIG_KEYS) {
+    console.error(`  ${meta.key} — ${meta.description}`);
+  }
+}
+
+function readLineFromStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    process.stdin.resume();
+    process.stdin.setEncoding("utf-8");
+    process.stdin.once("data", (data) => {
+      process.stdin.pause();
+      resolve(String(data).trim());
+    });
+  });
+}
+
+export async function config(args: string[]): Promise<void> {
+  // mink config --reset-all
+  if (args.includes("--reset-all")) {
+    process.stdout.write(
+      "[mink] reset all settings to defaults? (yes/no): "
+    );
+    const answer = await readLineFromStdin();
+    if (answer === "yes" || answer === "y") {
+      resetAllConfig();
+      console.log("[mink] all settings reset to defaults");
+    } else {
+      console.log("[mink] cancelled");
+    }
+    return;
+  }
+
+  // mink config --reset <key>
+  const resetIdx = args.indexOf("--reset");
+  if (resetIdx !== -1) {
+    const key = args[resetIdx + 1];
+    if (!key) {
+      console.error("Usage: mink config --reset <key>");
+      printValidKeys();
+      process.exit(1);
+    }
+    if (!isValidConfigKey(key)) {
+      console.error(`[mink] unknown config key: ${key}`);
+      printValidKeys();
+      process.exit(1);
+    }
+    resetConfigKey(key);
+    console.log(`[mink] ${key} reset to default`);
+    return;
+  }
+
+  // mink config (no args) — show all
+  if (args.length === 0) {
+    const all = resolveAllConfig();
+    console.log("[mink] configuration:");
+    for (const entry of all) {
+      let line = `  ${entry.key} = ${entry.value} (source: ${entry.source})`;
+      if (
+        entry.source === "environment variable" &&
+        entry.configFileValue !== undefined
+      ) {
+        line += ` [config file value: ${entry.configFileValue} — overridden]`;
+      }
+      console.log(line);
+    }
+    return;
+  }
+
+  const key = args[0];
+  if (!isValidConfigKey(key)) {
+    console.error(`[mink] unknown config key: ${key}`);
+    printValidKeys();
+    process.exit(1);
+  }
+
+  // mink config <key> <value> — set
+  if (args.length >= 2) {
+    const value = args.slice(1).join(" ");
+    setConfigValue(key, value);
+    console.log(`[mink] ${key} = ${value}`);
+    return;
+  }
+
+  // mink config <key> — show one
+  const resolved = resolveConfigValue(key);
+  let line = `${key} = ${resolved.value} (source: ${resolved.source})`;
+  if (
+    resolved.source === "environment variable" &&
+    resolved.configFileValue !== undefined
+  ) {
+    line += `\n  note: config file value (${resolved.configFileValue}) is overridden`;
+  }
+  console.log(line);
+}

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -1,0 +1,46 @@
+import { readFileSync, existsSync } from "fs";
+import { startDaemon, stopDaemon } from "../core/daemon";
+import { schedulerLogPath } from "../core/paths";
+
+export async function daemon(cwd: string, args: string[]): Promise<void> {
+  const subcommand = args[0];
+
+  switch (subcommand) {
+    case "start":
+      startDaemon(cwd);
+      break;
+
+    case "stop":
+      await stopDaemon();
+      break;
+
+    case "restart":
+      await stopDaemon();
+      startDaemon(cwd);
+      break;
+
+    case "logs": {
+      const logPath = schedulerLogPath();
+      if (!existsSync(logPath)) {
+        console.log("[mink] no log file found");
+        return;
+      }
+      try {
+        const content = readFileSync(logPath, "utf-8");
+        const lines = content.split("\n");
+        const tail = lines.slice(-50).join("\n");
+        console.log(tail);
+      } catch {
+        console.error("[mink] error reading log file");
+      }
+      break;
+    }
+
+    default:
+      console.error(
+        `[mink] unknown daemon subcommand: ${subcommand ?? "(none)"}`
+      );
+      console.error("Usage: mink daemon <start|stop|restart|logs>");
+      process.exit(1);
+  }
+}

--- a/src/commands/designqc.ts
+++ b/src/commands/designqc.ts
@@ -1,0 +1,3 @@
+export function designqc(_cwd: string, _args: string[]): void {
+  console.log("[mink] designqc: not yet implemented (see spec 13)");
+}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,7 +1,7 @@
 import { execSync } from "child_process";
-import { mkdirSync } from "fs";
-import { resolve, dirname } from "path";
-import { projectDir } from "../core/paths";
+import { mkdirSync, existsSync } from "fs";
+import { resolve, dirname, basename, join } from "path";
+import { projectDir, projectMetaPath } from "../core/paths";
 import { generateProjectId } from "../core/project-id";
 import { atomicWriteJson, safeReadJson } from "../core/fs-utils";
 
@@ -92,30 +92,61 @@ export function mergeHooksIntoSettings(
   atomicWriteJson(settingsPath, existing);
 }
 
+function isExistingInstallation(cwd: string): boolean {
+  const dir = projectDir(cwd);
+  if (!existsSync(dir)) return false;
+  return existsSync(join(dir, "file-index.json"));
+}
+
 export async function init(cwd: string): Promise<void> {
   const runtime = detectRuntime();
   const cliPath = resolve(dirname(new URL(import.meta.url).pathname), "../cli.ts");
   const hooks = buildHooksConfig(runtime, cliPath);
   const settingsPath = resolve(cwd, ".claude", "settings.json");
+  const dir = projectDir(cwd);
+  const upgrading = isExistingInstallation(cwd);
+
+  if (upgrading) {
+    console.log("[mink] existing installation detected, upgrading...");
+    const { createBackup } = await import("../core/backup");
+    const backupName = createBackup(cwd);
+    console.log(`  backup: ${backupName}`);
+  }
 
   mergeHooksIntoSettings(settingsPath, hooks);
 
-  const dir = projectDir(cwd);
   mkdirSync(dir, { recursive: true });
 
   const projectId = generateProjectId(cwd);
-  console.log(`[mink] initialized`);
-  console.log(`  project:  ${projectId}`);
-  console.log(`  state:    ${dir}`);
-  console.log(`  runtime:  ${runtime}`);
-  console.log(`  hooks:    ${settingsPath}`);
+
+  // Write project metadata
+  const metaPath = projectMetaPath(cwd);
+  const existingMeta = safeReadJson(metaPath) as Record<string, unknown> | null;
+  atomicWriteJson(metaPath, {
+    ...(existingMeta ?? {}),
+    cwd,
+    name: basename(cwd),
+    initTimestamp: existingMeta?.initTimestamp ?? new Date().toISOString(),
+    version: "0.1.0",
+  });
+
+  if (upgrading) {
+    console.log(`[mink] upgrade complete`);
+    console.log(`  project:  ${projectId}`);
+    console.log(`  hooks:    ${settingsPath}`);
+  } else {
+    console.log(`[mink] initialized`);
+    console.log(`  project:  ${projectId}`);
+    console.log(`  state:    ${dir}`);
+    console.log(`  runtime:  ${runtime}`);
+    console.log(`  hooks:    ${settingsPath}`);
+  }
 
   // Run initial scan
   const { scan } = await import("./scan");
   scan(cwd, { check: false });
 
   // Seed learning memory if it doesn't exist
-  const { existsSync } = await import("fs");
   const { learningMemoryPath } = await import("../core/paths");
   const memPath = learningMemoryPath(cwd);
   if (!existsSync(memPath)) {

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -1,0 +1,31 @@
+import { listBackups, restoreBackup } from "../core/backup";
+
+export function restore(cwd: string, args: string[]): void {
+  const backupName = args[0];
+
+  if (!backupName) {
+    // List available backups
+    const backups = listBackups(cwd);
+    if (backups.length === 0) {
+      console.log("[mink] no backups available");
+      return;
+    }
+
+    console.log("[mink] available backups:");
+    for (const b of backups) {
+      console.log(
+        `  ${b.name}  (${b.timestamp.toISOString().replace("T", " ").slice(0, 19)}, ${b.fileCount} files)`
+      );
+    }
+    return;
+  }
+
+  try {
+    restoreBackup(cwd, backupName);
+    console.log(`[mink] restored from: ${backupName}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[mink] restore failed: ${msg}`);
+    process.exit(1);
+  }
+}

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,152 @@
+import { existsSync, readFileSync, statSync } from "fs";
+import {
+  sessionPath,
+  fileIndexPath,
+  configPath,
+  learningMemoryPath,
+  tokenLedgerPath,
+  bugMemoryPath,
+  actionLogPath,
+} from "../core/paths";
+import { safeReadJson } from "../core/fs-utils";
+import { isFileIndex } from "../core/index-store";
+import { loadLedger } from "../core/token-ledger";
+import { parseLearningMemory, totalEntryCount } from "../core/learning-memory";
+import { loadBugMemory } from "../core/bug-memory";
+import { getDaemonStatus } from "../core/daemon";
+
+interface FileCheck {
+  name: string;
+  path: string;
+  status: "ok" | "missing" | "corrupt";
+}
+
+function checkJsonFile(name: string, filePath: string, validator?: (v: unknown) => boolean): FileCheck {
+  if (!existsSync(filePath)) return { name, path: filePath, status: "missing" };
+  const data = safeReadJson(filePath);
+  if (data === null) return { name, path: filePath, status: "corrupt" };
+  if (validator && !validator(data)) return { name, path: filePath, status: "corrupt" };
+  return { name, path: filePath, status: "ok" };
+}
+
+function checkTextFile(name: string, filePath: string): FileCheck {
+  if (!existsSync(filePath)) return { name, path: filePath, status: "missing" };
+  try {
+    readFileSync(filePath, "utf-8");
+    return { name, path: filePath, status: "ok" };
+  } catch {
+    return { name, path: filePath, status: "corrupt" };
+  }
+}
+
+export function status(cwd: string): void {
+  console.log("[mink] project status");
+  console.log();
+
+  // Section 1: State directory integrity
+  const checks: FileCheck[] = [
+    checkJsonFile("session.json", sessionPath(cwd)),
+    checkJsonFile("file-index.json", fileIndexPath(cwd), isFileIndex),
+    checkJsonFile("config.json", configPath(cwd)),
+    checkTextFile("learning-memory.md", learningMemoryPath(cwd)),
+    checkJsonFile("token-ledger.json", tokenLedgerPath(cwd)),
+    checkJsonFile("bug-memory.json", bugMemoryPath(cwd)),
+    checkTextFile("action-log.md", actionLogPath(cwd)),
+  ];
+
+  console.log("  State files:");
+  for (const check of checks) {
+    const icon = check.status === "ok" ? "ok" : check.status === "missing" ? "missing" : "corrupt";
+    console.log(`    ${check.name}: ${icon}`);
+  }
+
+  const corrupt = checks.filter((c) => c.status === "corrupt");
+  if (corrupt.length > 0) {
+    console.log();
+    console.log("  Warning: corrupted files detected. Consider running: mink restore");
+  }
+  console.log();
+
+  // Section 2: File index
+  try {
+    const raw = safeReadJson(fileIndexPath(cwd));
+    if (raw && isFileIndex(raw)) {
+      const h = raw.header;
+      const total = h.lifetimeHits + h.lifetimeMisses;
+      const ratio = total > 0 ? ((h.lifetimeHits / total) * 100).toFixed(1) : "N/A";
+      console.log("  File index:");
+      console.log(`    Files: ${h.totalFiles}`);
+      console.log(`    Last scan: ${h.lastScanTimestamp || "never"}`);
+      console.log(`    Hit/miss ratio: ${ratio}${total > 0 ? "%" : ""} (${h.lifetimeHits} hits, ${h.lifetimeMisses} misses)`);
+    } else {
+      console.log("  File index: not available");
+    }
+  } catch {
+    console.log("  File index: error reading");
+  }
+  console.log();
+
+  // Section 3: Token ledger
+  try {
+    const ledger = loadLedger(tokenLedgerPath(cwd));
+    const lt = ledger.lifetime;
+    console.log("  Token ledger:");
+    console.log(`    Sessions: ${lt.totalSessions}`);
+    console.log(`    Total tokens: ${lt.totalTokens.toLocaleString()}`);
+    console.log(`    Reads: ${lt.totalReads}  Writes: ${lt.totalWrites}`);
+    console.log(`    Estimated savings: ${lt.totalEstimatedSavings.toLocaleString()} tokens`);
+  } catch {
+    console.log("  Token ledger: error reading");
+  }
+  console.log();
+
+  // Section 4: Learning memory
+  try {
+    const memPath = learningMemoryPath(cwd);
+    if (existsSync(memPath)) {
+      const content = readFileSync(memPath, "utf-8");
+      const mem = parseLearningMemory(content);
+      const total = totalEntryCount(mem);
+      const mtime = statSync(memPath).mtime;
+      console.log("  Learning memory:");
+      console.log(`    User Preferences: ${mem.sections["User Preferences"].length}`);
+      console.log(`    Key Learnings: ${mem.sections["Key Learnings"].length}`);
+      console.log(`    Do-Not-Repeat: ${mem.sections["Do-Not-Repeat"].length}`);
+      console.log(`    Decision Log: ${mem.sections["Decision Log"].length}`);
+      console.log(`    Total entries: ${total}`);
+      console.log(`    Last modified: ${mtime.toISOString()}`);
+    } else {
+      console.log("  Learning memory: not initialized");
+    }
+  } catch {
+    console.log("  Learning memory: error reading");
+  }
+  console.log();
+
+  // Section 5: Bug log
+  try {
+    const bugs = loadBugMemory(bugMemoryPath(cwd));
+    console.log(`  Bug log: ${bugs.entries.length} entries`);
+  } catch {
+    console.log("  Bug log: error reading");
+  }
+  console.log();
+
+  // Section 6: Daemon status
+  try {
+    const daemon = getDaemonStatus(cwd);
+    if (daemon.running) {
+      const uptimeMs = Date.now() - new Date(daemon.startedAt!).getTime();
+      const uptimeMin = Math.floor(uptimeMs / 60_000);
+      const uptimeHrs = Math.floor(uptimeMin / 60);
+      const uptimeStr = uptimeHrs > 0
+        ? `${uptimeHrs}h ${uptimeMin % 60}m`
+        : `${uptimeMin}m`;
+      console.log(`  Daemon: running (PID: ${daemon.pid}, uptime: ${uptimeStr})`);
+    } else {
+      console.log("  Daemon: stopped");
+    }
+  } catch {
+    console.log("  Daemon: unknown");
+  }
+}

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,121 @@
+import { resolve, dirname, basename } from "path";
+import { existsSync } from "fs";
+import { listRegisteredProjects } from "../core/project-registry";
+import { createBackup } from "../core/backup";
+import { projectMetaPath } from "../core/paths";
+import { atomicWriteJson, safeReadJson } from "../core/fs-utils";
+import { buildHooksConfig, detectRuntime, mergeHooksIntoSettings } from "./init";
+
+function parseArgs(args: string[]): {
+  dryRun: boolean;
+  project: string | null;
+  list: boolean;
+} {
+  let dryRun = false;
+  let project: string | null = null;
+  let list = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--dry-run") dryRun = true;
+    else if (args[i] === "--list") list = true;
+    else if (args[i] === "--project" && i + 1 < args.length) {
+      project = args[++i];
+    }
+  }
+
+  return { dryRun, project, list };
+}
+
+export async function update(cwd: string, args: string[]): Promise<void> {
+  const { dryRun, project, list } = parseArgs(args);
+
+  const registered = listRegisteredProjects();
+
+  if (list) {
+    if (registered.length === 0) {
+      console.log("[mink] no registered projects found");
+      console.log("  Run 'mink init' in a project directory to register it.");
+      return;
+    }
+    console.log("[mink] registered projects:");
+    console.log(
+      "  " +
+        "ID".padEnd(30) +
+        "Name".padEnd(20) +
+        "Version".padEnd(12) +
+        "Path"
+    );
+    console.log("  " + "-".repeat(80));
+    for (const p of registered) {
+      console.log(
+        "  " +
+          p.id.padEnd(30) +
+          p.name.padEnd(20) +
+          p.version.padEnd(12) +
+          p.cwd
+      );
+    }
+    return;
+  }
+
+  let targets = registered;
+  if (project) {
+    targets = registered.filter(
+      (p) => p.name === project || p.id === project
+    );
+    if (targets.length === 0) {
+      console.error(`[mink] project not found: ${project}`);
+      console.error(
+        "  Available: " + registered.map((p) => p.name).join(", ")
+      );
+      process.exit(1);
+    }
+  }
+
+  if (targets.length === 0) {
+    console.log("[mink] no registered projects found");
+    console.log("  Run 'mink init' in a project directory to register it.");
+    return;
+  }
+
+  const runtime = detectRuntime();
+  const cliPath = resolve(
+    dirname(new URL(import.meta.url).pathname),
+    "../cli.ts"
+  );
+  const newHooks = buildHooksConfig(runtime, cliPath);
+
+  for (const target of targets) {
+    console.log(`[mink] updating: ${target.name} (${target.id})`);
+
+    if (dryRun) {
+      console.log("  [dry-run] would update hooks and project metadata");
+      console.log(`  [dry-run] would create backup before changes`);
+      continue;
+    }
+
+    // Create backup
+    const backupName = createBackup(target.cwd);
+    console.log(`  backup: ${backupName}`);
+
+    // Update hooks
+    const settingsPath = resolve(target.cwd, ".claude", "settings.json");
+    mergeHooksIntoSettings(settingsPath, newHooks);
+    console.log("  hooks: updated");
+
+    // Update project meta
+    const metaPath = projectMetaPath(target.cwd);
+    const existing = safeReadJson(metaPath) as Record<string, unknown> | null;
+    atomicWriteJson(metaPath, {
+      ...(existing ?? {}),
+      cwd: target.cwd,
+      name: target.name,
+      version: "0.1.0",
+    });
+    console.log("  metadata: updated");
+  }
+
+  if (!dryRun) {
+    console.log(`[mink] ${targets.length} project(s) updated`);
+  }
+}

--- a/src/core/backup.ts
+++ b/src/core/backup.ts
@@ -1,0 +1,110 @@
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  statSync,
+} from "fs";
+import { join } from "path";
+import { projectDir, backupDirPath } from "./paths";
+import type { BackupInfo } from "../types/backup";
+
+function formatTimestamp(date: Date): string {
+  const y = date.getFullYear();
+  const mo = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  const h = String(date.getHours()).padStart(2, "0");
+  const mi = String(date.getMinutes()).padStart(2, "0");
+  const s = String(date.getSeconds()).padStart(2, "0");
+  const ms = String(date.getMilliseconds()).padStart(3, "0");
+  return `${y}${mo}${d}-${h}${mi}${s}${ms}`;
+}
+
+function copyDirectoryFiles(
+  srcDir: string,
+  destDir: string,
+  excludeDirs: string[]
+): void {
+  mkdirSync(destDir, { recursive: true });
+  const entries = readdirSync(srcDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (excludeDirs.includes(entry.name)) continue;
+      copyDirectoryFiles(
+        join(srcDir, entry.name),
+        join(destDir, entry.name),
+        excludeDirs
+      );
+    } else if (entry.isFile()) {
+      writeFileSync(
+        join(destDir, entry.name),
+        readFileSync(join(srcDir, entry.name))
+      );
+    }
+  }
+}
+
+export function createBackup(cwd: string): string {
+  const name = `backup-${formatTimestamp(new Date())}`;
+  const src = projectDir(cwd);
+  const dest = join(backupDirPath(cwd), name);
+  copyDirectoryFiles(src, dest, ["backups"]);
+  return name;
+}
+
+export function listBackups(cwd: string): BackupInfo[] {
+  const dir = backupDirPath(cwd);
+  if (!existsSync(dir)) return [];
+
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const backups: BackupInfo[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith("backup-")) continue;
+
+    const backupPath = join(dir, entry.name);
+    const match = entry.name.match(
+      /^backup-(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})(\d{3})?$/
+    );
+    let timestamp: Date;
+    if (match) {
+      timestamp = new Date(
+        parseInt(match[1]),
+        parseInt(match[2]) - 1,
+        parseInt(match[3]),
+        parseInt(match[4]),
+        parseInt(match[5]),
+        parseInt(match[6]),
+        match[7] ? parseInt(match[7]) : 0
+      );
+    } else {
+      timestamp = statSync(backupPath).mtime;
+    }
+
+    let fileCount = 0;
+    try {
+      fileCount = readdirSync(backupPath).length;
+    } catch {
+      // ignore
+    }
+
+    backups.push({ name: entry.name, timestamp, path: backupPath, fileCount });
+  }
+
+  backups.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+  return backups;
+}
+
+export function restoreBackup(cwd: string, backupName: string): void {
+  const backupPath = join(backupDirPath(cwd), backupName);
+  if (!existsSync(backupPath)) {
+    throw new Error(`backup not found: ${backupName}`);
+  }
+
+  // Create a safety backup before restoring
+  createBackup(cwd);
+
+  // Copy files from backup to project dir, excluding backups/
+  copyDirectoryFiles(backupPath, projectDir(cwd), ["backups"]);
+}

--- a/src/core/global-config.ts
+++ b/src/core/global-config.ts
@@ -1,0 +1,74 @@
+import { globalConfigPath } from "./paths";
+import { safeReadJson, atomicWriteJson } from "./fs-utils";
+import {
+  CONFIG_KEYS,
+  isValidConfigKey,
+  getConfigKeyMeta,
+  type GlobalConfig,
+  type ConfigKey,
+} from "../types/config";
+
+export function loadGlobalConfig(): GlobalConfig {
+  const raw = safeReadJson(globalConfigPath());
+  if (raw === null) return {};
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    console.warn("[mink] warning: corrupt config file at " + globalConfigPath());
+    return {};
+  }
+  return raw as GlobalConfig;
+}
+
+export function saveGlobalConfig(config: GlobalConfig): void {
+  atomicWriteJson(globalConfigPath(), config);
+}
+
+export interface ResolvedValue {
+  value: string;
+  source: "default" | "config file" | "environment variable";
+  configFileValue?: string;
+}
+
+export function resolveConfigValue(key: ConfigKey): ResolvedValue {
+  const meta = getConfigKeyMeta(key);
+  const config = loadGlobalConfig();
+
+  const envValue = process.env[meta.envVar];
+  const fileValue = config[key];
+
+  if (envValue !== undefined && envValue !== "") {
+    return {
+      value: envValue,
+      source: "environment variable",
+      configFileValue: fileValue,
+    };
+  }
+
+  if (fileValue !== undefined) {
+    return { value: fileValue, source: "config file" };
+  }
+
+  return { value: meta.default, source: "default" };
+}
+
+export function resolveAllConfig(): Array<ResolvedValue & { key: ConfigKey }> {
+  return CONFIG_KEYS.map((meta) => ({
+    key: meta.key,
+    ...resolveConfigValue(meta.key),
+  }));
+}
+
+export function setConfigValue(key: ConfigKey, value: string): void {
+  const config = loadGlobalConfig();
+  config[key] = value;
+  saveGlobalConfig(config);
+}
+
+export function resetConfigKey(key: ConfigKey): void {
+  const config = loadGlobalConfig();
+  delete config[key];
+  saveGlobalConfig(config);
+}
+
+export function resetAllConfig(): void {
+  saveGlobalConfig({});
+}

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -56,3 +56,15 @@ export function schedulerLogPath(): string {
 export function schedulerManifestPath(cwd: string): string {
   return join(projectDir(cwd), "scheduler-manifest.json");
 }
+
+export function globalConfigPath(): string {
+  return join(MINK_ROOT, "config");
+}
+
+export function projectMetaPath(cwd: string): string {
+  return join(projectDir(cwd), "project-meta.json");
+}
+
+export function backupDirPath(cwd: string): string {
+  return join(projectDir(cwd), "backups");
+}

--- a/src/core/project-registry.ts
+++ b/src/core/project-registry.ts
@@ -1,0 +1,64 @@
+import { readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { minkRoot } from "./paths";
+import { safeReadJson } from "./fs-utils";
+
+export interface ProjectMeta {
+  cwd: string;
+  name: string;
+  initTimestamp: string;
+  version: string;
+}
+
+export interface RegisteredProject {
+  id: string;
+  cwd: string;
+  name: string;
+  version: string;
+}
+
+export function getProjectMeta(projDir: string): ProjectMeta | null {
+  const metaPath = join(projDir, "project-meta.json");
+  const raw = safeReadJson(metaPath);
+  if (
+    raw === null ||
+    typeof raw !== "object" ||
+    Array.isArray(raw)
+  ) {
+    return null;
+  }
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.cwd !== "string" || typeof obj.name !== "string") {
+    return null;
+  }
+  return {
+    cwd: obj.cwd as string,
+    name: obj.name as string,
+    initTimestamp: (obj.initTimestamp as string) ?? "",
+    version: (obj.version as string) ?? "0.1.0",
+  };
+}
+
+export function listRegisteredProjects(): RegisteredProject[] {
+  const projectsDir = join(minkRoot(), "projects");
+  if (!existsSync(projectsDir)) return [];
+
+  const entries = readdirSync(projectsDir, { withFileTypes: true });
+  const projects: RegisteredProject[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const projDir = join(projectsDir, entry.name);
+    const meta = getProjectMeta(projDir);
+    if (meta) {
+      projects.push({
+        id: entry.name,
+        cwd: meta.cwd,
+        name: meta.name,
+        version: meta.version,
+      });
+    }
+  }
+
+  return projects;
+}

--- a/src/types/backup.ts
+++ b/src/types/backup.ts
@@ -1,0 +1,6 @@
+export interface BackupInfo {
+  name: string;
+  timestamp: Date;
+  path: string;
+  fileCount: number;
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,0 +1,59 @@
+export interface GlobalConfig {
+  "wiki.path"?: string;
+  "wiki.enabled"?: string;
+  "wiki.sync-mode"?: string;
+  "wiki.git-backup"?: string;
+  "wiki.git-remote"?: string;
+}
+
+export type ConfigKey = keyof GlobalConfig & string;
+
+export interface ConfigKeyMeta {
+  key: ConfigKey;
+  default: string;
+  envVar: string;
+  description: string;
+}
+
+export const CONFIG_KEYS: ConfigKeyMeta[] = [
+  {
+    key: "wiki.path",
+    default: "~/.mink/wiki/",
+    envVar: "MINK_WIKI_PATH",
+    description: "Wiki vault location",
+  },
+  {
+    key: "wiki.enabled",
+    default: "true",
+    envVar: "MINK_WIKI_ENABLED",
+    description: "Enable/disable the wiki feature",
+  },
+  {
+    key: "wiki.sync-mode",
+    default: "immediate",
+    envVar: "MINK_WIKI_SYNC_MODE",
+    description: "Sync mode: immediate or batched",
+  },
+  {
+    key: "wiki.git-backup",
+    default: "false",
+    envVar: "MINK_WIKI_GIT_BACKUP",
+    description: "Enable/disable auto-commit and push",
+  },
+  {
+    key: "wiki.git-remote",
+    default: "origin",
+    envVar: "MINK_WIKI_GIT_REMOTE",
+    description: "Git remote name for push",
+  },
+];
+
+const VALID_KEYS = new Set<string>(CONFIG_KEYS.map((k) => k.key));
+
+export function isValidConfigKey(key: string): key is ConfigKey {
+  return VALID_KEYS.has(key);
+}
+
+export function getConfigKeyMeta(key: ConfigKey): ConfigKeyMeta {
+  return CONFIG_KEYS.find((k) => k.key === key)!;
+}

--- a/tests/integration/config.test.ts
+++ b/tests/integration/config.test.ts
@@ -1,0 +1,122 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { rmSync, existsSync, readFileSync } from "fs";
+import {
+  loadGlobalConfig,
+  saveGlobalConfig,
+  resolveConfigValue,
+  resolveAllConfig,
+  setConfigValue,
+  resetConfigKey,
+  resetAllConfig,
+} from "../../src/core/global-config";
+import { globalConfigPath } from "../../src/core/paths";
+import { CONFIG_KEYS } from "../../src/types/config";
+
+describe("config integration", () => {
+  let savedConfig: string | null = null;
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    // Save existing config
+    try {
+      savedConfig = readFileSync(globalConfigPath(), "utf-8");
+    } catch {
+      savedConfig = null;
+    }
+    // Clear env vars
+    for (const meta of CONFIG_KEYS) {
+      originalEnv[meta.envVar] = process.env[meta.envVar];
+      delete process.env[meta.envVar];
+    }
+    // Start with clean config
+    resetAllConfig();
+  });
+
+  afterEach(() => {
+    // Restore original config
+    if (savedConfig !== null) {
+      const { mkdirSync, writeFileSync } = require("fs");
+      const { dirname } = require("path");
+      mkdirSync(dirname(globalConfigPath()), { recursive: true });
+      writeFileSync(globalConfigPath(), savedConfig);
+    } else {
+      try {
+        rmSync(globalConfigPath(), { force: true });
+      } catch {}
+    }
+    // Restore env vars
+    for (const meta of CONFIG_KEYS) {
+      if (originalEnv[meta.envVar] === undefined) {
+        delete process.env[meta.envVar];
+      } else {
+        process.env[meta.envVar] = originalEnv[meta.envVar];
+      }
+    }
+  });
+
+  test("set and get wiki.path", () => {
+    setConfigValue("wiki.path", "/custom/wiki");
+    const result = resolveConfigValue("wiki.path");
+    expect(result.value).toBe("/custom/wiki");
+    expect(result.source).toBe("config file");
+  });
+
+  test("reset key reverts to default", () => {
+    setConfigValue("wiki.path", "/custom/wiki");
+    resetConfigKey("wiki.path");
+    const result = resolveConfigValue("wiki.path");
+    expect(result.value).toBe("~/.mink/wiki/");
+    expect(result.source).toBe("default");
+  });
+
+  test("env var overrides config file", () => {
+    setConfigValue("wiki.path", "/config/wiki");
+    process.env.MINK_WIKI_PATH = "/env/wiki";
+    const result = resolveConfigValue("wiki.path");
+    expect(result.value).toBe("/env/wiki");
+    expect(result.source).toBe("environment variable");
+    expect(result.configFileValue).toBe("/config/wiki");
+  });
+
+  test("resolveAllConfig shows all settings with defaults", () => {
+    const all = resolveAllConfig();
+    expect(all.length).toBe(5);
+    const byKey = Object.fromEntries(all.map((a) => [a.key, a]));
+    expect(byKey["wiki.path"].source).toBe("default");
+    expect(byKey["wiki.enabled"].value).toBe("true");
+    expect(byKey["wiki.sync-mode"].value).toBe("immediate");
+    expect(byKey["wiki.git-backup"].value).toBe("false");
+    expect(byKey["wiki.git-remote"].value).toBe("origin");
+  });
+
+  test("resetAllConfig clears all values", () => {
+    setConfigValue("wiki.path", "/a");
+    setConfigValue("wiki.enabled", "false");
+    resetAllConfig();
+    const config = loadGlobalConfig();
+    expect(Object.keys(config).length).toBe(0);
+    const result = resolveConfigValue("wiki.path");
+    expect(result.source).toBe("default");
+  });
+
+  test("loadGlobalConfig handles corrupt file", () => {
+    const { mkdirSync, writeFileSync } = require("fs");
+    const { dirname } = require("path");
+    mkdirSync(dirname(globalConfigPath()), { recursive: true });
+    writeFileSync(globalConfigPath(), "not valid json{{{");
+
+    const config = loadGlobalConfig();
+    expect(Object.keys(config).length).toBe(0);
+  });
+
+  test("config file created automatically on set", () => {
+    try {
+      rmSync(globalConfigPath(), { force: true });
+    } catch {}
+
+    setConfigValue("wiki.path", "/new/path");
+    expect(existsSync(globalConfigPath())).toBe(true);
+    const result = resolveConfigValue("wiki.path");
+    expect(result.value).toBe("/new/path");
+  });
+});

--- a/tests/integration/restore.test.ts
+++ b/tests/integration/restore.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  readFileSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { projectDir } from "../../src/core/paths";
+import { createBackup, listBackups, restoreBackup } from "../../src/core/backup";
+
+function createTempProject(): string {
+  const name = `mink-restore-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const dir = join(tmpdir(), name);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("restore integration", () => {
+  let testCwd: string;
+
+  beforeEach(() => {
+    testCwd = createTempProject();
+    const stateDir = projectDir(testCwd);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, "file-index.json"), '{"version":"original"}');
+    writeFileSync(join(stateDir, "learning-memory.md"), "# Original");
+  });
+
+  afterEach(() => {
+    rmSync(testCwd, { recursive: true, force: true });
+    try {
+      rmSync(projectDir(testCwd), { recursive: true, force: true });
+    } catch {}
+  });
+
+  test("full backup and restore round-trip", () => {
+    // Create backup of original state
+    const backupName = createBackup(testCwd);
+
+    // Modify state
+    const stateDir = projectDir(testCwd);
+    writeFileSync(join(stateDir, "file-index.json"), '{"version":"modified"}');
+    writeFileSync(join(stateDir, "learning-memory.md"), "# Modified");
+
+    // Verify modification
+    expect(
+      readFileSync(join(stateDir, "file-index.json"), "utf-8")
+    ).toContain("modified");
+
+    // Restore
+    restoreBackup(testCwd, backupName);
+
+    // Verify original is back
+    expect(
+      readFileSync(join(stateDir, "file-index.json"), "utf-8")
+    ).toContain("original");
+    expect(
+      readFileSync(join(stateDir, "learning-memory.md"), "utf-8")
+    ).toContain("Original");
+  });
+
+  test("list backups shows available backups", () => {
+    const name1 = createBackup(testCwd);
+    const name2 = createBackup(testCwd);
+
+    const backups = listBackups(testCwd);
+    expect(backups.length).toBeGreaterThanOrEqual(2);
+
+    const names = backups.map((b) => b.name);
+    expect(names).toContain(name1);
+    expect(names).toContain(name2);
+  });
+
+  test("restore nonexistent backup fails", () => {
+    expect(() => restoreBackup(testCwd, "backup-doesnotexist")).toThrow();
+  });
+});

--- a/tests/integration/status.test.ts
+++ b/tests/integration/status.test.ts
@@ -1,0 +1,135 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { projectDir } from "../../src/core/paths";
+import { status } from "../../src/commands/status";
+
+function createTempProject(): string {
+  const name = `mink-status-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const dir = join(tmpdir(), name);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("status command", () => {
+  let testCwd: string;
+  let logs: string[];
+
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+
+  beforeEach(() => {
+    testCwd = createTempProject();
+    logs = [];
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+    console.warn = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    rmSync(testCwd, { recursive: true, force: true });
+    try {
+      rmSync(projectDir(testCwd), { recursive: true, force: true });
+    } catch {}
+  });
+
+  test("shows status for initialized project", () => {
+    const stateDir = projectDir(testCwd);
+    mkdirSync(stateDir, { recursive: true });
+
+    // Create all required state files
+    writeFileSync(
+      join(stateDir, "session.json"),
+      JSON.stringify({ sessionId: "test", reads: {}, writes: [] })
+    );
+    writeFileSync(
+      join(stateDir, "file-index.json"),
+      JSON.stringify({
+        header: {
+          lastScanTimestamp: "2024-01-01T00:00:00.000Z",
+          totalFiles: 42,
+          lifetimeHits: 100,
+          lifetimeMisses: 10,
+        },
+        entries: {},
+      })
+    );
+    writeFileSync(join(stateDir, "config.json"), "{}");
+    writeFileSync(
+      join(stateDir, "learning-memory.md"),
+      "# Learning Memory — test\n\n## User Preferences\n- pref1\n\n## Key Learnings\n- learn1\n- learn2\n\n## Do-Not-Repeat\n\n## Decision Log\n- dec1\n"
+    );
+    writeFileSync(
+      join(stateDir, "token-ledger.json"),
+      JSON.stringify({
+        lifetime: {
+          totalTokens: 5000,
+          totalReads: 100,
+          totalWrites: 50,
+          totalSessions: 3,
+          totalFileIndexHits: 80,
+          totalFileIndexMisses: 20,
+          totalRepeatedReads: 5,
+          totalEstimatedSavings: 1500,
+        },
+        sessions: [],
+      })
+    );
+    writeFileSync(
+      join(stateDir, "bug-memory.json"),
+      JSON.stringify({ entries: [{ id: "bug-001" }], nextId: 2 })
+    );
+    writeFileSync(join(stateDir, "action-log.md"), "# Action Log\n");
+
+    status(testCwd);
+
+    const output = logs.join("\n");
+    expect(output).toContain("[mink] project status");
+    expect(output).toContain("session.json: ok");
+    expect(output).toContain("file-index.json: ok");
+    expect(output).toContain("Files: 42");
+    expect(output).toContain("Sessions: 3");
+    expect(output).toContain("5,000");
+    expect(output).toContain("1,500");
+    expect(output).toContain("User Preferences: 1");
+    expect(output).toContain("Key Learnings: 2");
+    expect(output).toContain("Decision Log: 1");
+    expect(output).toContain("1 entries");
+    expect(output).toContain("Daemon: stopped");
+  });
+
+  test("handles missing state files gracefully", () => {
+    const stateDir = projectDir(testCwd);
+    mkdirSync(stateDir, { recursive: true });
+    // Don't create any files
+
+    status(testCwd);
+
+    const output = logs.join("\n");
+    expect(output).toContain("[mink] project status");
+    expect(output).toContain("missing");
+  });
+
+  test("handles corrupt files gracefully", () => {
+    const stateDir = projectDir(testCwd);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, "file-index.json"), "not json{{{");
+    writeFileSync(join(stateDir, "token-ledger.json"), "corrupt");
+
+    status(testCwd);
+
+    const output = logs.join("\n");
+    expect(output).toContain("corrupt");
+  });
+});

--- a/tests/integration/update.test.ts
+++ b/tests/integration/update.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { projectDir, projectMetaPath, minkRoot } from "../../src/core/paths";
+import { listRegisteredProjects } from "../../src/core/project-registry";
+import { atomicWriteJson } from "../../src/core/fs-utils";
+
+function createTempProject(): string {
+  const name = `mink-update-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const dir = join(tmpdir(), name);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("project registry", () => {
+  let testCwd: string;
+
+  beforeEach(() => {
+    testCwd = createTempProject();
+  });
+
+  afterEach(() => {
+    rmSync(testCwd, { recursive: true, force: true });
+    try {
+      rmSync(projectDir(testCwd), { recursive: true, force: true });
+    } catch {}
+  });
+
+  test("listRegisteredProjects finds projects with meta", () => {
+    const stateDir = projectDir(testCwd);
+    mkdirSync(stateDir, { recursive: true });
+    atomicWriteJson(join(stateDir, "project-meta.json"), {
+      cwd: testCwd,
+      name: "test-project",
+      initTimestamp: "2024-01-01T00:00:00.000Z",
+      version: "0.1.0",
+    });
+
+    const projects = listRegisteredProjects();
+    const found = projects.find((p) => p.cwd === testCwd);
+    expect(found).toBeDefined();
+    expect(found!.name).toBe("test-project");
+    expect(found!.version).toBe("0.1.0");
+  });
+
+  test("listRegisteredProjects skips dirs without meta", () => {
+    const stateDir = projectDir(testCwd);
+    mkdirSync(stateDir, { recursive: true });
+    // Don't write project-meta.json
+
+    const projects = listRegisteredProjects();
+    const found = projects.find((p) => p.cwd === testCwd);
+    expect(found).toBeUndefined();
+  });
+});

--- a/tests/unit/backup.test.ts
+++ b/tests/unit/backup.test.ts
@@ -1,0 +1,126 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// Since backup.ts uses projectDir(cwd) and backupDirPath(cwd) which hash the cwd,
+// we test the internal helpers by creating a realistic project state directory.
+
+import { createBackup, listBackups, restoreBackup } from "../../src/core/backup";
+import { projectDir, backupDirPath } from "../../src/core/paths";
+
+function createTempProject(): string {
+  const name = `mink-backup-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const dir = join(tmpdir(), name);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("backup", () => {
+  let testCwd: string;
+
+  beforeEach(() => {
+    testCwd = createTempProject();
+    // Create a fake project state directory
+    const stateDir = projectDir(testCwd);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, "file-index.json"), '{"header":{},"entries":{}}');
+    writeFileSync(join(stateDir, "token-ledger.json"), '{"lifetime":{},"sessions":[]}');
+    writeFileSync(join(stateDir, "config.json"), "{}");
+  });
+
+  afterEach(() => {
+    rmSync(testCwd, { recursive: true, force: true });
+    // Clean up state dir
+    try {
+      rmSync(projectDir(testCwd), { recursive: true, force: true });
+    } catch {}
+  });
+
+  test("createBackup copies files to backup directory", () => {
+    const name = createBackup(testCwd);
+    expect(name).toMatch(/^backup-\d{8}-\d{9}$/);
+
+    const backupPath = join(backupDirPath(testCwd), name);
+    expect(existsSync(backupPath)).toBe(true);
+    expect(existsSync(join(backupPath, "file-index.json"))).toBe(true);
+    expect(existsSync(join(backupPath, "token-ledger.json"))).toBe(true);
+    expect(existsSync(join(backupPath, "config.json"))).toBe(true);
+  });
+
+  test("createBackup excludes backups/ subdirectory", () => {
+    // Create first backup
+    createBackup(testCwd);
+    // Create second backup — should NOT contain the backups/ dir from first
+    const name2 = createBackup(testCwd);
+    const backupPath = join(backupDirPath(testCwd), name2);
+    expect(existsSync(join(backupPath, "backups"))).toBe(false);
+  });
+
+  test("listBackups returns sorted backups", () => {
+    createBackup(testCwd);
+    // Slight delay to get different timestamp
+    const name2 = createBackup(testCwd);
+
+    const backups = listBackups(testCwd);
+    expect(backups.length).toBeGreaterThanOrEqual(2);
+    // Most recent should be first
+    expect(backups[0].name).toBe(name2);
+  });
+
+  test("listBackups returns empty for no backups", () => {
+    const freshCwd = createTempProject();
+    const stateDir = projectDir(freshCwd);
+    mkdirSync(stateDir, { recursive: true });
+
+    const backups = listBackups(freshCwd);
+    expect(backups.length).toBe(0);
+
+    rmSync(freshCwd, { recursive: true, force: true });
+    try { rmSync(stateDir, { recursive: true, force: true }); } catch {}
+  });
+
+  test("restoreBackup restores files", () => {
+    const name = createBackup(testCwd);
+
+    // Modify the current state
+    const stateDir = projectDir(testCwd);
+    writeFileSync(join(stateDir, "file-index.json"), '{"modified":true}');
+
+    // Restore
+    restoreBackup(testCwd, name);
+
+    // Verify original content is back
+    const content = readFileSync(join(stateDir, "file-index.json"), "utf-8");
+    expect(content).toBe('{"header":{},"entries":{}}');
+  });
+
+  test("restoreBackup throws for nonexistent backup", () => {
+    expect(() => restoreBackup(testCwd, "backup-nonexistent")).toThrow(
+      "backup not found"
+    );
+  });
+
+  test("restoreBackup creates safety backup before restoring", () => {
+    const name = createBackup(testCwd);
+
+    // Modify state
+    writeFileSync(
+      join(projectDir(testCwd), "file-index.json"),
+      '{"modified":true}'
+    );
+
+    restoreBackup(testCwd, name);
+
+    // Should now have at least 2 backups (original + safety)
+    const backups = listBackups(testCwd);
+    expect(backups.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tests/unit/daemon-command.test.ts
+++ b/tests/unit/daemon-command.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { schedulerLogPath } from "../../src/core/paths";
+
+describe("daemon logs", () => {
+  // Since the daemon command reads from schedulerLogPath() (a fixed location),
+  // we test the file reading logic by writing to that path.
+
+  const logPath = schedulerLogPath();
+  let hadExistingLog = false;
+  let existingContent = "";
+
+  beforeEach(() => {
+    // Save any existing log file
+    try {
+      const { readFileSync } = require("fs");
+      existingContent = readFileSync(logPath, "utf-8");
+      hadExistingLog = true;
+    } catch {
+      hadExistingLog = false;
+    }
+  });
+
+  afterEach(() => {
+    // Restore original state
+    if (hadExistingLog) {
+      writeFileSync(logPath, existingContent);
+    } else {
+      try {
+        rmSync(logPath, { force: true });
+      } catch {}
+    }
+  });
+
+  test("reads last 50 lines from log file", () => {
+    const { dirname } = require("path");
+    mkdirSync(dirname(logPath), { recursive: true });
+
+    // Write 100 lines
+    const lines = Array.from({ length: 100 }, (_, i) => `line-${i + 1}`);
+    writeFileSync(logPath, lines.join("\n"));
+
+    // Read file and verify we'd get last 50
+    const { readFileSync } = require("fs");
+    const content = readFileSync(logPath, "utf-8");
+    const allLines = content.split("\n");
+    const tail = allLines.slice(-50);
+    expect(tail.length).toBe(50);
+    expect(tail[0]).toBe("line-51");
+    expect(tail[49]).toBe("line-100");
+  });
+
+  test("handles missing log file gracefully", () => {
+    try {
+      rmSync(logPath, { force: true });
+    } catch {}
+
+    expect(existsSync(logPath)).toBe(false);
+    // The daemon command would print "[mink] no log file found"
+    // Just verify the file doesn't exist and we don't crash
+  });
+});

--- a/tests/unit/global-config.test.ts
+++ b/tests/unit/global-config.test.ts
@@ -1,0 +1,157 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// We test global-config by manipulating a temp directory
+// Since global-config uses paths.ts which uses homedir(), we'll test the
+// underlying logic by importing and calling functions with controlled state
+
+import {
+  loadGlobalConfig,
+  saveGlobalConfig,
+  resolveConfigValue,
+  resolveAllConfig,
+  setConfigValue,
+  resetConfigKey,
+  resetAllConfig,
+} from "../../src/core/global-config";
+import { globalConfigPath } from "../../src/core/paths";
+import { CONFIG_KEYS, isValidConfigKey } from "../../src/types/config";
+
+describe("config types", () => {
+  test("isValidConfigKey accepts valid keys", () => {
+    expect(isValidConfigKey("wiki.path")).toBe(true);
+    expect(isValidConfigKey("wiki.enabled")).toBe(true);
+    expect(isValidConfigKey("wiki.sync-mode")).toBe(true);
+    expect(isValidConfigKey("wiki.git-backup")).toBe(true);
+    expect(isValidConfigKey("wiki.git-remote")).toBe(true);
+  });
+
+  test("isValidConfigKey rejects invalid keys", () => {
+    expect(isValidConfigKey("invalid.key")).toBe(false);
+    expect(isValidConfigKey("")).toBe(false);
+    expect(isValidConfigKey("wiki")).toBe(false);
+  });
+
+  test("CONFIG_KEYS has 5 entries", () => {
+    expect(CONFIG_KEYS.length).toBe(5);
+  });
+
+  test("each CONFIG_KEY has required fields", () => {
+    for (const meta of CONFIG_KEYS) {
+      expect(meta.key).toBeTruthy();
+      expect(meta.default).toBeDefined();
+      expect(meta.envVar).toBeTruthy();
+      expect(meta.description).toBeTruthy();
+    }
+  });
+});
+
+describe("loadGlobalConfig", () => {
+  const configDir = join(tmpdir(), `mink-config-test-${Date.now()}`);
+
+  beforeEach(() => {
+    mkdirSync(configDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  test("returns empty object when file missing", () => {
+    // loadGlobalConfig reads from globalConfigPath() which is ~/.mink/config
+    // We can't easily redirect that, so we test resolveConfigValue defaults
+    const result = resolveConfigValue("wiki.path");
+    expect(result.source).toBe("default");
+    expect(result.value).toBe("~/.mink/wiki/");
+  });
+});
+
+describe("resolveConfigValue", () => {
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    // Save original env vars
+    for (const meta of CONFIG_KEYS) {
+      originalEnv[meta.envVar] = process.env[meta.envVar];
+    }
+  });
+
+  afterEach(() => {
+    // Restore original env vars
+    for (const meta of CONFIG_KEYS) {
+      if (originalEnv[meta.envVar] === undefined) {
+        delete process.env[meta.envVar];
+      } else {
+        process.env[meta.envVar] = originalEnv[meta.envVar];
+      }
+    }
+  });
+
+  test("returns default values when nothing is set", () => {
+    // Clear any env vars
+    for (const meta of CONFIG_KEYS) {
+      delete process.env[meta.envVar];
+    }
+
+    const result = resolveConfigValue("wiki.path");
+    expect(result.value).toBe("~/.mink/wiki/");
+    expect(result.source).toBe("default");
+  });
+
+  test("env var takes priority over default", () => {
+    process.env.MINK_WIKI_PATH = "/tmp/test-wiki";
+    const result = resolveConfigValue("wiki.path");
+    expect(result.value).toBe("/tmp/test-wiki");
+    expect(result.source).toBe("environment variable");
+  });
+
+  test("resolveAllConfig returns all keys", () => {
+    for (const meta of CONFIG_KEYS) {
+      delete process.env[meta.envVar];
+    }
+    const all = resolveAllConfig();
+    expect(all.length).toBe(5);
+    for (const entry of all) {
+      expect(entry.key).toBeTruthy();
+      expect(entry.value).toBeDefined();
+      expect(entry.source).toBeTruthy();
+    }
+  });
+
+  test("defaults are correct", () => {
+    for (const meta of CONFIG_KEYS) {
+      delete process.env[meta.envVar];
+    }
+    const all = resolveAllConfig();
+    const byKey = Object.fromEntries(all.map((a) => [a.key, a]));
+
+    expect(byKey["wiki.path"].value).toBe("~/.mink/wiki/");
+    expect(byKey["wiki.enabled"].value).toBe("true");
+    expect(byKey["wiki.sync-mode"].value).toBe("immediate");
+    expect(byKey["wiki.git-backup"].value).toBe("false");
+    expect(byKey["wiki.git-remote"].value).toBe("origin");
+  });
+});
+
+describe("saveGlobalConfig / setConfigValue / resetConfigKey", () => {
+  test("setConfigValue and resetConfigKey round-trip", () => {
+    // Set a value
+    setConfigValue("wiki.path", "/my/wiki");
+    const resolved = resolveConfigValue("wiki.path");
+    // It should be either from config file or default depending on file state
+    // Since we're writing to the real ~/.mink/config, just verify no crash
+    expect(resolved.value).toBeDefined();
+
+    // Reset
+    resetConfigKey("wiki.path");
+  });
+
+  test("resetAllConfig clears everything", () => {
+    setConfigValue("wiki.path", "/tmp/reset-test");
+    resetAllConfig();
+    const config = loadGlobalConfig();
+    expect(Object.keys(config).length).toBe(0);
+  });
+});


### PR DESCRIPTION
Add all missing CLI commands specified in spec 11:
- `mink status` — project health dashboard aggregating all state files
- `mink config` — global settings management with env var overrides
- `mink daemon` — direct daemon control (start/stop/restart/logs)
- `mink update` — multi-project update with backup safety
- `mink restore` — state recovery from timestamped backups
- `mink bug search` — subcommand alias for bug-search
- `mink designqc` — placeholder for spec 13
- `mink help` — comprehensive command listing

Also adds:
- Backup infrastructure (create/list/restore with millisecond timestamps)
- Global config system (wiki.* keys, env var priority, reset support)
- Project registry for cross-project operations
- Init upgrade path with automatic backup before changes
- Project metadata tracking (project-meta.json)

All 647 tests pass (35 new tests for config, backup, status, restore, update).

https://claude.ai/code/session_018XQDnhTZwFCGHWvY7DiNTV