### PR TITLE
fix: configure release-please for 0.x versioning

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,8 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
- Add `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` to release-please config
- This keeps versions at `0.x` while pre-1.0: `feat:` → 0.minor bump, `fix:` → 0.0.patch bump
- Closed PR #13 (which targeted 1.0.0) — release-please will recreate a Release PR targeting 0.1.0 after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)