### PR TITLE
fix: set release-please baseline to start at 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
       "release-type": "node",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "last-release-sha": "516d3bef7a089713fd87e29523f217a74da35bb9",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
- Set `last-release-sha` in release-please config to current main HEAD
- This tells release-please to ignore all pre-existing commits when computing the next version
- Without this, release-please sees all the historical `feat:` commits and bumps to 1.0.0 despite the `bump-minor-pre-major` setting

After this merges, the next commit with a conventional prefix (e.g. `feat:` or `fix:`) will trigger a Release PR for **0.2.0** or **0.1.1** respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)