### PR TITLE
fix: trigger npm publish on GitHub release events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Release
 on:
   push:
     branches: [main]
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -10,6 +12,7 @@ permissions:
 
 jobs:
   release-please:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -20,9 +23,34 @@ jobs:
         with:
           release-type: node
 
-  publish:
+  publish-from-release-please:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Test
+        run: bun test
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-from-manual-release:
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `release: published` trigger to release workflow so manually tagged releases also publish to npm
- Separates the release-please job (push to main only) from publish jobs
- This enables publishing `mink@0.1.0` by re-dispatching the v0.1.0 release after merge

## Next steps after merge
1. Delete and recreate the v0.1.0 release to trigger the publish workflow
2. Verify `mink@0.1.0` appears on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)