### PR TITLE
fix: scope npm package as @drewpayment/mink

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mink",
+  "name": "@drewpayment/mink",
   "version": "0.1.0",
   "description": "A hidden presence that moves alongside the developer — token efficiency and cross-project wiki for AI coding assistants",
   "type": "module",
@@ -16,6 +16,9 @@
   "files": [
     "src/**/*.ts"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "MIT",
   "dependencies": {
     "puppeteer-core": "^24.0.0"


### PR DESCRIPTION
## Summary
- Rename package from `mink` to `@drewpayment/mink` (unscoped name is taken on npm)
- Add `publishConfig.access: "public"` so the scoped package is publicly installable

## After merge
Delete and recreate the v0.1.0 release to trigger npm publish of `@drewpayment/mink@0.1.0`.

Install via: `bun add -g @drewpayment/mink`

🤖 Generated with [Claude Code](https://claude.com/claude-code)