### PR TITLE
fix: include dashboard static assets in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,19 @@
+# npm uses this instead of .gitignore when present.
+# The "files" field in package.json is the allowlist;
+# this file only needs to block things that would otherwise slip in.
+
+node_modules/
+.next/
+.cache/
+.parcel-cache/
+coverage/
+*.tsbuildinfo
+*.log
+*.tgz
+.env
+.env.*
+.DS_Store
+.claude/
+tests/
+dashboard/node_modules/
+dashboard/.next/

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
 .next/
-out/
 *.tsbuildinfo
 next-env.d.ts

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "files": [
     "src/**/*.ts",
     "dist/cli.js",
-    "skills/**/*"
+    "skills/**/*",
+    "dashboard/out"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Remove `out/` from `dashboard/.gitignore` (root `.gitignore` already covers it for git)
- Add root `.npmignore` so npm stops inheriting nested `.gitignore` exclusions
- Add `dashboard/out` to `package.json` `files` allowlist

**Root cause:** npm respects nested `.gitignore` files even when `package.json` `files` explicitly lists the directory. The `dashboard/.gitignore` had `out/` which blocked the dashboard static assets from being published.

Closes #23

## Test plan
- [x] `npm pack --dry-run` shows 56 `dashboard/out/` files included
- [x] `git check-ignore dashboard/out/index.html` still shows ignored (git still ignores it via root `.gitignore`)
- [x] Typecheck, build, and tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)