### PR TITLE
ci: build dashboard before publishing to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Build
         run: bun run build
 
+      - name: Build dashboard
+        run: |
+          cd dashboard
+          bun install --frozen-lockfile
+          bun run build
+
       - name: Test
         run: bun test
 
@@ -66,6 +72,12 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: Build dashboard
+        run: |
+          cd dashboard
+          bun install --frozen-lockfile
+          bun run build
 
       - name: Test
         run: bun test


### PR DESCRIPTION
## Summary
- The 0.4.0 tarball on npm is missing `dashboard/out/` entirely — 88 files, zero dashboard assets. Running `mink dashboard` on a globally installed copy serves the "Dashboard not built" fallback page.
- Root cause: `dashboard/out/` is gitignored (`out/` in `.gitignore`), CI's fresh checkout has no pre-built assets, and the release workflow only runs `bun run build` (the CLI bundler). The `files` allowlist in `package.json` correctly declares `dashboard/out` but has nothing to include at pack time.
- Fix: add a **Build dashboard** step (install deps + `bun run build`) to both `publish-from-release-please` and `publish-from-manual-release` jobs, before `npm publish` runs.

After this lands, cut a 0.4.1 patch to ship a fixed tarball.

## Test plan
- [ ] Merge triggers release-please PR as normal; no release cut from this PR itself
- [ ] On next version bump, confirm CI logs show the "Build dashboard" step succeeding
- [ ] After publish, `npm pack @drewpayment/mink@<new-version> --dry-run` lists files under `dashboard/out/`
- [ ] Install globally, run `mink dashboard`, confirm the built UI loads instead of the fallback message

🤖 Generated with [Claude Code](https://claude.com/claude-code)