### PR TITLE
docs: add note about trusting the package in Bun for postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,20 @@ bun add -g @drewpayment/mink
 npm install -g @drewpayment/mink
 ```
 
+> **Bun users:** Bun blocks `postinstall` scripts by default for security. Mink's `postinstall` compiles the CLI binary, so you need to trust the package for it to run:
+>
+> ```bash
+> bun pm trust @drewpayment/mink
+> ```
+>
+> If you installed globally and `mink` isn't on your PATH, run `bun pm trust -g @drewpayment/mink` instead. You can also allowlist Mink permanently by adding it to `trustedDependencies` in your `package.json`:
+>
+> ```json
+> {
+>   "trustedDependencies": ["@drewpayment/mink"]
+> }
+> ```
+
 ### Initialize in a project
 
 From your project root:


### PR DESCRIPTION
Bun blocks postinstall scripts by default, which prevented Mink's CLI
build step from running. Document `bun pm trust` and the
`trustedDependencies` allowlist so first-time installers know how to
opt in.

https://claude.ai/code/session_01AA5AQai1PUeZBBQLTCfxiJ