### PR TITLE
fix(cli): resolve skills dir from package root, not relative depth

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -72413,7 +72413,7 @@ var require_ffi_WASM_RELEASE_SYNC = __commonJS((exports) => {
 
 // node_modules/@tootallnate/quickjs-emscripten/dist/generated/emscripten-module.WASM_RELEASE_SYNC.js
 var require_emscripten_module_WASM_RELEASE_SYNC = __commonJS((exports, module) => {
-  var __dirname = "/Users/drewpayment/dev/mink/node_modules/@tootallnate/quickjs-emscripten/dist/generated", __filename = "/Users/drewpayment/dev/mink/node_modules/@tootallnate/quickjs-emscripten/dist/generated/emscripten-module.WASM_RELEASE_SYNC.js";
+  var __dirname = "/Users/scottpallas/Code/mink/node_modules/@tootallnate/quickjs-emscripten/dist/generated", __filename = "/Users/scottpallas/Code/mink/node_modules/@tootallnate/quickjs-emscripten/dist/generated/emscripten-module.WASM_RELEASE_SYNC.js";
   var QuickJSRaw = (() => {
     var _scriptDir = typeof document !== "undefined" && document.currentScript ? document.currentScript.src : undefined;
     if (typeof __filename !== "undefined")
@@ -89098,6 +89098,16 @@ import {
   lstatSync as lstatSync2
 } from "fs";
 function getSkillsSourceDir() {
+  let dir = dirname13(new URL(import.meta.url).pathname);
+  while (true) {
+    if (existsSync30(join28(dir, "package.json")) && existsSync30(join28(dir, "skills"))) {
+      return join28(dir, "skills");
+    }
+    const parent = dirname13(dir);
+    if (parent === dir)
+      break;
+    dir = parent;
+  }
   return resolve14(dirname13(new URL(import.meta.url).pathname), "../../skills");
 }
 function getAvailableSkills() {

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -17,7 +17,23 @@ const AGENTS_SKILLS_DIR = join(homedir(), ".agents", "skills");
 const CLAUDE_SKILLS_DIR = join(homedir(), ".claude", "skills");
 
 function getSkillsSourceDir(): string {
-  // Skills live at repo-root/skills/ (the standard skills/{name}/SKILL.md layout)
+  // Skills live at <package-root>/skills/. Walk up from this file until we
+  // find a directory that contains both package.json and skills/ — this works
+  // whether we're running from src/commands/skill.ts (dev) or dist/cli.js
+  // (bundled, installed as a package).
+  let dir = dirname(new URL(import.meta.url).pathname);
+  while (true) {
+    if (
+      existsSync(join(dir, "package.json")) &&
+      existsSync(join(dir, "skills"))
+    ) {
+      return join(dir, "skills");
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  // Fallback: the old behavior, relative to this file's location.
   return resolve(
     dirname(new URL(import.meta.url).pathname),
     "../../skills"


### PR DESCRIPTION
Fixes #43.

## Summary

- `getSkillsSourceDir()` resolved `../../skills` relative to `import.meta.url`, which only held from `src/commands/skill.ts`. In the bundled `dist/cli.js` the entry sits one level deep, so the path landed one directory above the package root — producing `@drewpayment/skills` instead of `@drewpayment/mink/skills` for globally installed users.
- Walk up from the current file looking for a directory that contains both `package.json` and `skills/`. Works from the source tree (dev) and from the bundled package (installed globally).
- Kept the original `../../skills` resolution as a fallback.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run src/cli.ts skill list` — lists `mink-note` from the dev tree
- [x] Simulated bundled-package layout (`dist/cli.js` + `package.json` + `skills/<name>/SKILL.md` one level above `dist/`) — `mink skill list` finds the skill instead of erroring with "Expected skills at:"
- [ ] Reviewer: `bun add -g .` on a local checkout, then `mink skill install`