### PR TITLE
fix(cli): resolve skills dir from package root, not relative depth

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -89098,6 +89098,16 @@ import {
   lstatSync as lstatSync2
 } from "fs";
 function getSkillsSourceDir() {
+  let dir = dirname13(new URL(import.meta.url).pathname);
+  while (true) {
+    if (existsSync30(join28(dir, "package.json")) && existsSync30(join28(dir, "skills"))) {
+      return join28(dir, "skills");
+    }
+    const parent = dirname13(dir);
+    if (parent === dir)
+      break;
+    dir = parent;
+  }
   return resolve14(dirname13(new URL(import.meta.url).pathname), "../../skills");
 }
 function getAvailableSkills() {

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -17,7 +17,22 @@ const AGENTS_SKILLS_DIR = join(homedir(), ".agents", "skills");
 const CLAUDE_SKILLS_DIR = join(homedir(), ".claude", "skills");
 
 function getSkillsSourceDir(): string {
-  // Skills live at repo-root/skills/ (the standard skills/{name}/SKILL.md layout)
+  // Walk up from this file until we find a directory that contains both
+  // package.json and skills/ — works from src/commands/skill.ts (dev) and
+  // from dist/cli.js (bundled + installed as a package), which sit at
+  // different depths relative to the package root.
+  let dir = dirname(new URL(import.meta.url).pathname);
+  while (true) {
+    if (
+      existsSync(join(dir, "package.json")) &&
+      existsSync(join(dir, "skills"))
+    ) {
+      return join(dir, "skills");
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
   return resolve(
     dirname(new URL(import.meta.url).pathname),
     "../../skills"


### PR DESCRIPTION
Fixes #43. Credit to @scott-pallas for the original diagnosis and fix in #44 — this is the same approach, rebuilt locally to keep the `dist/cli.js` diff scoped to just the behavior change (the original PR also picked up an unrelated absolute-path hunk from a rebuild).

## Summary

- `getSkillsSourceDir()` resolved `../../skills` relative to `import.meta.url`. That worked from `src/commands/skill.ts` (dev) but in the bundled `dist/cli.js` the entry sits one level deep, so the path landed one directory above the package root — producing `@drewpayment/skills` instead of `@drewpayment/mink/skills` for globally installed users.
- Walk up from the current file until finding a directory that contains both `package.json` and `skills/`. Works from source and from the bundled package.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run src/cli.ts skill list` — works from dev tree
- [x] `node dist/cli.js skill list` — works from bundled entry
- [x] `bun test` — 929/930 pass (1 pre-existing, unrelated environment-dependent status test)
- [ ] Reviewer: `bun add -g .` on a local checkout, then `mink skill install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)