### PR TITLE
feat(agent): add `mink agent` command with bundled persona

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ All state lives in `~/.mink/` -- nothing is stored in your project repository.
 - **Wiki Vault** — Obsidian-compatible markdown vault that accumulates knowledge across all projects
 - **Note Capture** — `mink note` CLI captures notes from any directory into the vault
 - **Claude Code Skill** — `/mink:note` skill uses Claude as the AI brain for intelligent categorization, tagging, and wikilink insertion
+- **Mink Agent** — `mink agent` opens a Claude Code session with a dedicated mink-agent persona scoped to your vault
 - **Daily Notes** — `mink note --daily` creates or appends to daily journal entries
 - **Vault Index** — Token-efficient file index for the vault, with search and tag aggregation
 - **External Linking** — Symlink external notes directories into the vault for a unified Obsidian experience
@@ -247,6 +248,24 @@ Then in any Claude Code session:
 ```
 
 Claude will analyze the content, check existing notes for related topics and people, and run `mink note` with the right flags — placing the note in the correct category with tags and `[[wikilinks]]` to related notes.
+
+### Open the mink agent
+
+For longer conversations with your vault — capturing several notes in one sitting, asking what's stale, or running `mink` commands without leaving the chat — open a dedicated Claude Code session as the **mink agent**:
+
+```bash
+mink agent
+```
+
+This launches Claude Code in your mink home (`~/.mink`) with a persona that:
+- Captures and files notes into the right categories with tags and wikilinks
+- Surfaces orphans, untagged notes, and stale daily notes (with confirmation before fixing)
+- Runs `mink` commands on demand (`mink status`, `mink bug search`, `mink detect-waste`, etc.)
+- Reads everywhere under your mink root and vault, but only writes inside the vault
+
+The agent definition is auto-installed to `~/.claude/agents/mink-agent.md` and refreshed when you change `mink config wiki.path`. Pass `--no-update` to keep manual customizations, or `--reinstall` to force a refresh.
+
+Requires the `claude` CLI on PATH ([Claude Code](https://claude.com/claude-code)).
 
 ### Browse and search
 

--- a/agents/mink-agent.md.tmpl
+++ b/agents/mink-agent.md.tmpl
@@ -1,0 +1,84 @@
+---
+name: mink-agent
+description: Proactive mink wiki & note assistant. Lives in your mink home. Helps you capture, organize, and explore your cross-project knowledge vault.
+model: claude-opus-4-7
+tools: Read, Grep, Glob, Edit, Write, Bash
+permissionMode: acceptEdits
+permissions:
+  allow:
+    - "Read({{MINK_ROOT}}/**)"
+    - "Grep({{MINK_ROOT}}/**)"
+    - "Glob({{MINK_ROOT}}/**)"
+    - "Read({{VAULT_PATH}}/**)"
+    - "Grep({{VAULT_PATH}}/**)"
+    - "Glob({{VAULT_PATH}}/**)"
+    - "Edit({{VAULT_PATH}}/**)"
+    - "Write({{VAULT_PATH}}/**)"
+    - "Bash(mink *)"
+    - "Bash(mink)"
+    - "Bash(cat *)"
+    - "Bash(head *)"
+    - "Bash(tail *)"
+    - "Bash(grep *)"
+    - "Bash(rg *)"
+    - "Bash(awk *)"
+    - "Bash(sed *)"
+    - "Bash(jq *)"
+    - "Bash(wc *)"
+    - "Bash(sort *)"
+    - "Bash(uniq *)"
+    - "Bash(cut *)"
+    - "Bash(ls *)"
+    - "Bash(find {{MINK_ROOT}} *)"
+    - "Bash(find {{VAULT_PATH}} *)"
+  deny:
+    - "Edit({{MINK_ROOT}}/projects/**)"
+    - "Write({{MINK_ROOT}}/projects/**)"
+    - "Edit({{MINK_ROOT}}/config*)"
+    - "Write({{MINK_ROOT}}/config*)"
+    - "Bash(rm *)"
+    - "Bash(mv {{MINK_ROOT}}/projects *)"
+mink-version: {{MINK_VERSION}}
+---
+
+You are the **mink agent**. You live inside the user's mink home (`{{MINK_ROOT}}`).
+
+## Your mission
+
+Be a proactive partner for the user's cross-project knowledge vault. You ingest notes, organize them properly, clarify gaps, ensure notes are filed with the information needed to be comprehensive, and surface organization issues (untagged notes, orphans, stale daily notes). You run `mink` scans on demand. You make suggestions, create reminders inside notes, and stay attentive — you are more than a tool that monitors the vault, you facilitate proper information gathering.
+
+## Your environment
+
+- **Vault root:** `{{VAULT_PATH}}` — Obsidian-compatible markdown with `[[wikilinks]]`. May live outside `{{MINK_ROOT}}` if the user configured `mink config wiki.path`.
+- **Vault index:** `{{VAULT_PATH}}/.mink-index.json` — searchable index of tags, categories, paths.
+- **Master index:** `{{VAULT_PATH}}/_index.md` — generated overview of the vault.
+- **Inbox:** `{{VAULT_PATH}}/inbox/` — quick captures land here.
+- **Daily notes:** `{{VAULT_PATH}}/areas/daily/YYYY-MM-DD.md`.
+- **Templates:** `{{VAULT_PATH}}/templates/`.
+- **Projects (in vault):** `{{VAULT_PATH}}/projects/<slug>/{overview,conventions,architecture,bugs/}.md`.
+- **Per-project state (read-only):** `{{MINK_ROOT}}/projects/<slug>/` — `learning-memory.md`, `bug-memory.json`, `file-index.json`, `action-log.md`, `token-ledger.json`, `project-meta.json`.
+
+## Your tools
+
+- **Read, Grep, Glob:** anywhere in the mink root and the vault.
+- **Edit, Write:** **only** inside the vault. Per-project state under `{{MINK_ROOT}}/projects/` is read-only to you, as is the global mink config.
+- **Bash:** `mink ...` invocations (e.g., `mink note`, `mink note list`, `mink note search`, `mink wiki status`, `mink bug search`, `mink detect-waste`, `mink scan`, `mink status`) plus a small set of read-only pipeline utilities for chaining (`cat`, `head`, `tail`, `grep`, `rg`, `awk`, `sed`, `jq`, `wc`, `sort`, `uniq`, `cut`, `ls`, `find` scoped to the mink root or vault). `rm` is denied; mutations happen through Edit/Write to the vault or through `mink` commands.
+
+## How to behave
+
+1. **Capture proactively.** When the user shares a thought, idea, decision, or fact, capture it via `mink note "..."` (preferred — mink picks the right structure) or by writing under `{{VAULT_PATH}}/inbox/` if more structure is needed. Choose category, tags, and `[[wikilinks]]` based on the existing vault vocabulary — read `{{VAULT_PATH}}/.mink-index.json` first to stay consistent.
+
+2. **Clarify before filing.** If a note is missing context that would make it useful later (no project, no date for an event, no link to a person/system), ask one short follow-up before saving. Don't interrogate — one or two questions max, then save what you have.
+
+3. **Search before answering.** When the user asks about past decisions, projects, bugs, or people, search the vault and per-project state before answering. Cite paths so the user can navigate.
+
+4. **Surface vault hygiene issues.** When entering the session or asked "what's stale?" / "what needs attention?", scan for:
+   - Notes in `inbox/` older than 7 days that haven't been filed.
+   - Notes with no tags or category.
+   - Orphans — notes with no inbound `[[wikilinks]]`.
+   - Daily notes gaps — recent days with no entry.
+   Suggest fixes. **Never modify the vault to fix these without confirmation.**
+
+5. **Run mink commands when the user asks for state.** "How's my token usage?" → `mink status` or read `token-ledger.json`. "Find bugs about migrations" → `mink bug search migration`. "Anything wasteful?" → `mink detect-waste`. Don't guess; run the command.
+
+6. **Stay concise.** End each turn with 1–2 sentences on what changed (note created, file updated, command run) and what's next if anything.

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -89241,6 +89241,213 @@ var init_skill = __esm(() => {
   CLAUDE_SKILLS_DIR = join28(homedir5(), ".claude", "skills");
 });
 
+// src/commands/agent.ts
+var exports_agent = {};
+__export(exports_agent, {
+  agent: () => agent
+});
+import { join as join29, resolve as resolve15, dirname as dirname14 } from "path";
+import { homedir as homedir6 } from "os";
+import {
+  existsSync as existsSync31,
+  mkdirSync as mkdirSync14,
+  readFileSync as readFileSync28,
+  writeFileSync as writeFileSync9
+} from "fs";
+import { createHash as createHash2 } from "crypto";
+import { spawnSync as spawnSync5 } from "child_process";
+function getAgentTemplatePath() {
+  let dir = dirname14(new URL(import.meta.url).pathname);
+  while (true) {
+    if (existsSync31(join29(dir, "package.json")) && existsSync31(join29(dir, "agents", TEMPLATE_FILE))) {
+      return join29(dir, "agents", TEMPLATE_FILE);
+    }
+    const parent = dirname14(dir);
+    if (parent === dir)
+      break;
+    dir = parent;
+  }
+  return resolve15(dirname14(new URL(import.meta.url).pathname), "../../agents", TEMPLATE_FILE);
+}
+function getMinkVersion() {
+  let dir = dirname14(new URL(import.meta.url).pathname);
+  while (true) {
+    const pkgPath = join29(dir, "package.json");
+    if (existsSync31(pkgPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync28(pkgPath, "utf-8"));
+        if (pkg.name && pkg.version)
+          return pkg.version;
+      } catch {}
+    }
+    const parent = dirname14(dir);
+    if (parent === dir)
+      break;
+    dir = parent;
+  }
+  return "unknown";
+}
+function renderTemplate(template, vars) {
+  let out = template;
+  for (const [key, value] of Object.entries(vars)) {
+    out = out.split(`{{${key}}}`).join(value);
+  }
+  return out;
+}
+function sha256(text) {
+  return createHash2("sha256").update(text).digest("hex");
+}
+function claudeAgentsDir() {
+  return join29(homedir6(), ".claude", "agents");
+}
+function installedAgentPath() {
+  return join29(claudeAgentsDir(), INSTALLED_FILE);
+}
+function installAgentDefinition(opts) {
+  const templatePath = getAgentTemplatePath();
+  if (!existsSync31(templatePath)) {
+    throw new Error(`[mink agent] bundled agent template not found at ${templatePath}
+` + "  This usually means the package was installed without bundled assets.");
+  }
+  const installed = installedAgentPath();
+  if (opts.skip && existsSync31(installed)) {
+    return { action: "skipped", path: installed };
+  }
+  const template = readFileSync28(templatePath, "utf-8");
+  const rendered = renderTemplate(template, {
+    MINK_ROOT: minkRoot(),
+    VAULT_PATH: resolveVaultPath(),
+    MINK_VERSION: getMinkVersion()
+  });
+  const exists = existsSync31(installed);
+  if (!opts.force && exists) {
+    const current = readFileSync28(installed, "utf-8");
+    if (sha256(current) === sha256(rendered)) {
+      return { action: "unchanged", path: installed };
+    }
+  }
+  mkdirSync14(claudeAgentsDir(), { recursive: true });
+  writeFileSync9(installed, rendered);
+  return {
+    action: exists ? "updated" : "installed",
+    path: installed
+  };
+}
+function isClaudeOnPath() {
+  const result = spawnSync5("claude", ["--version"], {
+    stdio: "ignore"
+  });
+  return !result.error && result.status === 0;
+}
+function parseArgs2(args) {
+  const out = {
+    noUpdate: false,
+    reinstall: false,
+    passthrough: [],
+    showHelp: false
+  };
+  let inPassthrough = false;
+  for (const arg of args) {
+    if (inPassthrough) {
+      out.passthrough.push(arg);
+      continue;
+    }
+    if (arg === "--") {
+      inPassthrough = true;
+      continue;
+    }
+    if (arg === "--no-update") {
+      out.noUpdate = true;
+      continue;
+    }
+    if (arg === "--reinstall") {
+      out.reinstall = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      out.showHelp = true;
+      continue;
+    }
+    out.passthrough.push(arg);
+  }
+  return out;
+}
+function printHelp() {
+  console.log("Usage: mink agent [options] [-- <claude args...>]");
+  console.log();
+  console.log("Open an interactive Claude Code session in your mink home with");
+  console.log("the mink-agent persona — a proactive note/wiki assistant.");
+  console.log();
+  console.log("Options:");
+  console.log("  --no-update    Don't refresh ~/.claude/agents/mink-agent.md if it exists");
+  console.log("  --reinstall    Force overwrite the installed agent definition");
+  console.log("  -- <args>      Forward remaining arguments to `claude`");
+  console.log();
+  console.log("Environment:");
+  console.log("  MINK_AGENT_NO_UPDATE=1   Equivalent to --no-update");
+  console.log();
+  console.log("The agent is bound to your mink root and resolved vault path. Changing");
+  console.log("`mink config wiki.path` triggers a refresh on the next launch.");
+}
+async function agent(_cwd, rawArgs) {
+  const args = parseArgs2(rawArgs);
+  if (args.showHelp) {
+    printHelp();
+    return;
+  }
+  const skipUpdate = args.noUpdate || process.env.MINK_AGENT_NO_UPDATE === "1";
+  const root = minkRoot();
+  if (!existsSync31(root)) {
+    mkdirSync14(root, { recursive: true });
+  }
+  let result;
+  try {
+    result = installAgentDefinition({
+      force: args.reinstall,
+      skip: skipUpdate && !args.reinstall
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(msg);
+    process.exit(1);
+  }
+  switch (result.action) {
+    case "installed":
+      console.log(`[mink] installed mink-agent definition (v${getMinkVersion()}) -> ${result.path}`);
+      break;
+    case "updated":
+      console.log(`[mink] updated mink-agent definition -> ${result.path}`);
+      break;
+    case "unchanged":
+    case "skipped":
+      break;
+  }
+  if (!isClaudeOnPath()) {
+    console.error("[mink agent] `claude` (Claude Code CLI) was not found on PATH.");
+    console.error("  Install Claude Code: https://claude.com/claude-code");
+    process.exit(1);
+  }
+  const claudeArgs = ["--agent", AGENT_NAME, ...args.passthrough];
+  const child = spawnSync5("claude", claudeArgs, {
+    cwd: root,
+    stdio: "inherit"
+  });
+  if (child.error) {
+    console.error(`[mink agent] failed to launch claude: ${child.error.message}`);
+    process.exit(1);
+  }
+  if (typeof child.status === "number") {
+    process.exit(child.status);
+  }
+}
+var AGENT_NAME = "mink-agent", TEMPLATE_FILE, INSTALLED_FILE;
+var init_agent = __esm(() => {
+  init_paths();
+  init_vault();
+  TEMPLATE_FILE = `${AGENT_NAME}.md.tmpl`;
+  INSTALLED_FILE = `${AGENT_NAME}.md`;
+});
+
 // src/commands/sync.ts
 var exports_sync2 = {};
 __export(exports_sync2, {
@@ -89738,6 +89945,11 @@ switch (command2) {
     await skill2(process.argv.slice(3));
     break;
   }
+  case "agent": {
+    const { agent: agent2 } = await Promise.resolve().then(() => (init_agent(), exports_agent));
+    await agent2(cwd, process.argv.slice(3));
+    break;
+  }
   case "sync": {
     const { sync: sync2 } = await Promise.resolve().then(() => (init_sync3(), exports_sync2));
     await sync2(process.argv.slice(3));
@@ -89767,11 +89979,11 @@ switch (command2) {
   case "version":
   case "--version":
   case "-v": {
-    const { resolve: resolve15, dirname: dirname14 } = await import("path");
-    const cliPath = resolve15(dirname14(new URL(import.meta.url).pathname));
-    const { readFileSync: readFileSync28 } = await import("fs");
+    const { resolve: resolve16, dirname: dirname15 } = await import("path");
+    const cliPath = resolve16(dirname15(new URL(import.meta.url).pathname));
+    const { readFileSync: readFileSync29 } = await import("fs");
     try {
-      const pkg = JSON.parse(readFileSync28(resolve15(cliPath, "../package.json"), "utf-8"));
+      const pkg = JSON.parse(readFileSync29(resolve16(cliPath, "../package.json"), "utf-8"));
       console.log(`mink ${pkg.version}`);
     } catch {
       console.log("mink (unknown version)");
@@ -89799,6 +90011,7 @@ switch (command2) {
     console.log("  note list [filters]     List notes (--category, --tag, --recent)");
     console.log("  note search <term>      Full-text search across the vault");
     console.log("  skill install           Install /mink:note skill for Claude Code");
+    console.log("  agent                   Open a Claude Code session with the mink-agent persona");
     console.log();
     console.log("Devices & Sync:");
     console.log("  device                  Show current device info");

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "src/**/*.ts",
     "dist/cli.js",
     "skills/**/*",
+    "agents/**/*",
     "dashboard/out"
   ],
   "publishConfig": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,6 +143,12 @@ switch (command) {
     break;
   }
 
+  case "agent": {
+    const { agent } = await import("./commands/agent");
+    await agent(cwd, process.argv.slice(3));
+    break;
+  }
+
   case "sync": {
     const { sync } = await import("./commands/sync");
     await sync(process.argv.slice(3));
@@ -213,6 +219,7 @@ switch (command) {
     console.log("  note list [filters]     List notes (--category, --tag, --recent)");
     console.log("  note search <term>      Full-text search across the vault");
     console.log("  skill install           Install /mink:note skill for Claude Code");
+    console.log("  agent                   Open a Claude Code session with the mink-agent persona");
     console.log();
     console.log("Devices & Sync:");
     console.log("  device                  Show current device info");

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,0 +1,245 @@
+import { join, resolve, dirname } from "path";
+import { homedir } from "os";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "fs";
+import { createHash } from "crypto";
+import { spawnSync } from "child_process";
+import { minkRoot } from "../core/paths";
+import { resolveVaultPath } from "../core/vault";
+
+const AGENT_NAME = "mink-agent";
+const TEMPLATE_FILE = `${AGENT_NAME}.md.tmpl`;
+const INSTALLED_FILE = `${AGENT_NAME}.md`;
+
+function getAgentTemplatePath(): string {
+  let dir = dirname(new URL(import.meta.url).pathname);
+  while (true) {
+    if (
+      existsSync(join(dir, "package.json")) &&
+      existsSync(join(dir, "agents", TEMPLATE_FILE))
+    ) {
+      return join(dir, "agents", TEMPLATE_FILE);
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return resolve(
+    dirname(new URL(import.meta.url).pathname),
+    "../../agents",
+    TEMPLATE_FILE
+  );
+}
+
+function getMinkVersion(): string {
+  let dir = dirname(new URL(import.meta.url).pathname);
+  while (true) {
+    const pkgPath = join(dir, "package.json");
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+        if (pkg.name && pkg.version) return pkg.version;
+      } catch {
+        // fall through
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return "unknown";
+}
+
+function renderTemplate(template: string, vars: Record<string, string>): string {
+  let out = template;
+  for (const [key, value] of Object.entries(vars)) {
+    out = out.split(`{{${key}}}`).join(value);
+  }
+  return out;
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+function claudeAgentsDir(): string {
+  return join(homedir(), ".claude", "agents");
+}
+
+function installedAgentPath(): string {
+  return join(claudeAgentsDir(), INSTALLED_FILE);
+}
+
+interface InstallResult {
+  action: "installed" | "updated" | "unchanged" | "skipped";
+  path: string;
+}
+
+function installAgentDefinition(opts: { force: boolean; skip: boolean }): InstallResult {
+  const templatePath = getAgentTemplatePath();
+  if (!existsSync(templatePath)) {
+    throw new Error(
+      `[mink agent] bundled agent template not found at ${templatePath}\n` +
+        "  This usually means the package was installed without bundled assets."
+    );
+  }
+
+  const installed = installedAgentPath();
+
+  if (opts.skip && existsSync(installed)) {
+    return { action: "skipped", path: installed };
+  }
+
+  const template = readFileSync(templatePath, "utf-8");
+  const rendered = renderTemplate(template, {
+    MINK_ROOT: minkRoot(),
+    VAULT_PATH: resolveVaultPath(),
+    MINK_VERSION: getMinkVersion(),
+  });
+
+  const exists = existsSync(installed);
+  if (!opts.force && exists) {
+    const current = readFileSync(installed, "utf-8");
+    if (sha256(current) === sha256(rendered)) {
+      return { action: "unchanged", path: installed };
+    }
+  }
+
+  mkdirSync(claudeAgentsDir(), { recursive: true });
+  writeFileSync(installed, rendered);
+  return {
+    action: exists ? "updated" : "installed",
+    path: installed,
+  };
+}
+
+function isClaudeOnPath(): boolean {
+  const result = spawnSync("claude", ["--version"], {
+    stdio: "ignore",
+  });
+  return !result.error && result.status === 0;
+}
+
+interface ParsedArgs {
+  noUpdate: boolean;
+  reinstall: boolean;
+  passthrough: string[];
+  showHelp: boolean;
+}
+
+function parseArgs(args: string[]): ParsedArgs {
+  const out: ParsedArgs = {
+    noUpdate: false,
+    reinstall: false,
+    passthrough: [],
+    showHelp: false,
+  };
+  let inPassthrough = false;
+  for (const arg of args) {
+    if (inPassthrough) {
+      out.passthrough.push(arg);
+      continue;
+    }
+    if (arg === "--") {
+      inPassthrough = true;
+      continue;
+    }
+    if (arg === "--no-update") {
+      out.noUpdate = true;
+      continue;
+    }
+    if (arg === "--reinstall") {
+      out.reinstall = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      out.showHelp = true;
+      continue;
+    }
+    out.passthrough.push(arg);
+  }
+  return out;
+}
+
+function printHelp(): void {
+  console.log("Usage: mink agent [options] [-- <claude args...>]");
+  console.log();
+  console.log("Open an interactive Claude Code session in your mink home with");
+  console.log("the mink-agent persona — a proactive note/wiki assistant.");
+  console.log();
+  console.log("Options:");
+  console.log("  --no-update    Don't refresh ~/.claude/agents/mink-agent.md if it exists");
+  console.log("  --reinstall    Force overwrite the installed agent definition");
+  console.log("  -- <args>      Forward remaining arguments to `claude`");
+  console.log();
+  console.log("Environment:");
+  console.log("  MINK_AGENT_NO_UPDATE=1   Equivalent to --no-update");
+  console.log();
+  console.log("The agent is bound to your mink root and resolved vault path. Changing");
+  console.log("`mink config wiki.path` triggers a refresh on the next launch.");
+}
+
+export async function agent(_cwd: string, rawArgs: string[]): Promise<void> {
+  const args = parseArgs(rawArgs);
+
+  if (args.showHelp) {
+    printHelp();
+    return;
+  }
+
+  const skipUpdate = args.noUpdate || process.env.MINK_AGENT_NO_UPDATE === "1";
+
+  const root = minkRoot();
+  if (!existsSync(root)) {
+    mkdirSync(root, { recursive: true });
+  }
+
+  let result: InstallResult;
+  try {
+    result = installAgentDefinition({
+      force: args.reinstall,
+      skip: skipUpdate && !args.reinstall,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(msg);
+    process.exit(1);
+  }
+
+  switch (result.action) {
+    case "installed":
+      console.log(`[mink] installed mink-agent definition (v${getMinkVersion()}) -> ${result.path}`);
+      break;
+    case "updated":
+      console.log(`[mink] updated mink-agent definition -> ${result.path}`);
+      break;
+    case "unchanged":
+    case "skipped":
+      // silent
+      break;
+  }
+
+  if (!isClaudeOnPath()) {
+    console.error("[mink agent] `claude` (Claude Code CLI) was not found on PATH.");
+    console.error("  Install Claude Code: https://claude.com/claude-code");
+    process.exit(1);
+  }
+
+  const claudeArgs = ["--agent", AGENT_NAME, ...args.passthrough];
+  const child = spawnSync("claude", claudeArgs, {
+    cwd: root,
+    stdio: "inherit",
+  });
+
+  if (child.error) {
+    console.error(`[mink agent] failed to launch claude: ${child.error.message}`);
+    process.exit(1);
+  }
+  if (typeof child.status === "number") {
+    process.exit(child.status);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new `mink agent` command that opens an interactive Claude Code session inside `~/.mink` with a dedicated **mink-agent** persona — a proactive note/wiki assistant that captures notes, surfaces vault hygiene issues (orphans, untagged notes, stale daily notes), and runs `mink` commands on demand.

- Bundles `agents/mink-agent.md.tmpl` with `{{MINK_ROOT}}`, `{{VAULT_PATH}}`, `{{MINK_VERSION}}` placeholders
- `mink agent` renders the template with `minkRoot()` + `resolveVaultPath()` and auto-installs to `~/.claude/agents/mink-agent.md` (SHA-256 hash compare on rendered output, so changing `mink config wiki.path` triggers a refresh)
- Execs `claude --agent mink-agent` with `cwd=minkRoot()` so the session opens as the persona
- Persona uses **Opus 4.7** with `permissionMode: acceptEdits` and tight Read/Edit/Write/Bash allowlists scoped to the mink root and vault; `rm` and writes outside the vault are denied

## Architecture notes

- Reuses the package-root walk pattern from `src/commands/skill.ts` so the bundled template resolves correctly in dev (`src/`) and production (`dist/`)
- Calls `minkRoot()` (hardcoded today, function-routed for forward-compat) and `resolveVaultPath()` (which reads `wiki.path` config) so the agent definition is always pinned to the user's actual paths
- `--no-update` / `MINK_AGENT_NO_UPDATE=1` preserve manual customizations; `--reinstall` forces a refresh
- Trailing args after `--` are forwarded to `claude`

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run build` succeeds
- [x] `bun test` — 930 pass, 0 fail
- [x] `mink agent --help` prints usage
- [x] First run installs `~/.claude/agents/mink-agent.md`; rendered paths substituted correctly
- [x] Re-run is silent (hash short-circuit)
- [x] Tampering with installed file triggers `[mink] updated mink-agent definition`
- [x] `--no-update` preserves manual customizations
- [x] `--reinstall` force-overwrites
- [x] Missing `claude` binary on PATH produces a clear error and exit 1
- [x] Manual session check: persona loads as Opus 4.7, `mink ...` commands run without permission prompts, vault writes auto-accepted
- [ ] Verify changing `mink config wiki.path` triggers a refresh on next `mink agent` launch (paths in installed file reflect the new vault location)

🤖 Generated with [Claude Code](https://claude.com/claude-code)