### PR TITLE
feat(init): write .claude/rules/mink.md during mink init

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -2951,6 +2951,7 @@ var init_seed = __esm(() => {
 // src/commands/init.ts
 var exports_init = {};
 __export(exports_init, {
+  writeMinkRule: () => writeMinkRule,
   resolveCliPath: () => resolveCliPath,
   mergeHooksIntoSettings: () => mergeHooksIntoSettings,
   init: () => init,
@@ -3011,6 +3012,12 @@ function isMinkHook(entry) {
   }
   return false;
 }
+function writeMinkRule(cwd) {
+  const rulePath = resolve2(cwd, ".claude", "rules", "mink.md");
+  mkdirSync6(dirname4(rulePath), { recursive: true });
+  atomicWriteText(rulePath, MINK_RULE_CONTENT);
+  return rulePath;
+}
 function mergeHooksIntoSettings(settingsPath, newHooks) {
   mkdirSync6(dirname4(settingsPath), { recursive: true });
   const existing = safeReadJson(settingsPath) ?? {};
@@ -3043,6 +3050,7 @@ async function init(cwd) {
     console.log(`  backup: ${backupName}`);
   }
   mergeHooksIntoSettings(settingsPath, hooks);
+  const rulePath = writeMinkRule(cwd);
   mkdirSync6(dir, { recursive: true });
   const projectId = generateProjectId(cwd);
   const isNotesProject = isWikiEnabled() && isVaultInitialized() && isInsideVault(cwd);
@@ -3060,12 +3068,14 @@ async function init(cwd) {
     console.log(`[mink] upgrade complete`);
     console.log(`  project:  ${projectId}`);
     console.log(`  hooks:    ${settingsPath}`);
+    console.log(`  rule:     ${rulePath}`);
   } else {
     console.log(`[mink] initialized`);
     console.log(`  project:  ${projectId}`);
     console.log(`  state:    ${dir}`);
     console.log(`  runtime:  ${runtime}`);
     console.log(`  hooks:    ${settingsPath}`);
+    console.log(`  rule:     ${rulePath}`);
   }
   const { scan: scan2 } = await Promise.resolve().then(() => (init_scan(), exports_scan));
   scan2(cwd, { check: false });
@@ -3110,6 +3120,22 @@ async function init(cwd) {
     } catch {}
   }
 }
+var MINK_RULE_CONTENT = `---
+description: Mink context management — automatic via hooks
+---
+
+This project uses **Mink** (\`@drewpayment/mink\`) for cross-session context management.
+
+## How it works
+- Mink runs automatically through Claude Code hooks configured in \`.claude/settings.json\` (SessionStart, PreToolUse, PostToolUse, Stop).
+- All state lives in \`~/.mink/\` on the user's machine — **not** in this repository. Do not create or write to any in-repo state directory (no \`.wolf/\`, \`.mink/\`, etc.).
+- Read intelligence, write enforcement, bug memory, and the token ledger are handled by the hooks. You do not need to manually read or update any state files.
+
+## When to act on Mink
+- If the user asks to "save a note", "remember this", "log this to my wiki", or similar, use the \`mink-note\` skill — it captures into the user's \`~/.mink/\` vault.
+- If a hook surfaces a learning, past bug, or repeat-read warning, treat that as authoritative project memory and follow it.
+- The \`mink dashboard\` and \`mink agent\` commands are user tools — do not invoke them on the user's behalf.
+`;
 var init_init = __esm(() => {
   init_paths();
   init_project_id();

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -106,6 +106,30 @@ function isMinkHook(entry: HookEntry | Record<string, unknown>): boolean {
   return false;
 }
 
+const MINK_RULE_CONTENT = `---
+description: Mink context management — automatic via hooks
+---
+
+This project uses **Mink** (\`@drewpayment/mink\`) for cross-session context management.
+
+## How it works
+- Mink runs automatically through Claude Code hooks configured in \`.claude/settings.json\` (SessionStart, PreToolUse, PostToolUse, Stop).
+- All state lives in \`~/.mink/\` on the user's machine — **not** in this repository. Do not create or write to any in-repo state directory (no \`.wolf/\`, \`.mink/\`, etc.).
+- Read intelligence, write enforcement, bug memory, and the token ledger are handled by the hooks. You do not need to manually read or update any state files.
+
+## When to act on Mink
+- If the user asks to "save a note", "remember this", "log this to my wiki", or similar, use the \`mink-note\` skill — it captures into the user's \`~/.mink/\` vault.
+- If a hook surfaces a learning, past bug, or repeat-read warning, treat that as authoritative project memory and follow it.
+- The \`mink dashboard\` and \`mink agent\` commands are user tools — do not invoke them on the user's behalf.
+`;
+
+export function writeMinkRule(cwd: string): string {
+  const rulePath = resolve(cwd, ".claude", "rules", "mink.md");
+  mkdirSync(dirname(rulePath), { recursive: true });
+  atomicWriteText(rulePath, MINK_RULE_CONTENT);
+  return rulePath;
+}
+
 export function mergeHooksIntoSettings(
   settingsPath: string,
   newHooks: HooksConfig
@@ -148,6 +172,7 @@ export async function init(cwd: string): Promise<void> {
   }
 
   mergeHooksIntoSettings(settingsPath, hooks);
+  const rulePath = writeMinkRule(cwd);
 
   mkdirSync(dir, { recursive: true });
 
@@ -173,12 +198,14 @@ export async function init(cwd: string): Promise<void> {
     console.log(`[mink] upgrade complete`);
     console.log(`  project:  ${projectId}`);
     console.log(`  hooks:    ${settingsPath}`);
+    console.log(`  rule:     ${rulePath}`);
   } else {
     console.log(`[mink] initialized`);
     console.log(`  project:  ${projectId}`);
     console.log(`  state:    ${dir}`);
     console.log(`  runtime:  ${runtime}`);
     console.log(`  hooks:    ${settingsPath}`);
+    console.log(`  rule:     ${rulePath}`);
   }
 
   // Run initial scan

--- a/tests/unit/init.test.ts
+++ b/tests/unit/init.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync
 import { join } from "path";
 import { tmpdir } from "os";
 import { safeReadJson } from "../../src/core/fs-utils";
-import { buildHooksConfig, mergeHooksIntoSettings, init } from "../../src/commands/init";
+import { buildHooksConfig, mergeHooksIntoSettings, writeMinkRule, init } from "../../src/commands/init";
 import { learningMemoryPath } from "../../src/core/paths";
 
 describe("buildHooksConfig", () => {
@@ -179,6 +179,45 @@ describe("mergeHooksIntoSettings", () => {
   });
 });
 
+describe("writeMinkRule", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mink-rule-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("writes .claude/rules/mink.md with the expected rule content", () => {
+    const path = writeMinkRule(dir);
+    expect(path).toBe(join(dir, ".claude", "rules", "mink.md"));
+    expect(existsSync(path)).toBe(true);
+    const content = readFileSync(path, "utf-8");
+    expect(content).toContain("description: Mink context management");
+    expect(content).toContain("@drewpayment/mink");
+    expect(content).toContain("`.claude/settings.json`");
+    expect(content).toContain("mink-note");
+  });
+
+  test("creates the .claude/rules directory if missing", () => {
+    expect(existsSync(join(dir, ".claude", "rules"))).toBe(false);
+    writeMinkRule(dir);
+    expect(existsSync(join(dir, ".claude", "rules"))).toBe(true);
+  });
+
+  test("overwrites an existing mink.md so the rule stays current", () => {
+    const path = join(dir, ".claude", "rules", "mink.md");
+    mkdirSync(join(dir, ".claude", "rules"), { recursive: true });
+    writeFileSync(path, "stale content");
+    writeMinkRule(dir);
+    const content = readFileSync(path, "utf-8");
+    expect(content).not.toContain("stale content");
+    expect(content).toContain("Mink");
+  });
+});
+
 describe("init", () => {
   let projectDir: string;
   let memPath: string;
@@ -214,6 +253,21 @@ describe("init", () => {
     expect(content).toContain("my-test-project");
     expect(content).toContain("React");
     expect(content).toContain("TypeScript");
+  });
+
+  test("writes .claude/rules/mink.md as part of init", async () => {
+    writeFileSync(
+      join(projectDir, "package.json"),
+      JSON.stringify({ name: "rule-init-project" })
+    );
+
+    await init(projectDir);
+
+    const rulePath = join(projectDir, ".claude", "rules", "mink.md");
+    expect(existsSync(rulePath)).toBe(true);
+    const content = readFileSync(rulePath, "utf-8");
+    expect(content).toContain("Mink");
+    expect(content).toContain("@drewpayment/mink");
   });
 
   test("does not overwrite existing learning-memory.md on re-init", async () => {


### PR DESCRIPTION
## Summary
- `mink init` now writes `.claude/rules/mink.md` alongside the existing `.claude/settings.json` hook setup, so any Claude Code session in the project sees a rule explaining Mink's role.
- The rule mirrors the file the user landed in `choice-marketing-partners` — points at `~/.mink/` for state, tells Claude to use the `mink-note` skill for capture, and warns against writing to in-repo state dirs.
- Idempotent: re-running `mink init` overwrites the rule so it stays current with new wording.

## Test plan
- [x] `bun test tests/unit/init.test.ts` — new `writeMinkRule` describe block + `init` rule check pass
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run build` — bundles
- [ ] Manual: `mink init` in a fresh repo, confirm `.claude/rules/mink.md` appears with the expected frontmatter and that re-running keeps content fresh

Note: one pre-existing failure in `tests/integration/status.test.ts` ("Daemon: stopped") reproduces on `main` — it picks up a real running daemon on the host and is unrelated to this change.