### PR TITLE
fix(wiki): make vault tree folders clickable and filter from full index

### DIFF
--- a/dashboard/components/panels/wiki-panel.tsx
+++ b/dashboard/components/panels/wiki-panel.tsx
@@ -11,6 +11,16 @@ import { fetchWikiNote } from "@/lib/api-client";
 const CATS = ["all", "inbox", "projects", "areas", "resources", "archives"] as const;
 type Cat = (typeof CATS)[number];
 
+function normalizeSlashes(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+function isInTreePath(filePath: string, treePath: string): boolean {
+  const f = normalizeSlashes(filePath);
+  const t = normalizeSlashes(treePath);
+  return f === t || f.startsWith(t + "/");
+}
+
 function formatTimestamp(iso: string): string {
   if (!iso) return "—";
   const d = new Date(iso);
@@ -28,6 +38,7 @@ export function WikiPanel() {
   const wikiNote = useDashboardStore((s) => s.wikiNote);
   const setWikiNote = useDashboardStore((s) => s.setWikiNote);
   const [cat, setCat] = useState<Cat>("all");
+  const [selectedTreePath, setSelectedTreePath] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
   const [noteError, setNoteError] = useState<string | null>(null);
 
@@ -81,7 +92,10 @@ export function WikiPanel() {
     );
   }
 
-  const filtered = cat === "all" ? wiki.recent : wiki.recent.filter((n) => n.category === cat);
+  const byCat = cat === "all" ? wiki.recent : wiki.recent.filter((n) => n.category === cat);
+  const filtered = selectedTreePath
+    ? byCat.filter((n) => isInTreePath(n.filePath, selectedTreePath))
+    : byCat;
 
   return (
     <div className="page">
@@ -103,17 +117,32 @@ export function WikiPanel() {
             {wiki.tree.length === 0 ? (
               <div className="muted" style={{ fontSize: 11, padding: 6 }}>Vault is empty.</div>
             ) : (
-              wiki.tree.map((n) => (
-                <div
-                  key={n.path}
-                  className="tree-row dir"
-                  style={{ paddingLeft: 10 + n.depth * 14 }}
-                >
-                  <Icon name="folder" size={11} />
-                  <span className="fn">{n.name}</span>
-                  <span className="meta">{n.count}</span>
-                </div>
-              ))
+              wiki.tree.map((n) => {
+                const active = selectedTreePath === n.path;
+                return (
+                  <button
+                    key={n.path}
+                    type="button"
+                    className={`tree-row dir${active ? " on" : ""}`}
+                    style={{
+                      paddingLeft: 10 + n.depth * 14,
+                      width: "100%",
+                      background: "transparent",
+                      border: 0,
+                      textAlign: "left",
+                      font: "inherit",
+                      color: "inherit",
+                    }}
+                    onClick={() =>
+                      setSelectedTreePath((prev) => (prev === n.path ? null : n.path))
+                    }
+                  >
+                    <Icon name="folder" size={11} />
+                    <span className="fn">{n.name}</span>
+                    <span className="meta">{n.count}</span>
+                  </button>
+                );
+              })
             )}
           </div>
         </Card>
@@ -129,6 +158,16 @@ export function WikiPanel() {
                   </button>
                 ))}
               </div>
+              {selectedTreePath && (
+                <button
+                  type="button"
+                  onClick={() => setSelectedTreePath(null)}
+                  title="Clear folder filter"
+                  style={{ background: "transparent", border: 0, padding: 0, marginLeft: 8, cursor: "pointer" }}
+                >
+                  <Chip tone="accent">{selectedTreePath} ×</Chip>
+                </button>
+              )}
             </div>
           }
           flush

--- a/dashboard/components/panels/wiki-panel.tsx
+++ b/dashboard/components/panels/wiki-panel.tsx
@@ -1,25 +1,16 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import type { WikiPanelPayload } from "@mink/types/dashboard";
 import { Card } from "@/components/ui/panel-card";
 import { Chip } from "@/components/ui/chip";
 import { Btn } from "@/components/ui/btn";
 import { Icon } from "@/components/ui/icon";
 import { useDashboardStore } from "@/hooks/use-dashboard-store";
-import { fetchWikiNote } from "@/lib/api-client";
+import { fetchWiki, fetchWikiNote } from "@/lib/api-client";
 
 const CATS = ["all", "inbox", "projects", "areas", "resources", "archives"] as const;
 type Cat = (typeof CATS)[number];
-
-function normalizeSlashes(p: string): string {
-  return p.replace(/\\/g, "/");
-}
-
-function isInTreePath(filePath: string, treePath: string): boolean {
-  const f = normalizeSlashes(filePath);
-  const t = normalizeSlashes(treePath);
-  return f === t || f.startsWith(t + "/");
-}
 
 function formatTimestamp(iso: string): string {
   if (!iso) return "—";
@@ -39,6 +30,8 @@ export function WikiPanel() {
   const setWikiNote = useDashboardStore((s) => s.setWikiNote);
   const [cat, setCat] = useState<Cat>("all");
   const [selectedTreePath, setSelectedTreePath] = useState<string | null>(null);
+  const [filteredWiki, setFilteredWiki] = useState<WikiPanelPayload | null>(null);
+  const [filterLoading, setFilterLoading] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
   const [noteError, setNoteError] = useState<string | null>(null);
 
@@ -48,6 +41,33 @@ export function WikiPanel() {
       setSelected(wiki.recent[0].filePath);
     }
   }, [selected, wiki]);
+
+  // Refetch a path-filtered payload whenever the selected folder changes,
+  // and again when the baseline wiki payload changes (SSE refresh).
+  useEffect(() => {
+    if (!selectedTreePath) {
+      setFilteredWiki(null);
+      setFilterLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setFilterLoading(true);
+    fetchWiki({ path: selectedTreePath })
+      .then((data) => {
+        if (cancelled) return;
+        setFilteredWiki(data);
+        setFilterLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.warn(err);
+        setFilteredWiki(null);
+        setFilterLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedTreePath, wiki]);
 
   // Load selected note body.
   useEffect(() => {
@@ -92,10 +112,10 @@ export function WikiPanel() {
     );
   }
 
-  const byCat = cat === "all" ? wiki.recent : wiki.recent.filter((n) => n.category === cat);
-  const filtered = selectedTreePath
-    ? byCat.filter((n) => isInTreePath(n.filePath, selectedTreePath))
-    : byCat;
+  const notesSource = selectedTreePath ? filteredWiki : wiki;
+  const recent = notesSource?.recent ?? [];
+  const filtered = cat === "all" ? recent : recent.filter((n) => n.category === cat);
+  const showFilterLoading = selectedTreePath && filterLoading && !filteredWiki;
 
   return (
     <div className="page">
@@ -172,7 +192,9 @@ export function WikiPanel() {
           }
           flush
         >
-          {filtered.length === 0 ? (
+          {showFilterLoading ? (
+            <div className="empty"><h4>Loading…</h4></div>
+          ) : filtered.length === 0 ? (
             <div className="empty"><h4>No notes</h4></div>
           ) : (
             <table className="tbl">

--- a/dashboard/lib/api-client.ts
+++ b/dashboard/lib/api-client.ts
@@ -149,10 +149,13 @@ export async function triggerChannelRestart(): Promise<ActionResult> {
   return res.json();
 }
 
-export function fetchWiki(options: { limit?: number; category?: string } = {}) {
+export function fetchWiki(
+  options: { limit?: number; category?: string; path?: string } = {},
+) {
   const params = new URLSearchParams();
   if (options.limit != null) params.set("limit", String(options.limit));
   if (options.category) params.set("category", options.category);
+  if (options.path) params.set("path", options.path);
   const qs = params.toString();
   return fetchApi<WikiPanelPayload>(`/api/wiki${qs ? `?${qs}` : ""}`);
 }

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -7025,6 +7025,14 @@ function tallyTags(entries) {
   }
   return Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
 }
+function normalizeVaultPath(p) {
+  return p.replace(/\\/g, "/");
+}
+function entryMatchesPath(filePath, prefix) {
+  const f = normalizeVaultPath(filePath);
+  const t = normalizeVaultPath(prefix);
+  return f === t || f.startsWith(t + "/");
+}
 function loadWikiPanel(opts = {}) {
   const initialized = isVaultInitialized();
   const vaultPath = resolveVaultPath();
@@ -7042,7 +7050,12 @@ function loadWikiPanel(opts = {}) {
   const index = loadVaultIndex();
   const allEntries = Object.values(index.entries);
   const limit = Math.max(1, Math.min(opts.limit ?? DEFAULT_RECENT_LIMIT, 200));
-  let recent = getRecentNotes(limit);
+  let recent;
+  if (opts.path) {
+    recent = allEntries.filter((e) => entryMatchesPath(e.filePath, opts.path)).sort((a, b) => b.lastModified.localeCompare(a.lastModified)).slice(0, PATH_FILTER_MAX);
+  } else {
+    recent = getRecentNotes(limit);
+  }
   if (opts.category && opts.category !== "all") {
     recent = recent.filter((e) => e.category === opts.category);
   }
@@ -7468,7 +7481,7 @@ async function triggerConfigReset(key, all) {
     };
   }
 }
-var SECRET_KEY_PATTERNS, BOOLEAN_VALUES, GROUP_LABELS, CHANNEL_LOG_LIMIT = 120, TIMESTAMP_PREFIX, WIKI_TREE_MAX_DEPTH = 2, WIKI_TREE_EXCLUDES, DEFAULT_RECENT_LIMIT = 25, VALID_CATEGORIES, DEDUP_TTL_MS = 600000, dedupCache;
+var SECRET_KEY_PATTERNS, BOOLEAN_VALUES, GROUP_LABELS, CHANNEL_LOG_LIMIT = 120, TIMESTAMP_PREFIX, WIKI_TREE_MAX_DEPTH = 2, WIKI_TREE_EXCLUDES, DEFAULT_RECENT_LIMIT = 25, PATH_FILTER_MAX = 500, VALID_CATEGORIES, DEDUP_TTL_MS = 600000, dedupCache;
 var init_dashboard_api = __esm(() => {
   init_paths();
   init_fs_utils();
@@ -7845,10 +7858,12 @@ retry: 3000
           try {
             const limitRaw = url.searchParams.get("limit");
             const categoryRaw = url.searchParams.get("category");
+            const pathRaw = url.searchParams.get("path");
             const limit = limitRaw ? Number(limitRaw) : undefined;
             return jsonResponse(loadWikiPanel({
               limit: Number.isFinite(limit) ? limit : undefined,
-              category: categoryRaw ?? undefined
+              category: categoryRaw ?? undefined,
+              path: pathRaw ?? undefined
             }));
           } catch (err) {
             return jsonResponse({ error: err instanceof Error ? err.message : String(err) }, 500);
@@ -73431,7 +73446,7 @@ var require_ffi_WASM_RELEASE_SYNC = __commonJS((exports) => {
 
 // node_modules/@tootallnate/quickjs-emscripten/dist/generated/emscripten-module.WASM_RELEASE_SYNC.js
 var require_emscripten_module_WASM_RELEASE_SYNC = __commonJS((exports, module) => {
-  var __dirname = "/home/user/mink/node_modules/@tootallnate/quickjs-emscripten/dist/generated", __filename = "/home/user/mink/node_modules/@tootallnate/quickjs-emscripten/dist/generated/emscripten-module.WASM_RELEASE_SYNC.js";
+  var __dirname = "/Users/drewpayment/dev/mink/node_modules/@tootallnate/quickjs-emscripten/dist/generated", __filename = "/Users/drewpayment/dev/mink/node_modules/@tootallnate/quickjs-emscripten/dist/generated/emscripten-module.WASM_RELEASE_SYNC.js";
   var QuickJSRaw = (() => {
     var _scriptDir = typeof document !== "undefined" && document.currentScript ? document.currentScript.src : undefined;
     if (typeof __filename !== "undefined")

--- a/src/core/dashboard-api.ts
+++ b/src/core/dashboard-api.ts
@@ -503,6 +503,19 @@ function tallyTags(entries: VaultIndexEntry[]): Array<[string, number]> {
 interface WikiPanelOptions {
   limit?: number;
   category?: NoteCategory | "all";
+  path?: string;
+}
+
+const PATH_FILTER_MAX = 500;
+
+function normalizeVaultPath(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+function entryMatchesPath(filePath: string, prefix: string): boolean {
+  const f = normalizeVaultPath(filePath);
+  const t = normalizeVaultPath(prefix);
+  return f === t || f.startsWith(t + "/");
 }
 
 export function loadWikiPanel(opts: WikiPanelOptions = {}): WikiPanelPayload {
@@ -524,7 +537,15 @@ export function loadWikiPanel(opts: WikiPanelOptions = {}): WikiPanelPayload {
   const index = loadVaultIndex();
   const allEntries = Object.values(index.entries);
   const limit = Math.max(1, Math.min(opts.limit ?? DEFAULT_RECENT_LIMIT, 200));
-  let recent = getRecentNotes(limit);
+  let recent: VaultIndexEntry[];
+  if (opts.path) {
+    recent = allEntries
+      .filter((e) => entryMatchesPath(e.filePath, opts.path!))
+      .sort((a, b) => b.lastModified.localeCompare(a.lastModified))
+      .slice(0, PATH_FILTER_MAX);
+  } else {
+    recent = getRecentNotes(limit);
+  }
   if (opts.category && opts.category !== "all") {
     recent = recent.filter((e) => e.category === opts.category);
   }

--- a/src/core/dashboard-server.ts
+++ b/src/core/dashboard-server.ts
@@ -470,11 +470,13 @@ export async function startDashboardServer(
           try {
             const limitRaw = url.searchParams.get("limit");
             const categoryRaw = url.searchParams.get("category");
+            const pathRaw = url.searchParams.get("path");
             const limit = limitRaw ? Number(limitRaw) : undefined;
             return jsonResponse(
               loadWikiPanel({
                 limit: Number.isFinite(limit) ? limit : undefined,
                 category: (categoryRaw as "all" | undefined) ?? undefined,
+                path: pathRaw ?? undefined,
               }),
             );
           } catch (err) {


### PR DESCRIPTION
## Summary

- Wires up onClick on each Vault tree row so clicking a folder filters the Notes table to that prefix; click again or hit the chip × to clear.
- Adds an optional `path` query param to `GET /api/wiki`. When set, the server returns **all** index entries under that path prefix (sorted by lastModified desc, capped at 500) instead of the default recent-25 slice. The panel uses this when a folder is selected, and refetches when the baseline payload updates so SSE edits propagate into the filtered view.

Without the second commit, the click filter operates against the recent-25 client-side, so most folders show "No notes" even when the tree count says items exist there.

## Test plan

- [x] `bunx tsc --noEmit` (root) and `cd dashboard && bunx tsc --noEmit` both pass
- [x] `bun run build` and `bun run dashboard:build` both succeed
- [x] `bun test` — 973/974 pass; the 1 failure (`status` "Daemon: stopped") fails on `main` too because a real `mink cron __daemon` is running locally
- [x] `curl /api/wiki` → 25 entries (default unchanged)
- [x] `curl /api/wiki?path=projects/apis/sessions` → 4 entries (full-index match)
- [ ] Verify in browser at `mink dashboard`: clicking a deep tree folder lists notes; chip × clears; category buttons still combine; SSE refresh while filter active doesn't lose the filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)