### PR TITLE
fix(index): surface scan cap and detect stale vault index

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -1133,6 +1133,7 @@ import { readFileSync as readFileSync4, readdirSync, statSync } from "fs";
 function createEmptyVaultIndex() {
   return {
     lastScanTimestamp: "",
+    lastFullScanTimestamp: "",
     totalNotes: 0,
     entries: {}
   };
@@ -1266,7 +1267,9 @@ function rebuildVaultIndex() {
       updateVaultEntry(index, entry);
     } catch {}
   }
-  index.lastScanTimestamp = new Date().toISOString();
+  const now = new Date().toISOString();
+  index.lastScanTimestamp = now;
+  index.lastFullScanTimestamp = now;
   saveVaultIndex(index);
   return index;
 }
@@ -1278,6 +1281,40 @@ function searchVaultIndex(term) {
 function getRecentNotes(n) {
   const index = loadVaultIndex();
   return Object.values(index.entries).sort((a, b) => b.lastModified.localeCompare(a.lastModified)).slice(0, n);
+}
+function vaultIndexStaleness() {
+  const index = loadVaultIndex();
+  const root = resolveVaultPath();
+  const diskCount = collectAllMarkdown(root).length;
+  const indexCount = Object.keys(index.entries).length;
+  const lastFullScan = index.lastFullScanTimestamp || null;
+  if (!lastFullScan) {
+    return {
+      isStale: true,
+      reason: "no full scan on record",
+      diskCount,
+      indexCount,
+      lastFullScan: null
+    };
+  }
+  const delta = Math.abs(diskCount - indexCount);
+  const threshold = Math.max(5, Math.floor(diskCount * 0.05));
+  if (delta >= threshold) {
+    return {
+      isStale: true,
+      reason: `${diskCount} files on disk but ${indexCount} in index`,
+      diskCount,
+      indexCount,
+      lastFullScan
+    };
+  }
+  return {
+    isStale: false,
+    reason: null,
+    diskCount,
+    indexCount,
+    lastFullScan
+  };
 }
 function collectAllMarkdown(rootPath) {
   const files = [];
@@ -3247,11 +3284,16 @@ function loadConfig(configPath3) {
 function getExcludes(config) {
   return [...DEFAULT_EXCLUDES, ...config.excludePatterns ?? []];
 }
-function scanProject(projectRoot, excludes, maxFiles = DEFAULT_MAX_FILES) {
+function scanProjectWithStats(projectRoot, excludes, maxFiles = DEFAULT_MAX_FILES) {
   const results = [];
   walkDirectory(projectRoot, projectRoot, excludes, results);
   results.sort((a, b) => b.mtimeMs - a.mtimeMs);
-  return results.slice(0, maxFiles);
+  const totalScanned = results.length;
+  const files = results.slice(0, maxFiles);
+  return { files, totalScanned, truncated: totalScanned - files.length };
+}
+function scanProject(projectRoot, excludes, maxFiles = DEFAULT_MAX_FILES) {
+  return scanProjectWithStats(projectRoot, excludes, maxFiles).files;
 }
 var DEFAULT_EXCLUDES, DEFAULT_MAX_FILES = 500;
 var init_scanner = __esm(() => {
@@ -3550,7 +3592,11 @@ __export(exports_scan, {
   scan: () => scan
 });
 import { readFileSync as readFileSync11 } from "fs";
-import { join as join14 } from "path";
+import { join as join14, relative as relative2 } from "path";
+function configRelativePath(cfgPath, cwd) {
+  const rel = relative2(cwd, cfgPath);
+  return rel.startsWith("..") ? cfgPath : rel;
+}
 function loadExistingIndex(indexPath) {
   const raw = safeReadJson(indexPath);
   if (isFileIndex(raw))
@@ -3595,7 +3641,8 @@ function scan(cwd, options) {
   }
   const start = Date.now();
   const index = loadExistingIndex(idxPath);
-  const scanned = scanProject(cwd, excludes, maxFiles);
+  const stats = scanProjectWithStats(cwd, excludes, maxFiles);
+  const scanned = stats.files;
   const newIndex = createEmptyIndex();
   newIndex.header.lifetimeHits = index.header.lifetimeHits;
   newIndex.header.lifetimeMisses = index.header.lifetimeMisses;
@@ -3619,7 +3666,13 @@ function scan(cwd, options) {
   newIndex.header.lastScanTimestamp = new Date().toISOString();
   atomicWriteJson(idxPath, newIndex);
   const elapsed = Date.now() - start;
-  console.log(`[mink] indexed ${newIndex.header.totalFiles} files in ${elapsed}ms`);
+  if (stats.truncated > 0) {
+    console.log(`[mink] scanned ${stats.totalScanned} files; indexed ${newIndex.header.totalFiles} most recent in ${elapsed}ms`);
+    console.log(`  ${stats.truncated} files past maxFiles=${maxFiles} were not indexed`);
+    console.log(`  raise the cap by setting "maxFiles" in ${configRelativePath(cfgPath, cwd)}`);
+  } else {
+    console.log(`[mink] indexed ${newIndex.header.totalFiles} files in ${elapsed}ms`);
+  }
 }
 var init_scan = __esm(() => {
   init_paths();
@@ -4829,7 +4882,11 @@ __export(exports_scan2, {
   scan: () => scan2
 });
 import { readFileSync as readFileSync16 } from "fs";
-import { join as join19 } from "path";
+import { join as join19, relative as relative3 } from "path";
+function configRelativePath2(cfgPath, cwd) {
+  const rel = relative3(cwd, cfgPath);
+  return rel.startsWith("..") ? cfgPath : rel;
+}
 function loadExistingIndex2(indexPath) {
   const raw = safeReadJson(indexPath);
   if (isFileIndex(raw))
@@ -4874,7 +4931,8 @@ function scan2(cwd, options) {
   }
   const start = Date.now();
   const index = loadExistingIndex2(idxPath);
-  const scanned = scanProject(cwd, excludes, maxFiles);
+  const stats = scanProjectWithStats(cwd, excludes, maxFiles);
+  const scanned = stats.files;
   const newIndex = createEmptyIndex();
   newIndex.header.lifetimeHits = index.header.lifetimeHits;
   newIndex.header.lifetimeMisses = index.header.lifetimeMisses;
@@ -4898,7 +4956,13 @@ function scan2(cwd, options) {
   newIndex.header.lastScanTimestamp = new Date().toISOString();
   atomicWriteJson(idxPath, newIndex);
   const elapsed = Date.now() - start;
-  console.log(`[mink] indexed ${newIndex.header.totalFiles} files in ${elapsed}ms`);
+  if (stats.truncated > 0) {
+    console.log(`[mink] scanned ${stats.totalScanned} files; indexed ${newIndex.header.totalFiles} most recent in ${elapsed}ms`);
+    console.log(`  ${stats.truncated} files past maxFiles=${maxFiles} were not indexed`);
+    console.log(`  raise the cap by setting "maxFiles" in ${configRelativePath2(cfgPath, cwd)}`);
+  } else {
+    console.log(`[mink] indexed ${newIndex.header.totalFiles} files in ${elapsed}ms`);
+  }
 }
 var init_scan2 = __esm(() => {
   init_paths();
@@ -4961,7 +5025,7 @@ __export(exports_pre_read, {
   preRead: () => preRead,
   analyzePreRead: () => analyzePreRead
 });
-import { relative as relative2 } from "path";
+import { relative as relative4 } from "path";
 function analyzePreRead(filePath, state, index) {
   const warnings = [];
   let repeatedRead = false;
@@ -5003,7 +5067,7 @@ async function preRead(cwd) {
     const absolutePath = input.tool_input.file_path;
     if (!absolutePath)
       return;
-    const filePath = relative2(cwd, absolutePath);
+    const filePath = relative4(cwd, absolutePath);
     const rawState = safeReadJson(sessionPath(cwd));
     const state = isSessionState(rawState) ? rawState : createSessionState();
     const rawIndex = safeReadJson(fileIndexPath(cwd));
@@ -5039,7 +5103,7 @@ __export(exports_post_read, {
   postRead: () => postRead,
   analyzePostRead: () => analyzePostRead
 });
-import { relative as relative3 } from "path";
+import { relative as relative5 } from "path";
 function analyzePostRead(filePath, content, index) {
   if (isBinaryFile(filePath, content ?? undefined)) {
     const entry = index ? lookupEntry(index, filePath) : null;
@@ -5094,7 +5158,7 @@ async function postRead(cwd) {
     const absolutePath = input.tool_input.file_path;
     if (!absolutePath)
       return;
-    const filePath = relative3(cwd, absolutePath);
+    const filePath = relative5(cwd, absolutePath);
     const rawState = safeReadJson(sessionPath(cwd));
     const state = isSessionState(rawState) ? rawState : createSessionState();
     const rawIndex = safeReadJson(fileIndexPath(cwd));
@@ -5205,7 +5269,7 @@ __export(exports_pre_write, {
   preWrite: () => preWrite,
   analyzePreWrite: () => analyzePreWrite
 });
-import { relative as relative4 } from "path";
+import { relative as relative6 } from "path";
 function analyzePreWrite(filePath, writeContent, doNotRepeatEntries, bugMemory) {
   const warnings = [];
   const allMatches = [];
@@ -5255,7 +5319,7 @@ async function preWrite(cwd) {
     const absolutePath = input.tool_input.file_path;
     if (!absolutePath)
       return;
-    const filePath = relative4(cwd, absolutePath);
+    const filePath = relative6(cwd, absolutePath);
     const writeContent = extractWriteContent(input);
     let doNotRepeatEntries = [];
     try {
@@ -5315,7 +5379,7 @@ __export(exports_post_write, {
   postWrite: () => postWrite,
   analyzePostWrite: () => analyzePostWrite
 });
-import { relative as relative5 } from "path";
+import { relative as relative7 } from "path";
 import { readFileSync as readFileSync17 } from "fs";
 function analyzePostWrite(filePath, fileContent, index) {
   if (isWriteExcluded(filePath)) {
@@ -5377,7 +5441,7 @@ async function postWrite(cwd) {
     const absolutePath = input.tool_input.file_path;
     if (!absolutePath)
       return;
-    const filePath = relative5(cwd, absolutePath);
+    const filePath = relative7(cwd, absolutePath);
     let fileContent = null;
     try {
       fileContent = readFileSync17(absolutePath, "utf-8");
@@ -9381,7 +9445,7 @@ var init_server_detect = __esm(() => {
 
 // src/core/design-eval/route-detect.ts
 import { existsSync as existsSync29, readdirSync as readdirSync9, statSync as statSync11 } from "fs";
-import { join as join29, relative as relative6, sep as sep2 } from "path";
+import { join as join29, relative as relative8, sep as sep2 } from "path";
 function detectFramework(cwd) {
   const has = (name) => ["js", "mjs", "ts", "cjs"].some((ext) => existsSync29(join29(cwd, `${name}.${ext}`))) || existsSync29(join29(cwd, name));
   if (has("next.config"))
@@ -9412,7 +9476,7 @@ function detectNextRoutes(cwd) {
   if (existsSync29(appDir)) {
     const pageFiles = findFiles(appDir, /^page\.(tsx?|jsx?)$/);
     for (const file of pageFiles) {
-      const rel = relative6(appDir, file);
+      const rel = relative8(appDir, file);
       const dir = rel.replace(/([/\\])?page\.(tsx?|jsx?)$/, "");
       const route = dir === "" ? "/" : `/${dir.split(sep2).join("/")}`;
       if (/\[|@|\(/.test(route))
@@ -9424,7 +9488,7 @@ function detectNextRoutes(cwd) {
   if (existsSync29(pagesDir)) {
     const pageFiles = findFiles(pagesDir, /\.(tsx?|jsx?)$/);
     for (const file of pageFiles) {
-      const rel = relative6(pagesDir, file);
+      const rel = relative8(pagesDir, file);
       const name = rel.replace(/\.(tsx?|jsx?)$/, "");
       if (/^_(app|document|error)/.test(name))
         continue;
@@ -9446,7 +9510,7 @@ function detectSvelteKitRoutes(cwd) {
   const routes = [];
   const pageFiles = findFiles(routesDir, /^\+page\.svelte$/);
   for (const file of pageFiles) {
-    const rel = relative6(routesDir, file);
+    const rel = relative8(routesDir, file);
     const dir = rel.replace(/([/\\])?\+page\.svelte$/, "");
     const route = dir === "" ? "/" : `/${dir.split(sep2).join("/")}`;
     if (/\[|\(/.test(route))
@@ -9462,7 +9526,7 @@ function detectNuxtRoutes(cwd) {
   const routes = [];
   const vueFiles = findFiles(pagesDir, /\.vue$/);
   for (const file of vueFiles) {
-    const rel = relative6(pagesDir, file);
+    const rel = relative8(pagesDir, file);
     const name = rel.replace(/\.vue$/, "");
     if (/\[/.test(name))
       continue;
@@ -58223,7 +58287,7 @@ var require_util2 = __commonJS((exports) => {
   exports.isAbsolute = function(aPath) {
     return aPath.charAt(0) === "/" || urlRegexp.test(aPath);
   };
-  function relative7(aRoot, aPath) {
+  function relative9(aRoot, aPath) {
     if (aRoot === "") {
       aRoot = ".";
     }
@@ -58242,7 +58306,7 @@ var require_util2 = __commonJS((exports) => {
     }
     return Array(level + 1).join("../") + aPath.substr(aRoot.length + 1);
   }
-  exports.relative = relative7;
+  exports.relative = relative9;
   var supportsNullProto = function() {
     var obj = Object.create(null);
     return !("__proto__" in obj);
@@ -83539,7 +83603,7 @@ import { notStrictEqual, strictEqual } from "assert";
 import { inspect } from "util";
 import { readFileSync as readFileSync26 } from "fs";
 import { fileURLToPath } from "url";
-import { basename as basename9, dirname as dirname14, extname as extname3, relative as relative7, resolve as resolve13 } from "path";
+import { basename as basename9, dirname as dirname14, extname as extname3, relative as relative9, resolve as resolve13 } from "path";
 var REQUIRE_ERROR = "require is not supported by ESM", REQUIRE_DIRECTORY_ERROR = "loading a directory of commands is not supported yet for ESM", __dirname2, mainFilename, esm_default;
 var init_esm = __esm(() => {
   init_cliui();
@@ -83574,7 +83638,7 @@ var init_esm = __esm(() => {
       basename: basename9,
       dirname: dirname14,
       extname: extname3,
-      relative: relative7,
+      relative: relative9,
       resolve: resolve13
     },
     process: {
@@ -90102,6 +90166,7 @@ async function wiki(_cwd, args) {
       wikiStatus();
       break;
     case "rebuild-index":
+    case "scan":
       wikiRebuildIndex();
       break;
     case "organize":
@@ -90121,7 +90186,8 @@ async function wiki(_cwd, args) {
       console.log();
       console.log("  init                Initialize the notes/wiki vault");
       console.log("  status              Show vault statistics");
-      console.log("  rebuild-index       Full rescan and reindex of vault");
+      console.log("  rebuild-index       Full rescan and reindex of vault (alias: scan)");
+      console.log("  scan                Alias for rebuild-index");
       console.log("  organize            List inbox notes needing categorization");
       console.log("  link <path> [name]  Symlink external notes into the vault");
       console.log("  unlink <name>       Remove a symlinked directory from the vault");
@@ -90210,6 +90276,11 @@ function wikiStatus() {
     return;
   }
   const vaultPath = resolveVaultPath();
+  const staleness = vaultIndexStaleness();
+  if (staleness.isStale) {
+    console.log(`[mink] vault index is stale (${staleness.reason}) — rebuilding...`);
+    rebuildVaultIndex();
+  }
   const index = loadVaultIndex();
   const categoryCounts = {
     inbox: 0,
@@ -90232,7 +90303,8 @@ function wikiStatus() {
     console.log(`    ${cat.padEnd(12)} ${count}`);
   }
   console.log();
-  console.log(`  last indexed: ${index.lastScanTimestamp || "never"}`);
+  console.log(`  last full scan: ${index.lastFullScanTimestamp || "never"}`);
+  console.log(`  last update:    ${index.lastScanTimestamp || "never"}`);
   const links = listLinks();
   if (links.length > 0) {
     console.log();
@@ -91719,7 +91791,7 @@ switch (command2) {
     console.log("  config [key] [value]    Manage global user settings");
     console.log();
     console.log("Notes & Wiki:");
-    console.log("  wiki <cmd>              Manage the notes/wiki vault (init|status|link|unlink|links|rebuild-index|organize)");
+    console.log("  wiki <cmd>              Manage the notes/wiki vault (init|status|link|unlink|links|rebuild-index|scan|organize)");
     console.log('  note "text"             Capture a note to the vault');
     console.log("  note --daily [text]     Create or append to today's daily note");
     console.log("  note list [filters]     List notes (--category, --tag, --recent)");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -219,7 +219,7 @@ switch (command) {
     console.log("  config [key] [value]    Manage global user settings");
     console.log();
     console.log("Notes & Wiki:");
-    console.log("  wiki <cmd>              Manage the notes/wiki vault (init|status|link|unlink|links|rebuild-index|organize)");
+    console.log("  wiki <cmd>              Manage the notes/wiki vault (init|status|link|unlink|links|rebuild-index|scan|organize)");
     console.log("  note \"text\"             Capture a note to the vault");
     console.log("  note --daily [text]     Create or append to today's daily note");
     console.log("  note list [filters]     List notes (--category, --tag, --recent)");

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,8 +1,13 @@
 import { readFileSync } from "fs";
-import { join } from "path";
+import { join, relative } from "path";
 import { fileIndexPath, configPath } from "../core/paths";
 import { atomicWriteJson, safeReadJson } from "../core/fs-utils";
-import { scanProject, loadConfig, getExcludes } from "../core/scanner";
+import {
+  scanProject,
+  scanProjectWithStats,
+  loadConfig,
+  getExcludes,
+} from "../core/scanner";
 import { extractDescription } from "../core/description";
 import { estimateTokens } from "../core/token-estimate";
 import {
@@ -12,6 +17,11 @@ import {
   checkStaleness,
 } from "../core/index-store";
 import type { FileIndex, FileIndexEntry } from "../types/file-index";
+
+function configRelativePath(cfgPath: string, cwd: string): string {
+  const rel = relative(cwd, cfgPath);
+  return rel.startsWith("..") ? cfgPath : rel;
+}
 
 function loadExistingIndex(indexPath: string): FileIndex {
   const raw = safeReadJson(indexPath);
@@ -64,7 +74,8 @@ export function scan(cwd: string, options: { check: boolean }): void {
   const start = Date.now();
   const index = loadExistingIndex(idxPath);
 
-  const scanned = scanProject(cwd, excludes, maxFiles);
+  const stats = scanProjectWithStats(cwd, excludes, maxFiles);
+  const scanned = stats.files;
 
   // Build new entries, preserving lifetime counters
   const newIndex = createEmptyIndex();
@@ -95,7 +106,19 @@ export function scan(cwd: string, options: { check: boolean }): void {
   atomicWriteJson(idxPath, newIndex);
 
   const elapsed = Date.now() - start;
-  console.log(
-    `[mink] indexed ${newIndex.header.totalFiles} files in ${elapsed}ms`
-  );
+  if (stats.truncated > 0) {
+    console.log(
+      `[mink] scanned ${stats.totalScanned} files; indexed ${newIndex.header.totalFiles} most recent in ${elapsed}ms`
+    );
+    console.log(
+      `  ${stats.truncated} files past maxFiles=${maxFiles} were not indexed`
+    );
+    console.log(
+      `  raise the cap by setting "maxFiles" in ${configRelativePath(cfgPath, cwd)}`
+    );
+  } else {
+    console.log(
+      `[mink] indexed ${newIndex.header.totalFiles} files in ${elapsed}ms`
+    );
+  }
 }

--- a/src/commands/wiki.ts
+++ b/src/commands/wiki.ts
@@ -14,7 +14,11 @@ import {
 import { atomicWriteJson } from "../core/fs-utils";
 import { setConfigValue } from "../core/global-config";
 import { seedTemplates } from "../core/vault-templates";
-import { rebuildVaultIndex, loadVaultIndex } from "../core/note-index";
+import {
+  rebuildVaultIndex,
+  loadVaultIndex,
+  vaultIndexStaleness,
+} from "../core/note-index";
 import { updateMasterIndex } from "../core/note-linker";
 import type { VaultManifest, NoteCategory } from "../types/note";
 
@@ -32,6 +36,7 @@ export async function wiki(
       wikiStatus();
       break;
     case "rebuild-index":
+    case "scan":
       wikiRebuildIndex();
       break;
     case "organize":
@@ -51,7 +56,8 @@ export async function wiki(
       console.log();
       console.log("  init                Initialize the notes/wiki vault");
       console.log("  status              Show vault statistics");
-      console.log("  rebuild-index       Full rescan and reindex of vault");
+      console.log("  rebuild-index       Full rescan and reindex of vault (alias: scan)");
+      console.log("  scan                Alias for rebuild-index");
       console.log("  organize            List inbox notes needing categorization");
       console.log("  link <path> [name]  Symlink external notes into the vault");
       console.log("  unlink <name>       Remove a symlinked directory from the vault");
@@ -174,6 +180,13 @@ function wikiStatus(): void {
   }
 
   const vaultPath = resolveVaultPath();
+  const staleness = vaultIndexStaleness();
+  if (staleness.isStale) {
+    console.log(
+      `[mink] vault index is stale (${staleness.reason}) — rebuilding...`
+    );
+    rebuildVaultIndex();
+  }
   const index = loadVaultIndex();
 
   const categoryCounts: Record<string, number> = {
@@ -200,7 +213,10 @@ function wikiStatus(): void {
   }
   console.log();
   console.log(
-    `  last indexed: ${index.lastScanTimestamp || "never"}`
+    `  last full scan: ${index.lastFullScanTimestamp || "never"}`
+  );
+  console.log(
+    `  last update:    ${index.lastScanTimestamp || "never"}`
   );
 
   const links = listLinks();

--- a/src/core/note-index.ts
+++ b/src/core/note-index.ts
@@ -7,6 +7,7 @@ import type { VaultIndex, VaultIndexEntry, NoteCategory } from "../types/note";
 export function createEmptyVaultIndex(): VaultIndex {
   return {
     lastScanTimestamp: "",
+    lastFullScanTimestamp: "",
     totalNotes: 0,
     entries: {},
   };
@@ -182,7 +183,9 @@ export function rebuildVaultIndex(): VaultIndex {
     }
   }
 
-  index.lastScanTimestamp = new Date().toISOString();
+  const now = new Date().toISOString();
+  index.lastScanTimestamp = now;
+  index.lastFullScanTimestamp = now;
   saveVaultIndex(index);
   return index;
 }
@@ -217,6 +220,52 @@ export function getRecentNotes(n: number): VaultIndexEntry[] {
   return Object.values(index.entries)
     .sort((a, b) => b.lastModified.localeCompare(a.lastModified))
     .slice(0, n);
+}
+
+export interface VaultStaleness {
+  isStale: boolean;
+  reason: string | null;
+  diskCount: number;
+  indexCount: number;
+  lastFullScan: string | null;
+}
+
+export function vaultIndexStaleness(): VaultStaleness {
+  const index = loadVaultIndex();
+  const root = resolveVaultPath();
+  const diskCount = collectAllMarkdown(root).length;
+  const indexCount = Object.keys(index.entries).length;
+  const lastFullScan = index.lastFullScanTimestamp || null;
+
+  if (!lastFullScan) {
+    return {
+      isStale: true,
+      reason: "no full scan on record",
+      diskCount,
+      indexCount,
+      lastFullScan: null,
+    };
+  }
+
+  const delta = Math.abs(diskCount - indexCount);
+  const threshold = Math.max(5, Math.floor(diskCount * 0.05));
+  if (delta >= threshold) {
+    return {
+      isStale: true,
+      reason: `${diskCount} files on disk but ${indexCount} in index`,
+      diskCount,
+      indexCount,
+      lastFullScan,
+    };
+  }
+
+  return {
+    isStale: false,
+    reason: null,
+    diskCount,
+    indexCount,
+    lastFullScan,
+  };
 }
 
 interface ScannedMarkdown {

--- a/src/core/scanner.ts
+++ b/src/core/scanner.ts
@@ -87,13 +87,29 @@ export function getExcludes(config: ProjectConfig): string[] {
   return [...DEFAULT_EXCLUDES, ...(config.excludePatterns ?? [])];
 }
 
+export interface ScanStats {
+  files: ScannedFile[];
+  totalScanned: number;
+  truncated: number;
+}
+
+export function scanProjectWithStats(
+  projectRoot: string,
+  excludes: string[],
+  maxFiles: number = DEFAULT_MAX_FILES
+): ScanStats {
+  const results: ScannedFile[] = [];
+  walkDirectory(projectRoot, projectRoot, excludes, results);
+  results.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  const totalScanned = results.length;
+  const files = results.slice(0, maxFiles);
+  return { files, totalScanned, truncated: totalScanned - files.length };
+}
+
 export function scanProject(
   projectRoot: string,
   excludes: string[],
   maxFiles: number = DEFAULT_MAX_FILES
 ): ScannedFile[] {
-  const results: ScannedFile[] = [];
-  walkDirectory(projectRoot, projectRoot, excludes, results);
-  results.sort((a, b) => b.mtimeMs - a.mtimeMs);
-  return results.slice(0, maxFiles);
+  return scanProjectWithStats(projectRoot, excludes, maxFiles).files;
 }

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -62,6 +62,7 @@ export interface VaultIndexEntry {
 
 export interface VaultIndex {
   lastScanTimestamp: string;
+  lastFullScanTimestamp?: string;
   totalNotes: number;
   entries: Record<string, VaultIndexEntry>;
 }

--- a/tests/unit/note-index.test.ts
+++ b/tests/unit/note-index.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { rmSync, writeFileSync, mkdtempSync } from "fs";
+import { rmSync, writeFileSync, mkdtempSync, mkdirSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -14,6 +14,9 @@ import {
   loadVaultIndex,
   saveVaultIndex,
   searchVaultIndex,
+  rebuildVaultIndex,
+  updateVaultIndexForFile,
+  vaultIndexStaleness,
 } from "../../src/core/note-index";
 import { ensureVaultStructure } from "../../src/core/vault";
 
@@ -371,6 +374,86 @@ ${longLine}`;
       expect(results.length).toBe(0);
     });
 
+  });
+
+  describe("rebuildVaultIndex", () => {
+    test("indexes nested subdirectories", () => {
+      mkdirSync(join(tempDir, "areas", "Personal"), { recursive: true });
+      mkdirSync(join(tempDir, "resources", "People", "Team"), {
+        recursive: true,
+      });
+      writeFileSync(join(tempDir, "inbox", "top.md"), "# Top\n");
+      writeFileSync(
+        join(tempDir, "areas", "Personal", "deep.md"),
+        "# Deep\n"
+      );
+      writeFileSync(
+        join(tempDir, "resources", "People", "Team", "deeper.md"),
+        "# Deeper\n"
+      );
+
+      const index = rebuildVaultIndex();
+      const paths = Object.keys(index.entries);
+      expect(paths).toContain("inbox/top.md");
+      expect(paths).toContain("areas/Personal/deep.md");
+      expect(paths).toContain("resources/People/Team/deeper.md");
+    });
+
+    test("sets lastFullScanTimestamp", () => {
+      writeFileSync(join(tempDir, "inbox", "note.md"), "# A\n");
+      const index = rebuildVaultIndex();
+      expect(index.lastFullScanTimestamp).toBeTruthy();
+      expect(index.lastScanTimestamp).toBeTruthy();
+    });
+
+    test("updateVaultIndexForFile does not bump lastFullScanTimestamp", () => {
+      writeFileSync(join(tempDir, "inbox", "first.md"), "# First\n");
+      const fullIdx = rebuildVaultIndex();
+      const fullStamp = fullIdx.lastFullScanTimestamp;
+
+      const filePath = join(tempDir, "inbox", "second.md");
+      writeFileSync(filePath, "# Second\n");
+      updateVaultIndexForFile(filePath, "# Second\n");
+
+      const after = loadVaultIndex();
+      expect(after.lastFullScanTimestamp).toBe(fullStamp);
+    });
+  });
+
+  describe("vaultIndexStaleness", () => {
+    test("flags stale when no full scan recorded", () => {
+      writeFileSync(join(tempDir, "inbox", "a.md"), "# A\n");
+      const result = vaultIndexStaleness();
+      expect(result.isStale).toBe(true);
+      expect(result.reason).toContain("no full scan");
+      expect(result.diskCount).toBe(1);
+    });
+
+    test("not stale immediately after rebuild", () => {
+      writeFileSync(join(tempDir, "inbox", "a.md"), "# A\n");
+      writeFileSync(join(tempDir, "inbox", "b.md"), "# B\n");
+      rebuildVaultIndex();
+      const result = vaultIndexStaleness();
+      expect(result.isStale).toBe(false);
+      expect(result.diskCount).toBe(2);
+      expect(result.indexCount).toBe(2);
+    });
+
+    test("flags stale when disk count diverges past threshold", () => {
+      writeFileSync(join(tempDir, "inbox", "a.md"), "# A\n");
+      rebuildVaultIndex();
+      // Add 10 more without indexing
+      for (let i = 0; i < 10; i++) {
+        writeFileSync(join(tempDir, "inbox", `extra-${i}.md`), `# Extra ${i}\n`);
+      }
+      const result = vaultIndexStaleness();
+      expect(result.isStale).toBe(true);
+      expect(result.diskCount).toBe(11);
+      expect(result.indexCount).toBe(1);
+    });
+  });
+
+  describe("searchVaultIndex (cont)", () => {
     test("case-insensitive search", () => {
       const index = createEmptyVaultIndex();
       updateVaultEntry(index, {

--- a/tests/unit/scanner.test.ts
+++ b/tests/unit/scanner.test.ts
@@ -10,6 +10,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 import {
   scanProject,
+  scanProjectWithStats,
   getExcludes,
   loadConfig,
   DEFAULT_EXCLUDES,
@@ -201,6 +202,26 @@ describe("scanner", () => {
     test("handles empty project directory", () => {
       const results = scanProject(dir, DEFAULT_EXCLUDES);
       expect(results).toHaveLength(0);
+    });
+
+    test("scanProjectWithStats reports truncation when over cap", () => {
+      for (let i = 0; i < 10; i++) {
+        writeFileSync(join(dir, `file${i}.ts`), `export const x${i} = ${i};`);
+      }
+
+      const stats = scanProjectWithStats(dir, DEFAULT_EXCLUDES, 5);
+      expect(stats.files).toHaveLength(5);
+      expect(stats.totalScanned).toBe(10);
+      expect(stats.truncated).toBe(5);
+    });
+
+    test("scanProjectWithStats reports zero truncation under cap", () => {
+      writeFileSync(join(dir, "a.ts"), "x");
+      writeFileSync(join(dir, "b.ts"), "x");
+
+      const stats = scanProjectWithStats(dir, DEFAULT_EXCLUDES, 100);
+      expect(stats.totalScanned).toBe(2);
+      expect(stats.truncated).toBe(0);
     });
 
     test("applies custom exclude patterns", () => {


### PR DESCRIPTION
## Summary

Two indexing bugs surfaced when debugging a vault with 831 `.md` files showing only 100 in the index:

- **`mink scan` silently truncated past `maxFiles`.** With the default cap of 500 and 831 files on disk, the command logged "indexed 500" and gave no signal that 331 files were dropped. Symptom looked like "fails to recurse into nested subfolders" but the walker is recursive — sort-by-mtime + slice was the culprit.
- **Vault index drifted out of sync with disk.** `mink note` upserts called `updateVaultIndexForFile`, which bumped `lastScanTimestamp` on every single-file write. A fresh timestamp therefore did not imply a full rescan happened, and divergence between disk and index went undetected.

## Changes

- `scanner.ts`: add `scanProjectWithStats` returning `{ files, totalScanned, truncated }`. `scanProject` keeps its existing signature.
- `commands/scan.ts`: when truncation occurs, log how many files were dropped and which config to edit to raise the cap.
- `types/note.ts`, `core/note-index.ts`: add `VaultIndex.lastFullScanTimestamp` (optional). Only `rebuildVaultIndex` sets it.
- `core/note-index.ts`: add `vaultIndexStaleness()` — compares disk count to index entries and flags when no full scan is on record or the divergence exceeds 5% / 5 files.
- `commands/wiki.ts`: `wiki status` calls `vaultIndexStaleness` and auto-rebuilds when stale; status output now shows both `last full scan` and `last update`.
- `commands/wiki.ts`, `cli.ts`: add `mink wiki scan` as alias for `mink wiki rebuild-index`.
- Tests: added coverage for scan stats, nested-subdir indexing, full-scan timestamp, and staleness detection.

## Before / after

```
$ mink scan                          # vault with 855 .md files
- [mink] indexed 500 files in 32ms
+ [mink] scanned 855 files; indexed 500 most recent in 32ms
+   355 files past maxFiles=500 were not indexed
+   raise the cap by setting "maxFiles" in /Users/.../config.json

$ mink wiki status                   # stale index, 837 files on disk
+ [mink] vault index is stale (no full scan on record) — rebuilding...
  [mink] vault status
    notes:   837
+   last full scan: 2026-05-08T17:59:18.172Z
+   last update:    2026-05-08T17:59:18.172Z
```

## Test plan

- [x] `bun run typecheck` passes.
- [x] `bun run build` succeeds.
- [x] `bun test tests/unit/scanner.test.ts tests/unit/note-index.test.ts` — 66 pass, 0 fail.
- [x] Full `bun test` — 993 pass, 1 pre-existing fail (`status.test.ts` daemon assertion picks up real local PID; reproduces on `main`).
- [x] Smoke-tested built CLI: `mink scan` shows new truncation warning; `mink wiki status` auto-rebuilt stale index from 100 → 837; `mink wiki scan` works as alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)