### PR TITLE
feat(identity): spec 20 + implementation — stable project identity (closes #72)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      dist_tag:
+        description: "npm dist-tag (leave blank to derive from the pre-release identifier in package.json)"
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -91,3 +97,73 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-prerelease:
+    # Manual pre-release publish from any branch. Refuses to run unless the
+    # version in package.json carries a pre-release identifier (e.g.,
+    # 0.11.0-beta.1) so it can never collide with the `latest` dist-tag that
+    # release-please drives off main.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Resolve version and dist-tag
+        id: resolve
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ ! "$VERSION" =~ -([a-z]+)\.[0-9]+$ ]]; then
+            echo "::error::package.json version '$VERSION' is not a pre-release. Expected form like 0.11.0-beta.1, -rc.1, or -alpha.1."
+            exit 1
+          fi
+          DERIVED="${BASH_REMATCH[1]}"
+          INPUT_TAG="${{ inputs.dist_tag }}"
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="$DERIVED"
+          fi
+          if [ "$TAG" = "latest" ]; then
+            echo "::error::Refusing to publish a pre-release under the 'latest' dist-tag."
+            exit 1
+          fi
+          echo "dist_tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Publishing version $VERSION under dist-tag '$TAG'"
+
+      - name: Build
+        run: bun run build
+
+      - name: Build dashboard
+        run: |
+          cd dashboard
+          bun install --frozen-lockfile
+          bun run build
+
+      - name: Test
+        run: bun test
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm with pre-release dist-tag
+        run: npm publish --tag "${{ steps.resolve.outputs.dist_tag }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "Published @drewpayment/mink@${{ steps.resolve.outputs.version }} → dist-tag '${{ steps.resolve.outputs.dist_tag }}'" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Install with:" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "npm i -g @drewpayment/mink@${{ steps.resolve.outputs.dist_tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,6 @@ Key domains:
 
 ## Git Workflow
 
-- **Never push directly to `main`.** All work must go on a feature branch with a PR targeting `main`.
-- Only human intervention should push directly to `main`.
-- Feature branches should be created for each spec or logical unit of work.
+- **Always commit and push work to a feature branch.** When work is ready to share, commit it, push the branch, and open a PR targeting `main` without waiting for further confirmation.
+- **Never push directly to `main`.** Only human intervention pushes to `main`. Claude must never push to `main`, force-push to `main`, or merge a PR into `main`.
+- Feature branches should be created for each spec or logical unit of work. Use the existing naming convention (`spec/...`, `feat/...`, `fix/...`, `docs/...`, `chore/...`).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,117 @@
+# Releasing
+
+Mink publishes to npm as `@drewpayment/mink`. The CLI's auto-update path
+follows the `latest` dist-tag, so anything tagged `latest` reaches every user
+on their next scheduled update.
+
+## Normal release (`latest`)
+
+Conventional commits land on `main` → `release-please` opens a release PR →
+merging that PR cuts a tag and publishes to npm under the `latest` dist-tag.
+
+This path is fully automated; nothing to do by hand.
+
+## Pre-release (`beta`, `rc`, `alpha`)
+
+Use a pre-release dist-tag whenever you want a build that can be installed
+explicitly without auto-update picking it up. Typical reasons:
+
+- Risky migrations (e.g. project-identity v3 in spec 20).
+- Cross-machine convergence tests that need two real installs.
+- Soaking new features for a week before promoting to `latest`.
+
+### Cut a beta
+
+1. Branch off the feature branch (don't reuse it — you don't want the version
+   bump merging to `main`):
+
+   ```bash
+   git switch -c beta/0.11.0-beta.1
+   ```
+
+2. Bump `package.json` to the pre-release version:
+
+   ```bash
+   npm version 0.11.0-beta.1 --no-git-tag-version
+   git commit -am "chore: publish 0.11.0-beta.1"
+   git push -u origin beta/0.11.0-beta.1
+   ```
+
+   The version must end with `-beta.N`, `-rc.N`, or `-alpha.N`. The workflow
+   rejects anything else and refuses to publish to `latest`.
+
+3. GitHub → **Actions** → **Release** → **Run workflow** → pick the
+   `beta/0.11.0-beta.1` branch. Leave the `dist_tag` input blank to derive it
+   from the pre-release identifier (`beta`), or set it explicitly.
+
+4. The workflow builds, tests, and publishes. The run summary prints the
+   exact install command, e.g.:
+
+   ```bash
+   npm i -g @drewpayment/mink@beta
+   ```
+
+### Test the beta
+
+On each test machine:
+
+```bash
+# Back up real state first
+cp -r ~/.mink ~/.mink.backup-pre-beta
+
+# Install the beta explicitly
+npm i -g @drewpayment/mink@beta
+mink --version    # confirms the pre-release version
+
+# Optional: sandbox the test entirely
+export MINK_HOME=~/.mink-sandbox
+mink init
+```
+
+Auto-update will not pull this version — it only follows `latest`.
+
+### Iterate
+
+Each iteration bumps the pre-release counter:
+
+```bash
+npm version 0.11.0-beta.2 --no-git-tag-version
+git commit -am "chore: publish 0.11.0-beta.2"
+git push
+# Run the workflow again against the same branch.
+```
+
+### Promote to `latest`
+
+When the beta has soaked long enough, promote without re-publishing:
+
+```bash
+npm dist-tag add @drewpayment/mink@0.11.0-beta.N latest
+```
+
+After promoting, merge the feature branch (the original one, **without** the
+pre-release version bump) into `main`. Release-please will then cut the real
+`0.11.0` from conventional commits and publish it under `latest`.
+
+The beta version stays on npm forever (registry policy), but no auto-update
+client will install it once `latest` has moved on.
+
+### Abandon a beta
+
+If a beta is wrong, do nothing — there is no untagging or unpublishing. Just
+cut the next pre-release (`-beta.N+1`) or never promote. `latest` is
+unaffected.
+
+## Manual `latest` release
+
+If `release-please` is unhealthy and you need to ship `latest` by hand, cut
+a GitHub Release through the UI. The `publish-from-manual-release` job picks
+it up and publishes with the default `latest` tag.
+
+## Safety rails
+
+- The `publish-prerelease` job refuses to run unless `package.json` carries a
+  pre-release identifier.
+- The job refuses an explicit `dist_tag` of `latest`.
+- `release-please` only runs on push to `main`, so dispatching the workflow
+  from a feature branch cannot touch the release manifest.

--- a/specs/20-stable-project-identity.md
+++ b/specs/20-stable-project-identity.md
@@ -145,6 +145,16 @@ A user who upgrades to the new version, migrates, and then downgrades to the pre
 
 A user whose two machines run different Mink versions during the rollout window must not see data corruption. The newer version writes the new fields; the older version ignores them; the existing sync merge drivers tolerate the schema difference.
 
+### Safety Mechanisms
+
+Because the migration rewrites on-disk directory names, three safety mechanisms protect the user from an unwanted outcome:
+
+- **Dry-run** — A user-invokable command prints the proposed rename plan (which projects would be renamed, which would be left alone, and why) without touching the filesystem. The user inspects the plan before opting in.
+- **Pre-migration backup** — Before the first rename in a migration pass, the migration snapshots every project directory that is about to be renamed into a timestamped backup folder under the Mink root. The snapshot is per-project (only projects that will actually change identity) so its cost is bounded, and it survives the migration so a user who discovers a problem later still has a snapshot to inspect or restore from.
+- **Rollback command** — A user-invokable command walks every project whose alias list is non-empty, renames the project directory back to the most recently appended alias, and pops that entry from the list. Rollback uses the alias list as the primary source of truth (which was written atomically with the rename) and falls back to the pre-migration backup only if alias-based rollback cannot proceed.
+
+Rollback alone is sufficient to recover from a botched migration. The pre-migration backup is a belt-and-suspenders safeguard in case the alias list itself is corrupted.
+
 ## Acceptance Criteria
 
 ```
@@ -280,6 +290,35 @@ GIVEN the user runs the init command in a fresh repo with the flag on
 WHEN init completes
 THEN the printed project identifier reflects the git-derived form
 AND if the repo has no remote yet, the printed identifier is the path-derived fallback and a short note explains how to stabilize it
+
+GIVEN the user invokes the migration with the dry-run option
+WHEN the command runs
+THEN the proposed rename plan is printed
+AND no project directory is renamed
+AND no alias is recorded
+AND no backup is written
+
+GIVEN a real migration pass is about to rename a project directory
+WHEN the rename is attempted
+THEN a snapshot of the project's contents is first written to a timestamped backup folder under the Mink root
+AND the snapshot survives the migration so it can be inspected or restored from later
+
+GIVEN a user invokes the rollback command after a migration ran
+WHEN the command processes a project whose alias list is non-empty
+THEN the project directory is renamed back to the most recently appended alias
+AND that alias is popped from the list
+AND the project's files are unchanged from before the original migration
+
+GIVEN the rollback target directory already exists for some project
+WHEN the rollback command tries to rename onto it
+THEN the rollback for that project is reported as failed
+AND no destination directory is overwritten
+AND rollback continues processing other projects
+
+GIVEN no project on disk has a non-empty alias list
+WHEN the rollback command runs
+THEN the command reports there is nothing to roll back
+AND exits cleanly with no filesystem changes
 ```
 
 ## Edge Cases

--- a/specs/20-stable-project-identity.md
+++ b/specs/20-stable-project-identity.md
@@ -1,0 +1,349 @@
+# 20 — Stable Project Identity
+
+## Overview
+
+Mink keeps a separate slice of state for each project the user works in — session history, file index, token ledger, learning memory, bug memory, action log, daily notes. Today, the identity that keys that state is derived from the project directory's absolute path on disk. That works for a single machine, but it falls apart the moment the same repository is checked out at a different path on a second machine: the two checkouts look like two unrelated projects, the dashboard shows duplicate entries, and none of the per-project history follows the user from one machine to the other.
+
+This spec replaces the path-derived identity with a stable identity that emerges from artifacts the repository already carries with it. When the project is a git checkout with a configured remote, the identity is derived from the normalized remote URL combined with the subpath inside the repository. When the user wants to pin a specific identity by hand, an override file inside the repository takes precedence. When no usable signal exists — a brand-new directory with no remote, a non-versioned folder — the resolver falls back to the existing path-derived identity so non-git workflows are not disturbed. The change is rolled out behind a configuration flag, and the on-disk migration from the old identity layout to the new one runs through the same sync-version mechanism Mink already uses for prior storage-shape changes.
+
+## Capabilities
+
+### Identity Resolver
+
+Project identity must be resolved through a deterministic priority order:
+
+1. **Explicit override** — If the project directory contains an override file declaring a chosen identifier and that identifier passes validation, use it verbatim and stop.
+2. **Git-derived identity** — If the working directory lies inside a git repository with a configured remote, derive the identity from the normalized remote URL combined with the subpath from the repository root.
+3. **Path-derived fallback** — Otherwise, fall back to a hash of the canonical absolute path. This preserves today's behavior for non-git directories or git directories that have not yet configured a remote.
+
+The resolver must never error out. Each tier falls through cleanly to the next if its precondition is not met or its input is malformed.
+
+### Override File
+
+A small file inside the project's repository allows the user to pin a chosen identifier so that two checkouts of forked repos, or a renamed repo whose new remote should still resolve to the old identity, can be unified by hand.
+
+The override file's purpose is to declare an identifier and nothing else. It is not a general project configuration file.
+
+Validation rules:
+
+- The declared identifier must be non-empty.
+- The identifier must consist only of characters that are safe as a directory name on all supported filesystems.
+- The identifier must not exceed a documented length cap.
+- A malformed override (invalid file format, missing identifier field, identifier outside the allowed character set or length) is rejected with a clear error and the resolver falls through to the next tier.
+
+The override file is intended to be committed to the repository so that both machines share the same pin without further coordination.
+
+### Git-Derived Identity
+
+When the resolver derives identity from git, it must produce the same identifier on every machine that has cloned the same logical repository, regardless of which protocol or which absolute path that machine used.
+
+Two ingredients combine to form the identity:
+
+- **Normalized remote URL** — The configured remote URL, reduced to a canonical string. The normalization rules must collapse all of the following forms for the same logical repo to a single canonical string:
+  - Secure-shell style and HTTPS style of the same remote.
+  - Remotes with or without embedded credentials.
+  - Remotes with or without a trailing slash.
+  - Remotes with or without a `.git` suffix.
+  - Remotes whose host and owner segments differ only in letter casing.
+- **Repository-root-relative subpath** — The path from the repository root down to the working directory at the moment of resolution. Determined by asking git, not by guessing from the absolute path. The repository root produces an empty subpath; a one-level-deep subdirectory produces a one-segment subpath. The subpath is normalized to forward-slash form with no trailing slash before it participates in the identity.
+
+The two ingredients are combined into a short identifier that contains a human-readable slug followed by a short stable hash. The slug is derived from the deepest meaningful name segment so the identifier remains scannable in a directory listing. The hash ensures the identifier is collision-resistant across the entire space of possible (remote, subpath) pairs.
+
+Identifier format must be safe as a directory name on macOS, Linux, and Windows. Total length must be bounded.
+
+### Monorepo Disambiguation
+
+The subpath ingredient is critical for monorepos. Two sibling services under one shared remote must resolve to two distinct identifiers, because they are two distinct projects to Mink — they have their own conventions, their own session history, their own notes. Two checkouts of the *same* service inside the monorepo at different absolute paths on different machines still unify, because both produce the same subpath.
+
+### Path-Derived Fallback
+
+When no override exists and the directory either is not inside a git repository or is inside one with no configured remote, the resolver falls back to the legacy behavior: a slug derived from the directory's leaf name combined with a short hash of the canonical absolute path.
+
+The path-derived tier exists so that:
+
+- Non-git workflows continue to function exactly as before.
+- A brand-new project that has not yet configured a remote is not blocked from using Mink while the user sets things up.
+- The transition from path-derived to git-derived for any one project can happen lazily — the moment a remote is configured, the next resolution picks it up.
+
+When the resolver lands on the path-derived tier inside a git repo that is missing a remote, it must emit a one-time warning explaining that the project will not unify across machines until a remote is configured or the override file is added. The warning must not repeat on every command.
+
+### Per-Device Path Map
+
+Today the project record stores a single working-copy path field — the path on the machine that initialized the project. After the change, that singular field becomes a device-keyed map: each machine that touches the project records its own local working-copy path under its own device identifier. No device's entry overwrites another's.
+
+The map is consumed when the dashboard or other surface needs to know where on the local disk to find the project's files. The map is also a useful diagnostic for the user, showing at a glance which machines have ever touched the project.
+
+When older records are read for the first time after the change, the singular path field must be upgraded in memory to a single-entry map keyed by the device that owned it. Subsequent writes persist the map.
+
+### Alias List
+
+Every project record carries a list of prior identifiers it was previously known by. The list grows in two situations:
+
+- The migration that moves a project from the old path-derived identifier to the new git-derived identifier records the prior identifier as an alias.
+- A subsequent identity change — for example, the remote URL is rewritten because the repository is renamed or transferred between owners — also records the prior identifier as an alias.
+
+Aliases are honored by every part of Mink that resolves an identifier to a project: dashboard routing, note source-project references, wiki link resolution, and command-line lookups. A historical reference using an old identifier must still resolve to the same project after the rename.
+
+Aliases are never garbage-collected. Their storage cost is negligible and the user-facing benefit — links and bookmarks that survive across years of remote-URL churn — is large.
+
+### Cross-Device Convergence
+
+Two machines that flip the identity flag on and run their first session-start independently must converge. Both derive the same target identifier from the same git remote, so both pick the same directory name for the project's state. When their state next synchronizes, the sync layer's existing merge handling unions the per-device path map and the alias list without conflict.
+
+If one machine has already migrated and pushed its state while a second machine still holds the old directory, the next sync pass must reconcile by folding the old directory's contents into the new one — never the other way around, never silently dropping files.
+
+### Migration
+
+The migration from the old identity layout to the new one is triggered eagerly on the next session-start hook after the identity flag is set to its new value. The migration reuses the same pattern Mink already uses for sync-layout changes: a single version marker, a coordination lock so two processes do not migrate concurrently, an idempotent pass that can be re-run if interrupted, and a resumable design that picks up where it left off if killed mid-flight.
+
+For each existing project directory whose identity changes:
+
+- Compute the new identifier from the working-copy path recorded on the project.
+- Rename the project directory from the old identifier to the new one, preferring a history-preserving rename where the directory is tracked by version control.
+- Record the old identifier on the project's alias list.
+- Lift the singular working-copy path field into the device-keyed map, keyed by the device that owned the record.
+
+Projects whose identity does not change (for example, projects with no git remote) are left alone.
+
+If the migration is interrupted between the directory rename and the metadata write, the resolver can still recompute the same target identifier from the working-copy path, so the next run completes the metadata update without redoing the rename. If the migration is interrupted in the middle of processing the project list, the next run picks up the unprocessed projects.
+
+### Configuration
+
+A single new configuration key controls the rollout:
+
+- **`projects.identity`** — Values: `path-derived` (default during rollout) or `git-remote`. When set to `path-derived`, the legacy behavior runs unchanged: the resolver returns the path-derived identifier, the override file is not consulted, and no migration runs. When set to `git-remote`, the full resolver chain is active and the migration runs on the next session-start.
+
+Setting the key follows the same precedence rules as every other Mink configuration value: environment variable beats local file beats shared file beats default.
+
+The default value is `path-derived` during the initial release so that existing users see no change until they opt in. A future release may flip the default to `git-remote` once the opt-in version has proven out in the field.
+
+### Init Behavior
+
+When the user initializes Mink in a repository, the identifier printed by the init command must reflect the resolver's output for that directory:
+
+- If the override file is present, the printed identifier is the overridden value.
+- If the directory is inside a git repository with a remote, the printed identifier is the git-derived value.
+- If the directory is inside a git repository with no remote yet, the printed identifier is the path-derived fallback, and the output includes a short note explaining how to stabilize the identity by configuring a remote or adding an override file.
+- If the directory is not a git repository at all, the printed identifier is the path-derived value with no note.
+
+When a remote is added to a previously remote-less repository, the next session-start must detect the change, offer to migrate that single project's directory to the new git-derived identifier, and record the previous path-derived identifier as an alias.
+
+### Dashboard Compatibility
+
+The dashboard surfaces project state by identifier — in URLs, in routing, in cached project lookups. After the migration:
+
+- Routing must resolve both the new primary identifier and every aliased prior identifier to the same project.
+- Bookmarks and links that reference an old identifier must continue to work.
+- Any in-memory or worker-process cache that the dashboard keeps of project identifiers must invalidate on identifier change so it never serves a stale directory pointer.
+
+### Forward and Backward Compatibility
+
+A user who upgrades to the new version, migrates, and then downgrades to the previous version must not lose data. The old version must:
+
+- Continue to read state out of the renamed directories without crashing.
+- Preserve the alias list and per-device path map fields on write rather than dropping them silently.
+
+A user whose two machines run different Mink versions during the rollout window must not see data corruption. The newer version writes the new fields; the older version ignores them; the existing sync merge drivers tolerate the schema difference.
+
+## Acceptance Criteria
+
+```
+GIVEN the user's repo contains a project override file declaring a chosen identifier
+WHEN Mink resolves the project identity at session start
+THEN the chosen identifier is used verbatim
+AND the git remote and path-derived strategies are skipped
+
+GIVEN the override file declares an identifier that contains characters outside the allowed alphabet
+WHEN Mink reads the override
+THEN the override is rejected with a clear validation error
+AND the resolver falls through to the next strategy
+AND the user is told what shape the identifier must take
+
+GIVEN the working directory is inside a git repo with a single configured remote and the override file is absent
+WHEN Mink resolves the project identity
+THEN the identity is derived from the normalized remote URL combined with the subpath from the repo root
+AND the same identity is produced no matter which absolute path the repo is checked out at
+
+GIVEN the working directory is inside a git repo with no configured remote and no override file
+WHEN Mink resolves the project identity
+THEN the resolver falls back to the absolute-path hash
+AND a one-time warning explains that the project will not unify across machines until a remote is configured or an override is added
+
+GIVEN the working directory is not inside a git repo at all
+WHEN Mink resolves the project identity
+THEN the resolver falls back to the absolute-path hash
+AND no warning is emitted because git-derived identity was never expected
+
+GIVEN the same repo is reachable through an SSH-style remote on one machine and an HTTPS-style remote on another
+WHEN Mink resolves the project identity on each machine
+THEN both machines compute the same identifier
+AND credentials, trailing slashes, dot-git suffixes, and host casing do not affect the result
+
+GIVEN the same repo's remote uses uppercase or mixed-case host and owner segments
+WHEN Mink normalizes the remote URL
+THEN host and owner segments are lowercased before hashing
+AND the repository segment retains its original case if the hosting provider treats repo names as case-sensitive, but the normalization rule is documented and consistent
+
+GIVEN a monorepo contains two sibling services in different subdirectories
+WHEN Mink resolves the identity from inside each subdirectory
+THEN the two services receive distinct identifiers
+AND project state, learning memory, and notes for each service stay isolated
+
+GIVEN the user runs Mink from the root of a repo rather than a subdirectory
+WHEN Mink resolves the identity
+THEN the subpath component is empty
+AND the resulting identifier is stable for that repo's root regardless of where the working copy lives on disk
+
+GIVEN the identity feature flag is set to the legacy path-derived mode
+WHEN any Mink command runs
+THEN the absolute-path hash is used as before
+AND no migration occurs
+AND no override or remote is consulted
+
+GIVEN the identity feature flag is flipped to the git-remote mode for the first time
+WHEN the next session-start hook fires
+THEN a migration pass runs once
+AND every existing project directory is examined, its new identity computed, and its directory renamed when the identity changes
+AND the previous identifier is recorded as an alias on the project so historical references still resolve
+
+GIVEN a migration pass renames a project directory
+WHEN any later lookup uses the old identifier
+THEN the lookup transparently resolves to the renamed directory via the alias list
+AND no data is lost from the rename
+
+GIVEN two machines independently flip the identity flag on and run migration
+WHEN their state later synchronizes
+THEN both machines converge on the same directory name for the shared repo
+AND each machine's local working-copy path is preserved on the project record under a per-device map
+AND neither machine's working-copy path overwrites the other
+
+GIVEN the migration runs on a project whose record previously stored a single working-copy path
+WHEN the migration finishes
+THEN the singular path is replaced with a per-device map keyed by the device that owned it
+AND subsequent commands on either device update only their own entry in the map
+
+GIVEN a user opens the dashboard immediately after a migration
+WHEN the dashboard lists projects, surfaces notes for a project, or routes by project identifier
+THEN every project is reachable under its new identifier
+AND every historical link or bookmark using the old identifier still resolves
+
+GIVEN a wiki note recorded a source project using the old identifier before migration
+WHEN the note is viewed after migration
+THEN the note still resolves to the same project page
+AND backlinks from the project page back to the note are intact
+
+GIVEN the git remote URL for a repo is changed after migration
+WHEN Mink next resolves the identity
+THEN a new identifier is computed
+AND on first detection the previous identifier is added to the alias list automatically so prior state remains reachable
+AND the user is informed that the remote changed and given a one-line command to confirm or override
+
+GIVEN the user adds an override file pointing a moved repo back to its original identifier
+WHEN Mink resolves the identity
+THEN the override wins
+AND the project resumes writing to the original directory without any further migration
+
+GIVEN two devices simultaneously sync after migration and one device still has the old directory while the other has the new directory
+WHEN the sync merge runs
+THEN both directories are reconciled into the new one
+AND no file from the old directory is silently dropped
+AND the alias list and per-device path map are merged without conflict
+
+GIVEN the override file on one device says one identifier and the override file on another device says a different identifier
+WHEN the two devices sync
+THEN the conflict is surfaced to the user with a clear explanation of both choices
+AND Mink does not silently pick a winner
+
+GIVEN a migration pass is interrupted before it finishes
+WHEN the next session-start runs
+THEN migration resumes from where it left off
+AND no project is migrated twice
+AND no project is left half-renamed
+
+GIVEN migration is already in progress in one process
+WHEN a second Mink process tries to run migration concurrently
+THEN the second process detects the in-flight migration and waits or skips cleanly
+AND no directory is corrupted by overlapping renames
+
+GIVEN a user downgrades to an older Mink version after migration has run
+WHEN the older version starts up
+THEN it continues to function against the renamed directories
+AND it ignores the alias list and per-device path map fields it does not understand rather than rewriting or erasing them
+
+GIVEN the identity flag is on and a project's git remote is genuinely missing
+WHEN the user adds a remote later
+THEN the next session-start re-resolves the identity
+AND offers to migrate that single project's directory to the new git-derived identifier
+AND the previous path-derived identifier is recorded as an alias
+
+GIVEN the user runs the init command in a fresh repo with the flag on
+WHEN init completes
+THEN the printed project identifier reflects the git-derived form
+AND if the repo has no remote yet, the printed identifier is the path-derived fallback and a short note explains how to stabilize it
+```
+
+## Edge Cases
+
+- Remote URL forms that must normalize to the same canonical string: secure-shell style, HTTPS style, HTTPS with embedded credentials, scheme-prefixed secure-shell style, with or without trailing slash, with mixed host casing.
+- Repository rename or ownership transfer at the hosting provider — the remote URL changes but it is still the same project in the user's mind. The resolver computes a new identifier; the prior identifier is auto-aliased on first detection so existing state is not orphaned.
+- Fork-of-fork situations where two different users push to two different remotes for what they consider the same project — identifiers diverge intentionally; the override file is the documented escape hatch for users who want to unify them.
+- Multiple configured remotes. The resolver picks the canonical primary remote if present, otherwise the first remote alphabetically; the choice is documented and the override remains available.
+- Submodules: a directory inside a submodule resolves against the submodule's remote and its in-submodule subpath, not the outer repo's, so a vendored sub-repo does not masquerade as part of the parent.
+- Detached head, no current branch, shallow clones, and worktrees — none of these affect the resolver because it only reads the remote URL and the path from the repo root.
+- Bare repos and mirror clones — typically not where Mink runs, but the resolver must not crash; it falls back to path-derived.
+- Working directory is a symlink into the repo — the resolver canonicalizes the path before asking git for the subpath so symlinked checkouts of the same repo unify.
+- Working directory is exactly the repo root vs. a one-deep subdirectory whose name matches the repo — these must produce distinct identifiers (empty subpath vs. one-segment subpath).
+- Override file is present but malformed — fail loudly, fall through to the next strategy, never silently treat it as absent.
+- Override file declares an identifier that collides with an existing different project's directory — refuse to use the override and report the collision; the user has to resolve manually.
+- Override file is checked into the repo and two devices each edit it to a different value — surfaces as a normal version-control merge conflict in the user's repo, not in Mink state.
+- Pre-existing alias collision: the about-to-be-recorded old identifier is already listed as an alias on a different project — record the collision in the project record and surface it to the user; do not pick a winner.
+- Migration interrupted between rename and metadata write — recoverable on next run because the resolver re-derives the identifier and the metadata write is idempotent. A lock file prevents two concurrent migration passes.
+- Migration interrupted between metadata write and the synchronization commit — recoverable because the metadata format is forward-compatible and the next sync run will pick it up.
+- User downgrades Mink after migration runs — older binary keeps reading the renamed directories; unknown fields on the project record are preserved untouched on write because the older code reads only the fields it knows about.
+- Two devices running different Mink versions during the rollout window — the device on the new version writes alias and per-device-path fields, the older device ignores them, sync merge handling tolerates the schema difference.
+- Dashboard has the project identifier cached in memory or in a worker process when migration runs — the dashboard must invalidate its routing cache (or pick up the change on next request) so it never serves a stale directory pointer.
+- A note's source-project reference points to an identifier that no project currently advertises as primary or alias — degrade gracefully: show the raw identifier, do not crash, and offer a reassign affordance.
+- Wiki notes that link to a project page by old identifier — link resolution checks the alias list, not just the primary identifier.
+- Repos using non-standard hosting (self-hosted forges, alternative providers, file-protocol remotes) — normalization rules must accept arbitrary hosts; only the canonicalization rules (lowercase host, strip credentials, strip suffix) are universal.
+- Repos whose remote URL is a relative path or a local-file URL — treat as no usable remote and fall back to path-derived with a warning.
+- Repos where the repo-root-relative subpath has a trailing slash or contains Windows-style separators — normalize to forward slashes with no trailing slash before hashing.
+- Per-device path map grows unbounded over years of use across many machines — bound the map by device identifier and rely on the existing device-registry cleanup to prune entries for retired devices.
+- The same machine has the same repo checked out twice at two different absolute paths intentionally (additional worktrees) — identifiers collide by design; the per-device path map will see one entry overwrite the other. Document this; recommend the override file as the escape hatch.
+
+## Test Requirements
+
+### Unit Tests
+
+- Resolver priority order: override beats git-derived; git-derived beats path-derived; missing override and missing remote falls through cleanly.
+- Override validation: rejects malformed input, rejects identifiers with disallowed characters, rejects identifiers exceeding the documented length, accepts well-formed identifiers verbatim.
+- Remote URL normalization across the matrix: secure-shell form, HTTPS form, HTTPS-with-credentials form, scheme-prefixed secure-shell form, with and without a suffix, with and without trailing slash, with mixed host casing — every form for the same logical repo produces the same canonical string.
+- Subpath extraction: returns empty for repo root, returns forward-slash-joined segments for any depth, strips trailing slash, normalizes Windows separators.
+- Identifier format: human-readable slug prefix derived from the deepest meaningful name segment, plus a short stable hash; total length bounded; safe for use as a directory name on all supported filesystems.
+- Alias list manipulation: appending an alias is idempotent (no duplicates), aliases survive a round-trip through the project metadata reader and writer.
+- Per-device path map: reading a project record with a singular path field upgrades it in memory to a single-entry map keyed by the current device; writing back persists the map.
+- Path lookups via the resolver tolerate a project whose primary identifier no longer matches its directory name because it was renamed — the directory is found via the alias list.
+
+### Integration Tests
+
+- End-to-end resolution from a freshly cloned repo: remote present, no override, resolver returns the expected git-derived identifier; same expectation on a clone of the same repo at a different absolute path on the same machine.
+- Monorepo with two sibling service directories: resolving from each subdirectory produces two distinct identifiers; running notes, learning memory writes, and dashboard listings against one does not bleed into the other.
+- Migration on session-start: starting with a populated state directory from before the flag flip, flipping the flag on, and triggering the next session — every project directory is renamed when its identity changes, every metadata file gains an alias entry, every singular path field becomes a per-device map.
+- Migration idempotency: running the migration twice in a row produces no further changes on the second run; killing the migration process mid-pass and re-running it completes the remaining projects without corrupting the ones that finished.
+- Migration concurrency: starting two Mink processes that both attempt migration at the same moment — exactly one performs the work, the other waits or exits cleanly, no directory is touched by both.
+- Convergence across two devices: device A migrates, device B migrates independently, both sync — final state has one directory per repo, alias list contains both prior identifiers when they differed, per-device path map contains both devices' working-copy paths.
+- Wiki note continuity: a note created before migration with a source-project reference still resolves to the same project page after migration; backlinks from the project page list the note.
+- Dashboard continuity: opening the dashboard with a URL or bookmark using the old identifier after migration routes to the new directory transparently.
+- Remote rename: a project that started with one remote URL has its remote rewritten between sessions — next session adds the prior identifier as an alias and resolves to a new directory, no data loss, user warning emitted.
+- Init in a brand-new repo with no remote configured: identifier printed is the path-derived fallback with a remediation note; adding a remote and re-running init offers to migrate that single project to the git-derived identifier.
+- Feature-flag off: every test above also passes in legacy mode without invoking the resolver — no migrations run, no overrides are read, behavior matches today's path-derived implementation byte for byte.
+- Forward and backward compatibility: a metadata file written by the new version is readable by the previous version without crashing; saving from the previous version preserves the alias list and per-device path map fields rather than dropping them.
+- Sync merge: simulated three-way merge where one device pushed the new directory and the other still holds the old directory — the post-merge tree contains only the new directory and all files from both sides are present.
+
+### Property Tests
+
+- For any pair of remote URL forms that point at the same logical repository (drawn from the canonicalization rules in the spec), the resolver returns the same identifier.
+- For any subpath inside any repo, the resolver returns the same identifier as long as the remote and subpath are unchanged, regardless of the absolute path prefix.
+- For any project record, applying the migration twice produces the same on-disk state as applying it once.
+- For any sequence of alias appends, the alias list never contains duplicates and never loses an entry that was once added.
+- For any sequence of writes to the per-device path map from different device identifiers, no device ever overwrites another device's entry.
+- For any identifier produced by the resolver, the identifier is a valid directory name on macOS, Linux, and Windows filesystems and does not exceed the documented length cap.

--- a/specs/README.md
+++ b/specs/README.md
@@ -29,6 +29,7 @@ Mink is a hidden presence that moves alongside the developer. It has two mission
 | 17 | [Companion Channels](./17-companion-channels.md) | Wiki |
 | 18 | [Configuration Surface](./18-configuration-surface.md) | Core |
 | 19 | [CLI Self-Update](./19-self-update.md) | Automation |
+| 20 | [Stable Project Identity](./20-stable-project-identity.md) | Core |
 
 ## Active Delivery Plans
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,8 +2,10 @@ import { execSync } from "child_process";
 import { mkdirSync, existsSync } from "fs";
 import { resolve, dirname, basename, join } from "path";
 import { projectDir, projectMetaPath } from "../core/paths";
-import { generateProjectId } from "../core/project-id";
+import { resolveProjectIdentity } from "../core/project-id";
 import { atomicWriteJson, atomicWriteText, safeReadJson } from "../core/fs-utils";
+import { getOrCreateDeviceId } from "../core/device";
+import { getRepoRoot, getRepoRemote } from "../core/git-identity";
 import {
   isWikiEnabled,
   isVaultInitialized,
@@ -176,21 +178,32 @@ export async function init(cwd: string): Promise<void> {
 
   mkdirSync(dir, { recursive: true });
 
-  const projectId = generateProjectId(cwd);
+  const identity = resolveProjectIdentity(cwd);
+  const projectId = identity.id;
 
   // Detect notes project type
   const isNotesProject =
     isWikiEnabled() && isVaultInitialized() && isInsideVault(cwd);
 
-  // Write project metadata
+  // Write project metadata. Lift cwd into the per-device map alongside the
+  // legacy singular field so older mink versions (which only read `cwd`) keep
+  // working after a downgrade and new versions can track each device's path.
   const metaPath = projectMetaPath(cwd);
   const existingMeta = safeReadJson(metaPath) as Record<string, unknown> | null;
+  const deviceId = getOrCreateDeviceId();
+  const existingPathsByDevice =
+    existingMeta?.pathsByDevice &&
+    typeof existingMeta.pathsByDevice === "object" &&
+    !Array.isArray(existingMeta.pathsByDevice)
+      ? (existingMeta.pathsByDevice as Record<string, string>)
+      : {};
   atomicWriteJson(metaPath, {
     ...(existingMeta ?? {}),
     cwd,
     name: basename(cwd),
     initTimestamp: existingMeta?.initTimestamp ?? new Date().toISOString(),
     version: "0.1.0",
+    pathsByDevice: { ...existingPathsByDevice, [deviceId]: cwd },
     ...(isNotesProject ? { projectType: "notes" } : {}),
   });
 
@@ -201,11 +214,23 @@ export async function init(cwd: string): Promise<void> {
     console.log(`  rule:     ${rulePath}`);
   } else {
     console.log(`[mink] initialized`);
-    console.log(`  project:  ${projectId}`);
+    console.log(`  project:  ${projectId} (${identity.source})`);
     console.log(`  state:    ${dir}`);
     console.log(`  runtime:  ${runtime}`);
     console.log(`  hooks:    ${settingsPath}`);
     console.log(`  rule:     ${rulePath}`);
+  }
+
+  // Surface a one-time hint when the project is in a git repo with no remote
+  // configured — that's the only case where stable cross-machine identity is
+  // a config-fix away.
+  if (identity.source === "path-derived") {
+    const root = getRepoRoot(cwd);
+    if (root && !getRepoRemote(cwd)) {
+      console.log(
+        `  note:     this repo has no remote configured. Project state will not unify across machines until you add one and run \`mink config projects.identity git-remote\`.`
+      );
+    }
   }
 
   // Run initial scan

--- a/src/commands/note.ts
+++ b/src/commands/note.ts
@@ -6,7 +6,7 @@ import {
   resolveVaultPath,
 } from "../core/vault";
 import { resolveConfigValue } from "../core/global-config";
-import { generateProjectId } from "../core/project-id";
+import { projectIdFor } from "../core/project-id";
 import {
   createNote,
   appendToDaily,
@@ -180,7 +180,7 @@ function detectSourceProject(cwd: string): string | undefined {
     const vaultPath = resolveVaultPath();
     // Don't mark notes created from within the vault itself
     if (cwd.startsWith(vaultPath)) return undefined;
-    return generateProjectId(cwd);
+    return projectIdFor(cwd);
   } catch {
     return undefined;
   }

--- a/src/commands/session-start.ts
+++ b/src/commands/session-start.ts
@@ -24,10 +24,16 @@ export function sessionStart(cwd: string): void {
     // Never crash hooks
   }
 
-  // One-shot migration to sync layout v2. Idempotent re-run is a no-op.
+  // One-shot migration to the current sync layout. Idempotent re-run is a
+  // no-op. We also re-trigger when projects.identity=git-remote so a user who
+  // flips the flag after the version has stamped still gets project directories
+  // renamed to their stable identifier on the next session-start.
   try {
     const { readSyncVersion, MINK_SYNC_VERSION } = require("../core/sync");
-    if (readSyncVersion() < MINK_SYNC_VERSION) {
+    const { resolveConfigValue } = require("../core/global-config");
+    const identityOn =
+      resolveConfigValue("projects.identity").value === "git-remote";
+    if (readSyncVersion() < MINK_SYNC_VERSION || identityOn) {
       const { migrateSyncLayout } = require("./sync-migrate");
       migrateSyncLayout();
     }

--- a/src/commands/sync-migrate.ts
+++ b/src/commands/sync-migrate.ts
@@ -472,17 +472,34 @@ function migrateProjectIdentities(
       entry.newId
     ) {
       const newProjDir = join(projectsRoot, entry.newId);
-      // Record the alias and lift the device path before evicting — if the
-      // canonical meta is broken (read returns null in addProjectAlias), the
-      // safer path is to leave the old directory alone rather than discard
-      // it without ever surfacing the alias. We detect that case below.
+      // Record the alias and lift the device path before evicting. If the new
+      // dir has no project-meta.json (e.g. the daemon wrote state under the
+      // git-derived id before any init or migrate ran), addProjectAlias would
+      // silently no-op and we'd leave the old dir stranded forever. Repair
+      // that case by writing the old meta forward — the daemon-authored
+      // payload state under the new dir is preserved; only the missing meta
+      // gets reconstructed, with the alias already in place.
       let aliasOnRecord = false;
       try {
         if (entry.action === "skip-evict") {
           aliasOnRecord = true;
         } else {
           addProjectAlias(newProjDir, entry.oldId);
-          const newMeta = getProjectMeta(newProjDir);
+          let newMeta = getProjectMeta(newProjDir);
+          if (!newMeta) {
+            const oldMeta = getProjectMeta(oldProjDir);
+            if (oldMeta) {
+              atomicWriteJson(join(newProjDir, "project-meta.json"), {
+                cwd: oldMeta.cwd,
+                name: oldMeta.name,
+                initTimestamp: oldMeta.initTimestamp,
+                version: oldMeta.version,
+                aliases: [...(oldMeta.aliases ?? []), entry.oldId],
+                pathsByDevice: oldMeta.pathsByDevice,
+              });
+              newMeta = getProjectMeta(newProjDir);
+            }
+          }
           aliasOnRecord = newMeta?.aliases?.includes(entry.oldId) ?? false;
         }
         if (entry.cwd) {

--- a/src/commands/sync-migrate.ts
+++ b/src/commands/sync-migrate.ts
@@ -6,6 +6,7 @@ import {
   writeFileSync,
   readFileSync,
   renameSync,
+  rmSync,
   unlinkSync,
 } from "fs";
 import { join } from "path";
@@ -236,7 +237,24 @@ function listProjectsNeedingMigration(): string[] {
 // Idempotent: re-running after a clean pass walks every project, finds every
 // id matches its directory name, and does nothing.
 
-export type IdentityPlanAction = "rename" | "skip-converged" | "skip-no-cwd" | "skip-unchanged";
+// Plan actions:
+//   rename          old dir present, new dir absent → rename old → new, record alias.
+//   skip-converged  old dir + new dir both present, alias NOT yet recorded → record
+//                   alias on new meta and evict old dir to .identity-rollback/. Named
+//                   "skip-converged" because the rename itself is unnecessary; the
+//                   convergence work (alias + eviction) is the action.
+//   skip-evict      old dir + new dir both present, alias already recorded → only
+//                   evict the old dir. Reached when a previous migration recorded
+//                   the alias but didn't (or couldn't) finish evicting. Without
+//                   this, dry-run would keep proposing skip-converged forever.
+//   skip-no-cwd     project's working-copy path is on a different device — leave alone.
+//   skip-unchanged  newId === oldId — no work needed at all.
+export type IdentityPlanAction =
+  | "rename"
+  | "skip-converged"
+  | "skip-evict"
+  | "skip-no-cwd"
+  | "skip-unchanged";
 
 export interface IdentityPlanEntry {
   oldId: string;
@@ -309,12 +327,23 @@ export function planIdentityMigration(flagOverride?: string): IdentityPlanEntry[
 
     const newProjDir = join(projectsRoot, newId);
     if (existsSync(newProjDir)) {
+      // If the canonical (new) project already records this oldId in its
+      // aliases list, the convergence bookkeeping is already done — only the
+      // leftover old directory remains to be cleaned up. Surfacing this as a
+      // distinct action (skip-evict) makes dry-run idempotent: once the alias
+      // is recorded AND the old directory is gone, the planner stops seeing
+      // the project entirely. Pre-fix it would keep proposing the same
+      // skip-converged action forever.
+      const newMeta = getProjectMeta(newProjDir);
+      const aliasAlreadyRecorded = newMeta?.aliases?.includes(oldId) ?? false;
       plan.push({
         oldId,
         newId,
         cwd: meta.cwd,
-        action: "skip-converged",
-        reason: "destination already exists (from sync); alias-only update",
+        action: aliasAlreadyRecorded ? "skip-evict" : "skip-converged",
+        reason: aliasAlreadyRecorded
+          ? "alias already recorded; will evict leftover old directory"
+          : "destination already exists (from sync); will record alias and evict old directory",
       });
       continue;
     }
@@ -373,29 +402,55 @@ function copyDirRecursive(src: string, dest: string, excludeNames: Set<string>):
 // that drives this very decision). Falls back to a fresh read for callers that
 // don't operate inside a stash window (e.g. session-start triggers and the
 // --dry-run path).
+export interface IdentityMigrationOutcome {
+  renamed: number;
+  converged: number;
+  evicted: number;
+  visited: number;
+  backupDir: string | null;
+  renames: Array<{ from: string; to: string }>;
+  evictions: string[];
+}
+
 function migrateProjectIdentities(
   deviceId: string,
   flag: string = resolveConfigValue("projects.identity").value
-): {
-  renamed: number;
-  visited: number;
-  backupDir: string | null;
-} {
+): IdentityMigrationOutcome {
   if (flag !== "git-remote") {
-    return { renamed: 0, visited: 0, backupDir: null };
+    return {
+      renamed: 0,
+      converged: 0,
+      evicted: 0,
+      visited: 0,
+      backupDir: null,
+      renames: [],
+      evictions: [],
+    };
   }
 
   const plan = planIdentityMigration(flag);
-  const willRename = plan.filter((p) => p.action === "rename");
+  // Any action that moves an old directory aside needs a backup destination.
+  // rename, skip-converged (record alias + evict), and skip-evict (alias
+  // already recorded; only evict) all qualify.
+  const willTouchOldDir = plan.filter(
+    (p) =>
+      p.action === "rename" ||
+      p.action === "skip-converged" ||
+      p.action === "skip-evict"
+  );
 
   // Compute the backup root up-front so all snapshots for this migration pass
   // land in one timestamped directory the user can find and reason about.
   let backupRoot: string | null = null;
-  if (willRename.length > 0) {
+  if (willTouchOldDir.length > 0) {
     backupRoot = identityBackupRoot(ensureIdentityBackupTimestamp());
   }
 
   let renamed = 0;
+  let converged = 0;
+  let evicted = 0;
+  const renames: Array<{ from: string; to: string }> = [];
+  const evictions: string[] = [];
   let visited = plan.length;
   const projectsRoot = join(minkRoot(), "projects");
 
@@ -412,15 +467,52 @@ function migrateProjectIdentities(
       }
     }
 
-    if (entry.action === "skip-converged" && entry.newId) {
+    if (
+      (entry.action === "skip-converged" || entry.action === "skip-evict") &&
+      entry.newId
+    ) {
       const newProjDir = join(projectsRoot, entry.newId);
+      // Record the alias and lift the device path before evicting — if the
+      // canonical meta is broken (read returns null in addProjectAlias), the
+      // safer path is to leave the old directory alone rather than discard
+      // it without ever surfacing the alias. We detect that case below.
+      let aliasOnRecord = false;
       try {
-        addProjectAlias(newProjDir, entry.oldId);
+        if (entry.action === "skip-evict") {
+          aliasOnRecord = true;
+        } else {
+          addProjectAlias(newProjDir, entry.oldId);
+          const newMeta = getProjectMeta(newProjDir);
+          aliasOnRecord = newMeta?.aliases?.includes(entry.oldId) ?? false;
+        }
         if (entry.cwd) {
           setProjectPathForDevice(newProjDir, deviceId, entry.cwd);
         }
       } catch {
         // best-effort
+      }
+
+      if (aliasOnRecord && backupRoot) {
+        // Snapshot the old dir before eviction so any local-only state
+        // (writes that landed here before sync converged) is recoverable.
+        const ok = backupProjectForRollback(
+          oldProjDir,
+          join(backupRoot, entry.oldId)
+        );
+        if (ok) {
+          let removed = false;
+          try {
+            rmSync(oldProjDir, { recursive: true, force: true });
+            removed = true;
+          } catch {
+            // best-effort; leave the directory rather than partially deleted
+          }
+          if (removed) {
+            evictions.push(entry.oldId);
+            evicted++;
+            if (entry.action === "skip-converged") converged++;
+          }
+        }
       }
       continue;
     }
@@ -456,9 +548,18 @@ function migrateProjectIdentities(
       // best-effort
     }
     renamed++;
+    renames.push({ from: entry.oldId, to: entry.newId });
   }
 
-  return { renamed, visited, backupDir: backupRoot };
+  return {
+    renamed,
+    converged,
+    evicted,
+    visited,
+    backupDir: backupRoot,
+    renames,
+    evictions,
+  };
 }
 
 // ── v3 identity rollback ──────────────────────────────────────────────────
@@ -545,6 +646,7 @@ export interface MigrateResult {
   fromVersion: number;
   toVersion: number;
   message?: string;
+  identity?: IdentityMigrationOutcome;
 }
 
 // Idempotent. Safe to invoke from `mink sync migrate` directly or from a
@@ -636,7 +738,15 @@ export function migrateSyncLayout(): MigrateResult {
     // flag is off or every project's identifier already matches its directory.
     // Pass the pre-stash snapshot of identityMode so we don't re-read the
     // config from a stash-hidden working tree.
-    let identity = { renamed: 0, visited: 0 };
+    let identity: IdentityMigrationOutcome = {
+      renamed: 0,
+      converged: 0,
+      evicted: 0,
+      visited: 0,
+      backupDir: null,
+      renames: [],
+      evictions: [],
+    };
     try {
       identity = migrateProjectIdentities(deviceId, identityMode);
     } catch {
@@ -650,16 +760,19 @@ export function migrateSyncLayout(): MigrateResult {
       writeSyncVersion(MINK_SYNC_VERSION);
     }
 
-    if (isSyncInitialized() && (processed > 0 || identity.renamed > 0)) {
+    if (
+      isSyncInitialized() &&
+      (processed > 0 || identity.renamed > 0 || identity.evicted > 0)
+    ) {
       // Skip the lock file — it's part of migration coordination, not state.
       gitSafe("add -A");
       gitSafe(`reset HEAD ".sync-migrate.lock"`);
-      const summary =
-        identity.renamed > 0
-          ? `${processed} projects, ${identity.renamed} renamed for identity v3`
-          : `${processed} projects`;
+      const identityNote =
+        identity.renamed > 0 || identity.evicted > 0
+          ? `, ${identity.renamed} renamed + ${identity.evicted} evicted for identity v3`
+          : "";
       gitSafe(
-        `commit -m "mink: migrate sync layout v${fromVersion} -> v${MINK_SYNC_VERSION} (device ${deviceId.slice(0, 8)}, ${summary})"`
+        `commit -m "mink: migrate sync layout v${fromVersion} -> v${MINK_SYNC_VERSION} (device ${deviceId.slice(0, 8)}, ${processed} projects${identityNote})"`
       );
     }
 
@@ -671,6 +784,7 @@ export function migrateSyncLayout(): MigrateResult {
       ranMigration: true,
       fromVersion,
       toVersion: MINK_SYNC_VERSION,
+      identity,
     };
   } finally {
     releaseLock();
@@ -696,20 +810,24 @@ export function syncMigrateCommand(args: string[] = []): void {
     }
     const renames = plan.filter((p) => p.action === "rename");
     const converged = plan.filter((p) => p.action === "skip-converged");
+    const evictOnly = plan.filter((p) => p.action === "skip-evict");
     const skippedNoCwd = plan.filter((p) => p.action === "skip-no-cwd");
     const unchanged = plan.filter((p) => p.action === "skip-unchanged");
 
     console.log(
-      `[mink] sync migrate --dry-run: ${renames.length} rename(s), ${converged.length} alias-only, ${skippedNoCwd.length} skipped (no cwd), ${unchanged.length} unchanged`
+      `[mink] sync migrate --dry-run: ${renames.length} rename(s), ${converged.length} converge (alias + evict), ${evictOnly.length} evict-only, ${skippedNoCwd.length} skipped (no cwd), ${unchanged.length} unchanged`
     );
     for (const p of renames) {
-      console.log(`  rename: ${p.oldId} → ${p.newId}`);
+      console.log(`  rename:   ${p.oldId} → ${p.newId}`);
     }
     for (const p of converged) {
-      console.log(`  alias:  ${p.oldId} → ${p.newId} (already on disk)`);
+      console.log(`  converge: ${p.oldId} → ${p.newId} (record alias on ${p.newId}, evict ${p.oldId} to .identity-rollback/)`);
+    }
+    for (const p of evictOnly) {
+      console.log(`  evict:    ${p.oldId} → .identity-rollback/ (alias already on ${p.newId})`);
     }
     for (const p of skippedNoCwd) {
-      console.log(`  skip:   ${p.oldId} — ${p.reason}`);
+      console.log(`  skip:     ${p.oldId} — ${p.reason}`);
     }
     return;
   }
@@ -749,4 +867,19 @@ export function syncMigrateCommand(args: string[] = []): void {
   console.log(
     `[mink] sync migrate: v${result.fromVersion} → v${result.toVersion} complete`
   );
+  const identity = result.identity;
+  if (identity && (identity.renamed > 0 || identity.evicted > 0)) {
+    console.log(
+      `  identity: ${identity.renamed} renamed, ${identity.converged} converged, ${identity.evicted} evicted`
+    );
+    for (const r of identity.renames) {
+      console.log(`    renamed: ${r.from} → ${r.to}`);
+    }
+    for (const id of identity.evictions) {
+      console.log(`    evicted: ${id} → .identity-rollback/`);
+    }
+    if (identity.backupDir) {
+      console.log(`  rollback snapshot: ${identity.backupDir}`);
+    }
+  }
 }

--- a/src/commands/sync-migrate.ts
+++ b/src/commands/sync-migrate.ts
@@ -224,90 +224,198 @@ function listProjectsNeedingMigration(): string[] {
 //
 // When `projects.identity = git-remote`, walks every project on disk and:
 //   1. Computes its new identifier from the recorded working-copy path.
-//   2. If the new identifier differs from the on-disk directory name, renames
-//      the directory (preferring `git mv` so history is preserved when sync
-//      is initialised), records the old identifier as an alias, and lifts the
-//      singular `cwd` into the per-device path map keyed by this device.
+//   2. If the new identifier differs from the on-disk directory name, snapshots
+//      the project to a rollback backup, then renames the directory (preferring
+//      `git mv` so history is preserved when sync is initialised), records the
+//      old identifier as an alias, and lifts the singular `cwd` into the
+//      per-device path map keyed by this device.
 //   3. If the working-copy path is missing from the local filesystem (the
 //      project's repo was cloned on a different machine), the project is left
-//      alone — the device that owns the cwd will migrate it.
+//      alone — the device that owns the cwd will handle the rename.
 //
 // Idempotent: re-running after a clean pass walks every project, finds every
 // id matches its directory name, and does nothing.
-function migrateProjectIdentities(deviceId: string): {
-  renamed: number;
-  visited: number;
-} {
+
+export type IdentityPlanAction = "rename" | "skip-converged" | "skip-no-cwd" | "skip-unchanged";
+
+export interface IdentityPlanEntry {
+  oldId: string;
+  newId: string | null;
+  cwd: string | null;
+  action: IdentityPlanAction;
+  reason?: string;
+}
+
+// Walks every project on disk and returns the rename plan without touching it.
+// Backbone for both --dry-run and the real migration so they share logic.
+export function planIdentityMigration(): IdentityPlanEntry[] {
+  const plan: IdentityPlanEntry[] = [];
   if (resolveConfigValue("projects.identity").value !== "git-remote") {
-    return { renamed: 0, visited: 0 };
+    return plan;
   }
 
-  let renamed = 0;
-  let visited = 0;
   const projectsRoot = join(minkRoot(), "projects");
-  if (!existsSync(projectsRoot)) return { renamed, visited };
+  if (!existsSync(projectsRoot)) return plan;
 
   let entries: string[];
   try {
     entries = readdirSync(projectsRoot);
   } catch {
-    return { renamed, visited };
+    return plan;
   }
 
   for (const oldId of entries) {
     const oldProjDir = join(projectsRoot, oldId);
-    let isDir = false;
     try {
-      isDir = statSync(oldProjDir).isDirectory();
+      if (!statSync(oldProjDir).isDirectory()) continue;
     } catch {
       continue;
     }
-    if (!isDir) continue;
-    visited++;
 
     const meta = getProjectMeta(oldProjDir);
     if (!meta) continue;
 
-    // Skip projects whose cwd isn't reachable on this device — we cannot
-    // reliably re-resolve identity without the underlying filesystem. The
-    // device that owns the cwd will handle the rename and sync will carry it.
-    if (!existsSync(meta.cwd)) continue;
+    if (!existsSync(meta.cwd)) {
+      plan.push({
+        oldId,
+        newId: null,
+        cwd: meta.cwd,
+        action: "skip-no-cwd",
+        reason: "working-copy path not reachable on this device",
+      });
+      continue;
+    }
 
-    let resolution;
+    let newId: string;
     try {
-      resolution = resolveProjectIdentity(meta.cwd);
+      newId = resolveProjectIdentity(meta.cwd).id;
     } catch {
       continue;
     }
 
-    const newId = resolution.id;
-
-    // Always lift the singular cwd into the per-device map so older records
-    // gain the multi-device shape even when their identifier hasn't changed.
-    try {
-      setProjectPathForDevice(oldProjDir, deviceId, meta.cwd);
-    } catch {
-      // best-effort; keep going
+    if (newId === oldId) {
+      plan.push({ oldId, newId, cwd: meta.cwd, action: "skip-unchanged" });
+      continue;
     }
-
-    if (newId === oldId) continue;
 
     const newProjDir = join(projectsRoot, newId);
     if (existsSync(newProjDir)) {
-      // A previous device already migrated this project and the new directory
-      // arrived via sync. Record the old id as an alias on the new directory,
-      // then remove the now-redundant old directory's metadata pointer. Leave
-      // the actual files for the cross-device sync merge to reconcile rather
-      // than blind-deleting.
+      plan.push({
+        oldId,
+        newId,
+        cwd: meta.cwd,
+        action: "skip-converged",
+        reason: "destination already exists (from sync); alias-only update",
+      });
+      continue;
+    }
+
+    plan.push({ oldId, newId, cwd: meta.cwd, action: "rename" });
+  }
+  return plan;
+}
+
+const IDENTITY_BACKUP_DIRNAME = ".identity-rollback";
+
+function identityBackupRoot(timestamp: string): string {
+  return join(minkRoot(), IDENTITY_BACKUP_DIRNAME, timestamp);
+}
+
+function ensureIdentityBackupTimestamp(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}${String(now.getUTCMonth() + 1).padStart(2, "0")}${String(
+    now.getUTCDate()
+  ).padStart(2, "0")}-${String(now.getUTCHours()).padStart(2, "0")}${String(
+    now.getUTCMinutes()
+  ).padStart(2, "0")}${String(now.getUTCSeconds()).padStart(2, "0")}`;
+}
+
+// Copies a project directory tree to the rollback backup. Skips `backups/` so
+// nested backups don't double the snapshot size. Returns the backup path or
+// null on failure (caller logs but does not abort migration on backup failure).
+function backupProjectForRollback(srcDir: string, backupDir: string): string | null {
+  try {
+    mkdirSync(backupDir, { recursive: true });
+    copyDirRecursive(srcDir, backupDir, new Set(["backups"]));
+    return backupDir;
+  } catch {
+    return null;
+  }
+}
+
+function copyDirRecursive(src: string, dest: string, excludeNames: Set<string>): void {
+  mkdirSync(dest, { recursive: true });
+  const entries = readdirSync(src, { withFileTypes: true });
+  for (const entry of entries) {
+    if (excludeNames.has(entry.name)) continue;
+    const srcPath = join(src, entry.name);
+    const destPath = join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirRecursive(srcPath, destPath, excludeNames);
+    } else if (entry.isFile()) {
+      writeFileSync(destPath, readFileSync(srcPath));
+    }
+  }
+}
+
+function migrateProjectIdentities(deviceId: string): {
+  renamed: number;
+  visited: number;
+  backupDir: string | null;
+} {
+  if (resolveConfigValue("projects.identity").value !== "git-remote") {
+    return { renamed: 0, visited: 0, backupDir: null };
+  }
+
+  const plan = planIdentityMigration();
+  const willRename = plan.filter((p) => p.action === "rename");
+
+  // Compute the backup root up-front so all snapshots for this migration pass
+  // land in one timestamped directory the user can find and reason about.
+  let backupRoot: string | null = null;
+  if (willRename.length > 0) {
+    backupRoot = identityBackupRoot(ensureIdentityBackupTimestamp());
+  }
+
+  let renamed = 0;
+  let visited = plan.length;
+  const projectsRoot = join(minkRoot(), "projects");
+
+  for (const entry of plan) {
+    const oldProjDir = join(projectsRoot, entry.oldId);
+
+    // Lift cwd into pathsByDevice for every project we can see, even
+    // skip-unchanged ones, so older records gain the multi-device shape.
+    if (entry.cwd && entry.action !== "skip-no-cwd") {
       try {
-        addProjectAlias(newProjDir, oldId);
-        setProjectPathForDevice(newProjDir, deviceId, meta.cwd);
+        setProjectPathForDevice(oldProjDir, deviceId, entry.cwd);
+      } catch {
+        // best-effort
+      }
+    }
+
+    if (entry.action === "skip-converged" && entry.newId) {
+      const newProjDir = join(projectsRoot, entry.newId);
+      try {
+        addProjectAlias(newProjDir, entry.oldId);
+        if (entry.cwd) {
+          setProjectPathForDevice(newProjDir, deviceId, entry.cwd);
+        }
       } catch {
         // best-effort
       }
       continue;
     }
 
+    if (entry.action !== "rename" || !entry.newId) continue;
+
+    // Snapshot the project before the rename so the user can recover if the
+    // alias-based rollback ever fails.
+    if (backupRoot) {
+      backupProjectForRollback(oldProjDir, join(backupRoot, entry.oldId));
+    }
+
+    const newProjDir = join(projectsRoot, entry.newId);
     const moved =
       gitSafe(`mv "${oldProjDir}" "${newProjDir}"`) !== null ||
       (() => {
@@ -322,15 +430,96 @@ function migrateProjectIdentities(deviceId: string): {
     if (!moved) continue;
 
     try {
-      addProjectAlias(newProjDir, oldId);
-      setProjectPathForDevice(newProjDir, deviceId, meta.cwd);
+      addProjectAlias(newProjDir, entry.oldId);
+      if (entry.cwd) {
+        setProjectPathForDevice(newProjDir, deviceId, entry.cwd);
+      }
     } catch {
       // best-effort
     }
     renamed++;
   }
 
-  return { renamed, visited };
+  return { renamed, visited, backupDir: backupRoot };
+}
+
+// ── v3 identity rollback ──────────────────────────────────────────────────
+//
+// Reverses the most recent identity rename for every project that has at
+// least one alias recorded. Picks the most recently appended alias as the
+// target id, renames the project directory back, and pops that entry from
+// the alias list. Idempotent: a project with no aliases is left alone.
+//
+// This is the primary rollback path. The pre-migration backup is a fallback
+// for when alias-based rollback can't proceed (e.g. metadata corruption).
+
+export interface RollbackEntry {
+  currentId: string;
+  restoredId: string;
+  ok: boolean;
+}
+
+export function rollbackProjectIdentities(): RollbackEntry[] {
+  const results: RollbackEntry[] = [];
+  const projectsRoot = join(minkRoot(), "projects");
+  if (!existsSync(projectsRoot)) return results;
+
+  let entries: string[];
+  try {
+    entries = readdirSync(projectsRoot);
+  } catch {
+    return results;
+  }
+
+  for (const currentId of entries) {
+    const projDir = join(projectsRoot, currentId);
+    try {
+      if (!statSync(projDir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    const meta = getProjectMeta(projDir);
+    if (!meta || !meta.aliases || meta.aliases.length === 0) continue;
+
+    const restoredId = meta.aliases[meta.aliases.length - 1];
+    const targetDir = join(projectsRoot, restoredId);
+
+    if (existsSync(targetDir)) {
+      // Refuse to overwrite an existing directory at the target id.
+      results.push({ currentId, restoredId, ok: false });
+      continue;
+    }
+
+    // Pop the alias before renaming so the resulting on-disk metadata file
+    // reflects the rolled-back state even if the rename itself succeeds.
+    const remainingAliases = meta.aliases.slice(0, -1);
+    const metaPath = join(projDir, "project-meta.json");
+    try {
+      const raw = safeReadJson(metaPath);
+      if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+        const obj = raw as Record<string, unknown>;
+        obj.aliases = remainingAliases;
+        atomicWriteJson(metaPath, obj);
+      }
+    } catch {
+      // best-effort; rollback continues
+    }
+
+    const moved =
+      gitSafe(`mv "${projDir}" "${targetDir}"`) !== null ||
+      (() => {
+        try {
+          renameSync(projDir, targetDir);
+          return true;
+        } catch {
+          return false;
+        }
+      })();
+
+    results.push({ currentId, restoredId, ok: moved });
+  }
+  return results;
 }
 
 export interface MigrateResult {
@@ -463,7 +652,70 @@ export function migrateSyncLayout(): MigrateResult {
   }
 }
 
-export function syncMigrateCommand(): void {
+export function syncMigrateCommand(args: string[] = []): void {
+  const dryRun = args.includes("--dry-run");
+  const rollback = args.includes("--rollback");
+
+  if (rollback && dryRun) {
+    console.error("[mink] --rollback and --dry-run cannot be combined");
+    process.exit(1);
+  }
+
+  if (dryRun) {
+    const plan = planIdentityMigration();
+    if (plan.length === 0) {
+      console.log(
+        "[mink] sync migrate --dry-run: no projects to rename (flag is off or no projects on disk)"
+      );
+      return;
+    }
+    const renames = plan.filter((p) => p.action === "rename");
+    const converged = plan.filter((p) => p.action === "skip-converged");
+    const skippedNoCwd = plan.filter((p) => p.action === "skip-no-cwd");
+    const unchanged = plan.filter((p) => p.action === "skip-unchanged");
+
+    console.log(
+      `[mink] sync migrate --dry-run: ${renames.length} rename(s), ${converged.length} alias-only, ${skippedNoCwd.length} skipped (no cwd), ${unchanged.length} unchanged`
+    );
+    for (const p of renames) {
+      console.log(`  rename: ${p.oldId} → ${p.newId}`);
+    }
+    for (const p of converged) {
+      console.log(`  alias:  ${p.oldId} → ${p.newId} (already on disk)`);
+    }
+    for (const p of skippedNoCwd) {
+      console.log(`  skip:   ${p.oldId} — ${p.reason}`);
+    }
+    return;
+  }
+
+  if (rollback) {
+    const results = rollbackProjectIdentities();
+    if (results.length === 0) {
+      console.log("[mink] sync migrate --rollback: nothing to roll back");
+      return;
+    }
+    const ok = results.filter((r) => r.ok);
+    const failed = results.filter((r) => !r.ok);
+    console.log(
+      `[mink] sync migrate --rollback: ${ok.length} restored, ${failed.length} failed`
+    );
+    for (const r of ok) {
+      console.log(`  restored: ${r.currentId} → ${r.restoredId}`);
+    }
+    for (const r of failed) {
+      console.log(
+        `  failed:   ${r.currentId} → ${r.restoredId} (destination already exists or rename blocked)`
+      );
+    }
+    if (ok.length > 0) {
+      console.log(
+        "\n[mink] tip: set projects.identity=path-derived to prevent the next session-start from re-migrating"
+      );
+    }
+    return;
+  }
+
   const result = migrateSyncLayout();
   if (!result.ranMigration) {
     console.log(`[mink] sync migrate: ${result.message ?? "no-op"}`);

--- a/src/commands/sync-migrate.ts
+++ b/src/commands/sync-migrate.ts
@@ -248,9 +248,15 @@ export interface IdentityPlanEntry {
 
 // Walks every project on disk and returns the rename plan without touching it.
 // Backbone for both --dry-run and the real migration so they share logic.
-export function planIdentityMigration(): IdentityPlanEntry[] {
+//
+// Accepts an optional `flagOverride` so callers that have already snapshotted
+// `projects.identity` (e.g. migrateSyncLayout, before its git-stash) can pass
+// the snapshot in rather than re-reading from disk inside a stash window where
+// the config file's uncommitted writes are temporarily hidden.
+export function planIdentityMigration(flagOverride?: string): IdentityPlanEntry[] {
   const plan: IdentityPlanEntry[] = [];
-  if (resolveConfigValue("projects.identity").value !== "git-remote") {
+  const flag = flagOverride ?? resolveConfigValue("projects.identity").value;
+  if (flag !== "git-remote") {
     return plan;
   }
 
@@ -288,7 +294,10 @@ export function planIdentityMigration(): IdentityPlanEntry[] {
 
     let newId: string;
     try {
-      newId = resolveProjectIdentity(meta.cwd).id;
+      newId = resolveProjectIdentity(
+        meta.cwd,
+        flag === "git-remote" || flag === "path-derived" ? flag : undefined
+      ).id;
     } catch {
       continue;
     }
@@ -358,16 +367,25 @@ function copyDirRecursive(src: string, dest: string, excludeNames: Set<string>):
   }
 }
 
-function migrateProjectIdentities(deviceId: string): {
+// Accepts the identity-mode value as a parameter so the caller can snapshot it
+// before any disk side-effects (notably the migrating git-stash in
+// migrateSyncLayout, which would hide uncommitted writes to the config file
+// that drives this very decision). Falls back to a fresh read for callers that
+// don't operate inside a stash window (e.g. session-start triggers and the
+// --dry-run path).
+function migrateProjectIdentities(
+  deviceId: string,
+  flag: string = resolveConfigValue("projects.identity").value
+): {
   renamed: number;
   visited: number;
   backupDir: string | null;
 } {
-  if (resolveConfigValue("projects.identity").value !== "git-remote") {
+  if (flag !== "git-remote") {
     return { renamed: 0, visited: 0, backupDir: null };
   }
 
-  const plan = planIdentityMigration();
+  const plan = planIdentityMigration(flag);
   const willRename = plan.filter((p) => p.action === "rename");
 
   // Compute the backup root up-front so all snapshots for this migration pass
@@ -542,6 +560,11 @@ export interface MigrateResult {
 export function migrateSyncLayout(): MigrateResult {
   const fromVersion = readSyncVersion();
   const pending = listProjectsNeedingMigration();
+  // Snapshot the identity mode BEFORE the migrating stash below. The stash
+  // hides any uncommitted edits to ~/.mink/config — including the very
+  // `projects.identity = git-remote` write that should be driving this
+  // migration. Reading the flag after the stash would see the stale,
+  // last-committed config and the v3 identity step would no-op.
   const identityMode = resolveConfigValue("projects.identity").value;
   if (
     fromVersion >= MINK_SYNC_VERSION &&
@@ -611,9 +634,11 @@ export function migrateSyncLayout(): MigrateResult {
     // v3 identity migration: rename per-project directories to their stable
     // git-derived identifier when the user has opted in. Cheap no-op when the
     // flag is off or every project's identifier already matches its directory.
+    // Pass the pre-stash snapshot of identityMode so we don't re-read the
+    // config from a stash-hidden working tree.
     let identity = { renamed: 0, visited: 0 };
     try {
-      identity = migrateProjectIdentities(deviceId);
+      identity = migrateProjectIdentities(deviceId, identityMode);
     } catch {
       // best-effort; never block the rest of migration
     }

--- a/src/commands/sync-migrate.ts
+++ b/src/commands/sync-migrate.ts
@@ -25,6 +25,16 @@ import {
 } from "../core/sync";
 import { getOrCreateDeviceId } from "../core/device";
 import { atomicWriteJson, safeReadJson } from "../core/fs-utils";
+import {
+  resolveProjectIdentity,
+  generateProjectId,
+} from "../core/project-id";
+import {
+  getProjectMeta,
+  addProjectAlias,
+  setProjectPathForDevice,
+} from "../core/project-registry";
+import { resolveConfigValue } from "../core/global-config";
 import type { FileIndex } from "../types/file-index";
 
 const MIGRATE_LOCK = ".sync-migrate.lock";
@@ -210,6 +220,119 @@ function listProjectsNeedingMigration(): string[] {
   return listProjects().filter(projectNeedsMigration);
 }
 
+// ── v3 identity migration ─────────────────────────────────────────────────
+//
+// When `projects.identity = git-remote`, walks every project on disk and:
+//   1. Computes its new identifier from the recorded working-copy path.
+//   2. If the new identifier differs from the on-disk directory name, renames
+//      the directory (preferring `git mv` so history is preserved when sync
+//      is initialised), records the old identifier as an alias, and lifts the
+//      singular `cwd` into the per-device path map keyed by this device.
+//   3. If the working-copy path is missing from the local filesystem (the
+//      project's repo was cloned on a different machine), the project is left
+//      alone — the device that owns the cwd will migrate it.
+//
+// Idempotent: re-running after a clean pass walks every project, finds every
+// id matches its directory name, and does nothing.
+function migrateProjectIdentities(deviceId: string): {
+  renamed: number;
+  visited: number;
+} {
+  if (resolveConfigValue("projects.identity").value !== "git-remote") {
+    return { renamed: 0, visited: 0 };
+  }
+
+  let renamed = 0;
+  let visited = 0;
+  const projectsRoot = join(minkRoot(), "projects");
+  if (!existsSync(projectsRoot)) return { renamed, visited };
+
+  let entries: string[];
+  try {
+    entries = readdirSync(projectsRoot);
+  } catch {
+    return { renamed, visited };
+  }
+
+  for (const oldId of entries) {
+    const oldProjDir = join(projectsRoot, oldId);
+    let isDir = false;
+    try {
+      isDir = statSync(oldProjDir).isDirectory();
+    } catch {
+      continue;
+    }
+    if (!isDir) continue;
+    visited++;
+
+    const meta = getProjectMeta(oldProjDir);
+    if (!meta) continue;
+
+    // Skip projects whose cwd isn't reachable on this device — we cannot
+    // reliably re-resolve identity without the underlying filesystem. The
+    // device that owns the cwd will handle the rename and sync will carry it.
+    if (!existsSync(meta.cwd)) continue;
+
+    let resolution;
+    try {
+      resolution = resolveProjectIdentity(meta.cwd);
+    } catch {
+      continue;
+    }
+
+    const newId = resolution.id;
+
+    // Always lift the singular cwd into the per-device map so older records
+    // gain the multi-device shape even when their identifier hasn't changed.
+    try {
+      setProjectPathForDevice(oldProjDir, deviceId, meta.cwd);
+    } catch {
+      // best-effort; keep going
+    }
+
+    if (newId === oldId) continue;
+
+    const newProjDir = join(projectsRoot, newId);
+    if (existsSync(newProjDir)) {
+      // A previous device already migrated this project and the new directory
+      // arrived via sync. Record the old id as an alias on the new directory,
+      // then remove the now-redundant old directory's metadata pointer. Leave
+      // the actual files for the cross-device sync merge to reconcile rather
+      // than blind-deleting.
+      try {
+        addProjectAlias(newProjDir, oldId);
+        setProjectPathForDevice(newProjDir, deviceId, meta.cwd);
+      } catch {
+        // best-effort
+      }
+      continue;
+    }
+
+    const moved =
+      gitSafe(`mv "${oldProjDir}" "${newProjDir}"`) !== null ||
+      (() => {
+        try {
+          renameSync(oldProjDir, newProjDir);
+          return true;
+        } catch {
+          return false;
+        }
+      })();
+
+    if (!moved) continue;
+
+    try {
+      addProjectAlias(newProjDir, oldId);
+      setProjectPathForDevice(newProjDir, deviceId, meta.cwd);
+    } catch {
+      // best-effort
+    }
+    renamed++;
+  }
+
+  return { renamed, visited };
+}
+
 export interface MigrateResult {
   ranMigration: boolean;
   fromVersion: number;
@@ -221,13 +344,21 @@ export interface MigrateResult {
 // session-start auto-trigger when readSyncVersion() < MINK_SYNC_VERSION.
 //
 // We treat the version marker as a hint, not a gate — a previous partial run
-// (interrupted by the budget cap) may have written v2 with projects still
-// pending. We re-run as long as any project on disk still has legacy files at
-// its top level, regardless of marker.
+// (interrupted by the budget cap) may have written the latest version with
+// projects still pending. We re-run as long as any project on disk still has
+// legacy files at its top level, regardless of marker. The v3 identity step
+// also runs whenever projects.identity=git-remote so a user who flips the
+// flag after the version has already stamped to 3 still gets their projects
+// migrated.
 export function migrateSyncLayout(): MigrateResult {
   const fromVersion = readSyncVersion();
   const pending = listProjectsNeedingMigration();
-  if (fromVersion >= MINK_SYNC_VERSION && pending.length === 0) {
+  const identityMode = resolveConfigValue("projects.identity").value;
+  if (
+    fromVersion >= MINK_SYNC_VERSION &&
+    pending.length === 0 &&
+    identityMode !== "git-remote"
+  ) {
     return {
       ranMigration: false,
       fromVersion,
@@ -288,6 +419,16 @@ export function migrateSyncLayout(): MigrateResult {
       }
     }
 
+    // v3 identity migration: rename per-project directories to their stable
+    // git-derived identifier when the user has opted in. Cheap no-op when the
+    // flag is off or every project's identifier already matches its directory.
+    let identity = { renamed: 0, visited: 0 };
+    try {
+      identity = migrateProjectIdentities(deviceId);
+    } catch {
+      // best-effort; never block the rest of migration
+    }
+
     // Only stamp the version marker once nothing is left to migrate. If we
     // still have pending projects, leave the marker as-is so the next session
     // knows to keep going.
@@ -295,12 +436,16 @@ export function migrateSyncLayout(): MigrateResult {
       writeSyncVersion(MINK_SYNC_VERSION);
     }
 
-    if (isSyncInitialized() && processed > 0) {
+    if (isSyncInitialized() && (processed > 0 || identity.renamed > 0)) {
       // Skip the lock file — it's part of migration coordination, not state.
       gitSafe("add -A");
       gitSafe(`reset HEAD ".sync-migrate.lock"`);
+      const summary =
+        identity.renamed > 0
+          ? `${processed} projects, ${identity.renamed} renamed for identity v3`
+          : `${processed} projects`;
       gitSafe(
-        `commit -m "mink: migrate sync layout v${fromVersion} -> v${MINK_SYNC_VERSION} (device ${deviceId.slice(0, 8)}, ${processed} projects)"`
+        `commit -m "mink: migrate sync layout v${fromVersion} -> v${MINK_SYNC_VERSION} (device ${deviceId.slice(0, 8)}, ${summary})"`
       );
     }
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -52,14 +52,17 @@ export async function sync(args: string[]): Promise<void> {
 
     case "migrate": {
       const { syncMigrateCommand } = await import("./sync-migrate");
-      syncMigrateCommand();
+      syncMigrateCommand(args.slice(1));
       return;
     }
 
     default:
       console.error(`[mink] unknown sync subcommand: ${subcommand}`);
       console.error(
-        "Usage: mink sync [init|status|push|pull|pause|resume|disconnect|reconcile|migrate|merge-driver]"
+        "Usage: mink sync [init|status|push|pull|pause|resume|disconnect|reconcile|merge-driver]"
+      );
+      console.error(
+        "       mink sync migrate [--dry-run|--rollback]"
       );
       process.exit(1);
   }

--- a/src/core/dashboard-server.ts
+++ b/src/core/dashboard-server.ts
@@ -35,7 +35,7 @@ import {
   triggerIngestFile,
 } from "./dashboard-api";
 import { listRegisteredProjects, getProjectMeta } from "./project-registry";
-import { generateProjectId } from "./project-id";
+import { projectIdFor } from "./project-id";
 import { runtimeFile, runtimeServe, runtimeSpawn } from "./runtime";
 import type { StateFileId, StateChangeEvent } from "../types/dashboard";
 import type { RegisteredProject } from "./project-registry";
@@ -154,10 +154,14 @@ function resolveProjectCwd(
 
   // If the requested project matches the currently active project, use it directly
   // (handles startup projects that may not be in the registry yet)
-  if (projectId === generateProjectId(defaultCwd)) return defaultCwd;
+  if (projectId === projectIdFor(defaultCwd)) return defaultCwd;
 
   const projects = listRegisteredProjects();
-  const match = projects.find((p) => p.id === projectId);
+  // Match against primary id first, then walk alias lists so historical
+  // dashboard URLs continue routing after a v3 identity migration.
+  const match =
+    projects.find((p) => p.id === projectId) ??
+    projects.find((p) => p.aliases.includes(projectId));
   if (!match) return null;
 
   return match.cwd;
@@ -170,11 +174,11 @@ function getProjectsList(
   projects: RegisteredProject[];
   activeProjectId: string;
 } {
-  const activeId = generateProjectId(activeCwd);
+  const activeId = projectIdFor(activeCwd);
   const registered = listRegisteredProjects();
 
   // Ensure startup project is always in the list
-  const startupId = generateProjectId(startupCwd);
+  const startupId = projectIdFor(startupCwd);
   const hasStartup = registered.some((p) => p.id === startupId);
   if (!hasStartup) {
     const meta = getProjectMeta(projectDir(startupCwd));
@@ -183,6 +187,8 @@ function getProjectsList(
       cwd: startupCwd,
       name: meta?.name ?? basename(startupCwd),
       version: meta?.version ?? "0.1.0",
+      aliases: meta?.aliases ?? [],
+      pathsByDevice: meta?.pathsByDevice ?? {},
     });
   }
 
@@ -196,6 +202,8 @@ function getProjectsList(
         cwd: activeCwd,
         name: meta?.name ?? basename(activeCwd),
         version: meta?.version ?? "0.1.0",
+        aliases: meta?.aliases ?? [],
+        pathsByDevice: meta?.pathsByDevice ?? {},
       });
     }
   }

--- a/src/core/git-identity.ts
+++ b/src/core/git-identity.ts
@@ -1,0 +1,120 @@
+import { execSync } from "child_process";
+import { existsSync, realpathSync } from "fs";
+
+const GIT_TIMEOUT_MS = 2_000;
+
+function gitOut(cwd: string, args: string): string | null {
+  if (!existsSync(cwd)) return null;
+  try {
+    return execSync(`git ${args}`, {
+      cwd,
+      timeout: GIT_TIMEOUT_MS,
+      stdio: ["pipe", "pipe", "pipe"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
+}
+
+function canonicalCwd(cwd: string): string {
+  try {
+    return realpathSync(cwd);
+  } catch {
+    return cwd;
+  }
+}
+
+export function getRepoRoot(cwd: string): string | null {
+  const root = gitOut(canonicalCwd(cwd), "rev-parse --show-toplevel");
+  return root && root.length > 0 ? root : null;
+}
+
+export function getRepoSubpath(cwd: string): string {
+  const prefix = gitOut(canonicalCwd(cwd), "rev-parse --show-prefix");
+  if (prefix === null) return "";
+  return prefix.replace(/\\/g, "/").replace(/\/+$/, "").replace(/^\/+/, "");
+}
+
+// Resolves the project's primary remote URL. Prefers `origin` when present —
+// otherwise falls back to the alphabetically-first remote so projects with a
+// non-standard remote name still get a stable identity.
+export function getRepoRemote(cwd: string): string | null {
+  const c = canonicalCwd(cwd);
+  const origin = gitOut(c, "config --get remote.origin.url");
+  if (origin && origin.length > 0) return origin;
+
+  const list = gitOut(c, "remote");
+  if (!list) return null;
+  const remotes = list
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .sort();
+  if (remotes.length === 0) return null;
+  const url = gitOut(c, `config --get remote.${remotes[0]}.url`);
+  return url && url.length > 0 ? url : null;
+}
+
+// Reduces remote URL forms to a single canonical string so SSH/HTTPS, with or
+// without credentials, with or without `.git`, and with mixed host casing all
+// collapse to one representation per logical repository.
+//
+// Examples that all collapse to `github.com/owner/repo`:
+//   git@github.com:Owner/Repo.git
+//   https://github.com/owner/repo.git
+//   https://user:token@github.com/owner/repo
+//   ssh://git@github.com/owner/repo/
+//
+// Returns the original string only if it cannot be parsed — callers can still
+// treat that as "no usable remote" and fall back to path-derived identity.
+export function normalizeRemoteUrl(url: string): string {
+  if (!url) return "";
+  let s = url.trim();
+  if (s.length === 0) return "";
+
+  // Skip file/local protocol — these aren't shared identities.
+  if (/^(file:|\.\.?\/|\/)/i.test(s)) return "";
+
+  // SSH scp-style: git@host:owner/repo(.git) → ssh://git@host/owner/repo
+  const scp = s.match(/^([^@\s]+)@([^:\s]+):(.+)$/);
+  if (scp) {
+    s = `ssh://${scp[1]}@${scp[2]}/${scp[3]}`;
+  }
+
+  // Strip leading scheme so we can normalize the rest uniformly.
+  s = s.replace(/^[a-z][a-z0-9+.-]*:\/\//i, "");
+
+  // Strip embedded credentials: `user:pass@host/...` → `host/...`
+  s = s.replace(/^[^@/]*@/, "");
+
+  // Strip trailing slash and `.git`
+  s = s.replace(/\/+$/, "").replace(/\.git$/i, "");
+
+  // Lowercase the entire path. Major forges (GitHub, GitLab, Bitbucket) treat
+  // repo names as case-insensitive for URL routing, so two checkouts whose
+  // remotes differ only in casing point at the same logical repo. Users on
+  // case-sensitive self-hosted forges can pin identity with the override file.
+  return s.toLowerCase();
+}
+
+export interface GitIdentityComponents {
+  remote: string;
+  subpath: string;
+}
+
+// Returns the (remote, subpath) pair for `cwd` if it lives inside a git repo
+// with a normalizable remote. Returns null when the directory is not a git
+// repo, has no remote, or the remote URL is a local/file path. Callers should
+// fall back to path-derived identity in those cases.
+export function deriveGitIdentity(cwd: string): GitIdentityComponents | null {
+  const root = getRepoRoot(cwd);
+  if (!root) return null;
+  const remoteRaw = getRepoRemote(cwd);
+  if (!remoteRaw) return null;
+  const remote = normalizeRemoteUrl(remoteRaw);
+  if (!remote) return null;
+  const subpath = getRepoSubpath(cwd);
+  return { remote, subpath };
+}

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,6 +1,7 @@
 import { join } from "path";
+import { existsSync } from "fs";
 import { homedir } from "os";
-import { generateProjectId } from "./project-id";
+import { projectIdFor } from "./project-id";
 
 // Resolved per-call so tests can override via MINK_ROOT_OVERRIDE without
 // reloading modules. Production callers get the default homedir/.mink path.
@@ -19,9 +20,24 @@ export function minkRoot(): string {
   return MINK_ROOT;
 }
 
+// Locates the on-disk project state directory for `cwd`. Walks the alias list
+// when the primary identifier's directory does not exist, so historical
+// references (notes, dashboard URLs) keep resolving after a v3 migration
+// renames the project directory.
 export function projectDir(cwd: string): string {
-  const id = generateProjectId(cwd);
-  return join(minkRoot(), "projects", id);
+  const id = projectIdFor(cwd);
+  const primary = join(minkRoot(), "projects", id);
+  if (existsSync(primary)) return primary;
+  // Lazy require: project-registry imports paths, so a top-level import would
+  // create a cycle. Only walk aliases on a cold miss.
+  try {
+    const { findProjectDirByIdOrAlias } = require("./project-registry");
+    const aliased = findProjectDirByIdOrAlias(id);
+    if (aliased) return aliased;
+  } catch {
+    // best-effort
+  }
+  return primary;
 }
 
 export function sessionPath(cwd: string): string {

--- a/src/core/project-id.ts
+++ b/src/core/project-id.ts
@@ -136,8 +136,16 @@ function readIdentityMode(): "path-derived" | "git-remote" {
   return "path-derived";
 }
 
-export function resolveProjectIdentity(cwd: string): ProjectIdentity {
-  const mode = readIdentityMode();
+// Accepts an optional `modeOverride` so callers that have already snapshotted
+// `projects.identity` (e.g. the v3 migration, which runs inside a git-stash
+// window where the config file's uncommitted writes are hidden from disk) can
+// pass the snapshot in. Without the override, the internal mode read can
+// disagree with the caller's view of the world and produce the wrong id.
+export function resolveProjectIdentity(
+  cwd: string,
+  modeOverride?: "path-derived" | "git-remote"
+): ProjectIdentity {
+  const mode = modeOverride ?? readIdentityMode();
   if (mode === "path-derived") {
     return { id: generateProjectId(cwd), source: "path-derived" };
   }

--- a/src/core/project-id.ts
+++ b/src/core/project-id.ts
@@ -1,5 +1,7 @@
 import { createHash } from "crypto";
-import { basename } from "path";
+import { basename, join } from "path";
+import { existsSync, readFileSync } from "fs";
+import { deriveGitIdentity, getRepoRoot } from "./git-identity";
 
 function slugify(name: string): string {
   return name
@@ -8,12 +10,147 @@ function slugify(name: string): string {
     .replace(/^-|-$/g, "");
 }
 
+function shortHash(input: string): string {
+  return createHash("sha256").update(input).digest("hex").slice(0, 6);
+}
+
+// Legacy identity: hash of the absolute path. Retained for two reasons:
+// 1) The path-derived fallback tier of the new resolver returns this verbatim
+//    so non-git directories continue to behave exactly as before.
+// 2) The v2→v3 migration computes the prior identifier with this function so
+//    it can locate and rename the old per-project state directory.
 export function generateProjectId(absolutePath: string): string {
   const normalized = absolutePath.replace(/\/+$/, "");
   const slug = slugify(basename(normalized));
-  const hash = createHash("sha256")
-    .update(normalized)
-    .digest("hex")
-    .slice(0, 6);
+  const hash = shortHash(normalized);
   return `${slug}-${hash}`;
+}
+
+// ── Stable-identity resolver ──────────────────────────────────────────────
+//
+// Three-tier priority order:
+//   1. Explicit override file inside the user's repo (.mink/project.json)
+//   2. Git-derived: normalized remote URL + repo-root-relative subpath
+//   3. Path-derived fallback (legacy generateProjectId)
+//
+// Gated by the `projects.identity` config key. When the value is
+// `path-derived` (default during rollout) the resolver short-circuits to the
+// legacy behavior so existing users see no change until they opt in.
+
+export type IdentitySource = "override" | "git-remote" | "path-derived";
+
+export interface ProjectIdentity {
+  id: string;
+  source: IdentitySource;
+}
+
+const IDENTIFIER_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+const OVERRIDE_RELATIVE_PATH = ".mink/project.json";
+
+export function validateProjectIdentifier(id: unknown): id is string {
+  return typeof id === "string" && IDENTIFIER_PATTERN.test(id);
+}
+
+// Reads .mink/project.json from the repo containing `cwd` (or `cwd` itself if
+// it is not inside a git repo). Returns the validated identifier, or null when
+// the file is missing, unreadable, malformed, or declares an invalid identifier.
+//
+// Malformed overrides are reported once to stderr so the user notices when
+// their pin file has been ignored — silent fall-through would let typos linger.
+export function readProjectOverride(cwd: string): string | null {
+  const root = getRepoRoot(cwd) ?? cwd;
+  const overridePath = join(root, OVERRIDE_RELATIVE_PATH);
+  if (!existsSync(overridePath)) return null;
+
+  let raw: string;
+  try {
+    raw = readFileSync(overridePath, "utf-8");
+  } catch {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    warnInvalidOverride(overridePath, "file is not valid JSON");
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    warnInvalidOverride(overridePath, "expected a JSON object");
+    return null;
+  }
+
+  const id = (parsed as Record<string, unknown>).projectId;
+  if (id === undefined) return null;
+  if (!validateProjectIdentifier(id)) {
+    warnInvalidOverride(
+      overridePath,
+      "projectId must start with a letter or digit, contain only [a-z0-9._-], and be 1–128 characters"
+    );
+    return null;
+  }
+  return id;
+}
+
+const warnedOverrides = new Set<string>();
+function warnInvalidOverride(path: string, reason: string): void {
+  if (warnedOverrides.has(path)) return;
+  warnedOverrides.add(path);
+  console.warn(`[mink] ignoring ${path}: ${reason}`);
+}
+
+// Returns the git-derived identifier for `cwd` when it lives inside a git repo
+// with a normalizable remote. Returns null otherwise so the caller can fall
+// through to the path-derived tier.
+function gitDerivedIdentity(cwd: string): string | null {
+  const components = deriveGitIdentity(cwd);
+  if (!components) return null;
+  // Slug derives from the normalized remote or subpath — never from the local
+  // checkout's directory name — so two clones at differently-named paths
+  // produce the same identifier.
+  const remoteLeaf = components.remote.split("/").filter((p) => p).pop();
+  const slugSource = components.subpath
+    ? components.subpath.split("/").pop()!
+    : remoteLeaf ?? "project";
+  const slug = slugify(slugSource);
+  const hash = shortHash(`git:${components.remote}:${components.subpath}`);
+  return `${slug}-${hash}`;
+}
+
+function readIdentityMode(): "path-derived" | "git-remote" {
+  const envOverride = process.env.MINK_PROJECTS_IDENTITY;
+  if (envOverride === "git-remote" || envOverride === "path-derived") {
+    return envOverride;
+  }
+  try {
+    // Lazy require to avoid a cycle: global-config imports types/config which
+    // is small; project-id is imported very widely.
+    const { resolveConfigValue } = require("./global-config");
+    const v = resolveConfigValue("projects.identity").value;
+    if (v === "git-remote") return "git-remote";
+  } catch {
+    // fall through
+  }
+  return "path-derived";
+}
+
+export function resolveProjectIdentity(cwd: string): ProjectIdentity {
+  const mode = readIdentityMode();
+  if (mode === "path-derived") {
+    return { id: generateProjectId(cwd), source: "path-derived" };
+  }
+
+  const override = readProjectOverride(cwd);
+  if (override) return { id: override, source: "override" };
+
+  const git = gitDerivedIdentity(cwd);
+  if (git) return { id: git, source: "git-remote" };
+
+  return { id: generateProjectId(cwd), source: "path-derived" };
+}
+
+export function projectIdFor(cwd: string): string {
+  return resolveProjectIdentity(cwd).id;
 }

--- a/src/core/project-registry.ts
+++ b/src/core/project-registry.ts
@@ -1,13 +1,27 @@
 import { readdirSync, existsSync } from "fs";
 import { join } from "path";
 import { minkRoot } from "./paths";
-import { safeReadJson } from "./fs-utils";
+import { safeReadJson, atomicWriteJson } from "./fs-utils";
+
+// ── Project metadata ──────────────────────────────────────────────────────
+//
+// `project-meta.json` records who/what/when about a project's state directory.
+// The schema evolved across sync versions:
+//
+//   v1/v2: { cwd, name, initTimestamp, version, projectType? }
+//   v3:    adds { aliases: string[], pathsByDevice: Record<deviceId, cwd> }
+//
+// `cwd` is preserved on disk for forward-compat with older mink versions that
+// downgrade after a v3 migration — they continue to read it. New code prefers
+// `pathsByDevice[deviceId]` and treats `cwd` as a single-device fallback.
 
 export interface ProjectMeta {
   cwd: string;
   name: string;
   initTimestamp: string;
   version: string;
+  aliases?: string[];
+  pathsByDevice?: Record<string, string>;
 }
 
 export interface RegisteredProject {
@@ -15,28 +29,95 @@ export interface RegisteredProject {
   cwd: string;
   name: string;
   version: string;
+  aliases: string[];
+  pathsByDevice: Record<string, string>;
+}
+
+function projectMetaFilePath(projDir: string): string {
+  return join(projDir, "project-meta.json");
 }
 
 export function getProjectMeta(projDir: string): ProjectMeta | null {
-  const metaPath = join(projDir, "project-meta.json");
-  const raw = safeReadJson(metaPath);
-  if (
-    raw === null ||
-    typeof raw !== "object" ||
-    Array.isArray(raw)
-  ) {
-    return null;
-  }
+  const raw = safeReadJson(projectMetaFilePath(projDir));
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return null;
   const obj = raw as Record<string, unknown>;
-  if (typeof obj.cwd !== "string" || typeof obj.name !== "string") {
-    return null;
-  }
+  if (typeof obj.cwd !== "string" || typeof obj.name !== "string") return null;
+
+  const aliases = Array.isArray(obj.aliases)
+    ? (obj.aliases as unknown[]).filter((s): s is string => typeof s === "string")
+    : undefined;
+
+  const pathsByDevice =
+    obj.pathsByDevice &&
+    typeof obj.pathsByDevice === "object" &&
+    !Array.isArray(obj.pathsByDevice)
+      ? Object.fromEntries(
+          Object.entries(obj.pathsByDevice as Record<string, unknown>).filter(
+            ([, v]) => typeof v === "string"
+          ) as [string, string][]
+        )
+      : undefined;
+
   return {
     cwd: obj.cwd as string,
     name: obj.name as string,
     initTimestamp: (obj.initTimestamp as string) ?? "",
     version: (obj.version as string) ?? "0.1.0",
+    aliases,
+    pathsByDevice,
   };
+}
+
+// Idempotently records `aliasId` on the project at `projDir`. Preserves the
+// existing alias list, deduplicates, and preserves any unknown fields on the
+// metadata record so a future-version downgrade doesn't lose data.
+export function addProjectAlias(projDir: string, aliasId: string): boolean {
+  const path = projectMetaFilePath(projDir);
+  const raw = safeReadJson(path);
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return false;
+  const obj = raw as Record<string, unknown>;
+  const existing = Array.isArray(obj.aliases)
+    ? (obj.aliases as unknown[]).filter((s): s is string => typeof s === "string")
+    : [];
+  if (existing.includes(aliasId)) return false;
+  obj.aliases = [...existing, aliasId];
+  atomicWriteJson(path, obj);
+  return true;
+}
+
+// Writes the working-copy path for the given device into the per-device map.
+// Reads the existing map (or seeds it from the legacy singular `cwd` field if
+// no map exists yet) and writes the merged result back. Preserves unknown fields.
+export function setProjectPathForDevice(
+  projDir: string,
+  deviceId: string,
+  cwd: string
+): void {
+  const path = projectMetaFilePath(projDir);
+  const raw = safeReadJson(path);
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return;
+  const obj = raw as Record<string, unknown>;
+  const existing =
+    obj.pathsByDevice &&
+    typeof obj.pathsByDevice === "object" &&
+    !Array.isArray(obj.pathsByDevice)
+      ? { ...(obj.pathsByDevice as Record<string, string>) }
+      : {};
+  // Seed the map from the legacy singular cwd so the first device-keyed write
+  // doesn't drop the prior single-device path on the floor.
+  if (
+    Object.keys(existing).length === 0 &&
+    typeof obj.cwd === "string" &&
+    obj.cwd !== cwd
+  ) {
+    existing[deviceId] = obj.cwd;
+  }
+  existing[deviceId] = cwd;
+  obj.pathsByDevice = existing;
+  // Keep `cwd` in sync as the local-machine fallback so older versions still
+  // read a meaningful value after a downgrade.
+  obj.cwd = cwd;
+  atomicWriteJson(path, obj);
 }
 
 export function listRegisteredProjects(): RegisteredProject[] {
@@ -56,9 +137,37 @@ export function listRegisteredProjects(): RegisteredProject[] {
         cwd: meta.cwd,
         name: meta.name,
         version: meta.version,
+        aliases: meta.aliases ?? [],
+        pathsByDevice: meta.pathsByDevice ?? {},
       });
     }
   }
 
   return projects;
+}
+
+// Scans every project directory for one whose on-disk name or alias list matches
+// `id`. Returns the on-disk project directory or null. Used by paths.ts to
+// tolerate historical references after migration renames the project's
+// directory.
+export function findProjectDirByIdOrAlias(id: string): string | null {
+  const projectsDir = join(minkRoot(), "projects");
+  if (!existsSync(projectsDir)) return null;
+
+  const primary = join(projectsDir, id);
+  if (existsSync(primary)) return primary;
+
+  let entries: string[];
+  try {
+    entries = readdirSync(projectsDir);
+  } catch {
+    return null;
+  }
+
+  for (const name of entries) {
+    const projDir = join(projectsDir, name);
+    const meta = getProjectMeta(projDir);
+    if (meta?.aliases?.includes(id)) return projDir;
+  }
+  return null;
 }

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -51,6 +51,13 @@ config.local
 # Migration coordination — never sync this
 .sync-migrate.lock
 
+# Per-device identity migration recovery snapshots — local recovery state
+# for the migrating device, not authoritative project state. A device that
+# needs to recover from its migration must do so from its own snapshot;
+# syncing would make rollback dirs appear on devices that never produced
+# the corresponding migration.
+.identity-rollback/
+
 # Local backups and per-device caches — machine-specific snapshots
 projects/*/backups/
 projects/*/session.json

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -15,7 +15,13 @@ const FETCH_TIMEOUT = 15_000;
 // Sync layout version. Bumped when the on-disk shape of `~/.mink/` changes in
 // a way that older devices cannot read. Migration runs on first session-start
 // after upgrade when readSyncVersion() < MINK_SYNC_VERSION.
-export const MINK_SYNC_VERSION = 2;
+//
+// v1 → v2: per-device shards under projects/<id>/state/<deviceId>/
+// v2 → v3: stable identity — adds aliases[] and pathsByDevice{} on project-meta;
+//          when projects.identity=git-remote, renames per-project directories
+//          from path-derived IDs to git-derived IDs and records prior ID as
+//          alias. Migration is a no-op when the flag is off.
+export const MINK_SYNC_VERSION = 3;
 
 export function readSyncVersion(): number {
   try {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -17,6 +17,7 @@ export interface GlobalConfig {
   "cli.auto-update"?: string;
   "cli.auto-update-schedule"?: string;
   "cli.auto-update-package-manager"?: string;
+  "projects.identity"?: string;
 }
 
 export type ConfigKey = keyof GlobalConfig & string;
@@ -169,6 +170,14 @@ export const CONFIG_KEYS: ConfigKeyMeta[] = [
     envVar: "MINK_CLI_AUTO_UPDATE_PACKAGE_MANAGER",
     description: "Force a package manager (auto|npm|bun) for self-upgrade installs",
     scope: "local",
+  },
+  {
+    key: "projects.identity",
+    default: "path-derived",
+    envVar: "MINK_PROJECTS_IDENTITY",
+    description:
+      "Project identity strategy: path-derived (legacy) or git-remote (stable across machines)",
+    scope: "shared",
   },
 ];
 

--- a/tests/integration/config.test.ts
+++ b/tests/integration/config.test.ts
@@ -95,7 +95,7 @@ describe("config integration", () => {
 
   test("resolveAllConfig shows all settings with defaults", () => {
     const all = resolveAllConfig();
-    expect(all.length).toBe(18);
+    expect(all.length).toBe(19);
     const byKey = Object.fromEntries(all.map((a) => [a.key, a]));
     expect(byKey["wiki.path"].source).toBe("default");
     expect(byKey["wiki.enabled"].value).toBe("true");

--- a/tests/integration/sync-migrate.test.ts
+++ b/tests/integration/sync-migrate.test.ts
@@ -105,7 +105,7 @@ describe("sync v1 → v2 migration", () => {
     const result = migrateSyncLayout();
     expect(result.ranMigration).toBe(true);
     expect(result.fromVersion).toBe(1);
-    expect(result.toVersion).toBe(2);
+    expect(result.toVersion).toBeGreaterThanOrEqual(2);
 
     const deviceId = getOrCreateDeviceId();
     const shardDir = join(mockRoot, "projects", "proj-A", "state", deviceId);
@@ -139,10 +139,12 @@ describe("sync v1 → v2 migration", () => {
     expect(idx.header.lifetimeHits).toBe(0);
     expect(idx.header.lifetimeMisses).toBe(0);
 
-    // Version bumped
-    expect(
-      readFileSync(join(mockRoot, ".mink-sync-version"), "utf-8").trim()
-    ).toBe("2");
+    // Version bumped to the current sync version (>=2)
+    const stamped = parseInt(
+      readFileSync(join(mockRoot, ".mink-sync-version"), "utf-8").trim(),
+      10
+    );
+    expect(stamped).toBeGreaterThanOrEqual(2);
   });
 
   test("re-running is a no-op", async () => {
@@ -156,7 +158,7 @@ describe("sync v1 → v2 migration", () => {
     migrateSyncLayout();
     const second = migrateSyncLayout();
     expect(second.ranMigration).toBe(false);
-    expect(second.message).toContain("already at v2");
+    expect(second.message).toMatch(/already at v\d+/);
   });
 
   test("migrates aggregator-readable state — pre-migration reads still work", async () => {
@@ -182,5 +184,157 @@ describe("sync v1 → v2 migration", () => {
     const after = aggregateTokenLedgerAt(projDir);
     expect(after.lifetime.totalTokens).toBe(5000);
     expect(aggregateBugMemoryAt(projDir).entries.length).toBe(1);
+  });
+});
+
+describe("sync v2 → v3 identity migration", () => {
+  test("is a no-op when projects.identity is not git-remote", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "mink-v3-noflag-"));
+    try {
+      execSync(`git init -q "${cwd}"`);
+      execSync(`git -C "${cwd}" remote add origin git@github.com:owner/repo.git`);
+
+      const { generateProjectId } = await import("../../src/core/project-id");
+      const oldId = generateProjectId(cwd);
+      const projDir = join(mockRoot, "projects", oldId);
+      mkdirSync(projDir, { recursive: true });
+      writeFileSync(
+        join(projDir, "project-meta.json"),
+        JSON.stringify({ cwd, name: "repo", initTimestamp: "x", version: "0.1.0" })
+      );
+
+      delete process.env.MINK_PROJECTS_IDENTITY;
+      const { migrateSyncLayout } = await import(
+        "../../src/commands/sync-migrate"
+      );
+      migrateSyncLayout();
+
+      // Directory unchanged because the flag was not set.
+      expect(existsSync(projDir)).toBe(true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("renames project directory and records the prior id as an alias", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "mink-v3-rename-"));
+    try {
+      execSync(`git init -q "${cwd}"`);
+      execSync(`git -C "${cwd}" remote add origin git@github.com:owner/repo.git`);
+
+      const { generateProjectId, resolveProjectIdentity } = await import(
+        "../../src/core/project-id"
+      );
+
+      const oldId = generateProjectId(cwd);
+      const projDir = join(mockRoot, "projects", oldId);
+      mkdirSync(projDir, { recursive: true });
+      writeFileSync(
+        join(projDir, "project-meta.json"),
+        JSON.stringify({ cwd, name: "repo", initTimestamp: "x", version: "0.1.0" })
+      );
+
+      process.env.MINK_PROJECTS_IDENTITY = "git-remote";
+      try {
+        const newId = resolveProjectIdentity(cwd).id;
+        expect(newId).not.toBe(oldId);
+
+        const { migrateSyncLayout } = await import(
+          "../../src/commands/sync-migrate"
+        );
+        migrateSyncLayout();
+
+        const newProjDir = join(mockRoot, "projects", newId);
+        expect(existsSync(newProjDir)).toBe(true);
+        expect(existsSync(projDir)).toBe(false);
+
+        const raw = JSON.parse(
+          readFileSync(join(newProjDir, "project-meta.json"), "utf-8")
+        );
+        expect(raw.aliases).toContain(oldId);
+        expect(raw.pathsByDevice).toBeDefined();
+        const pathValues = Object.values(raw.pathsByDevice) as string[];
+        expect(pathValues).toContain(cwd);
+      } finally {
+        delete process.env.MINK_PROJECTS_IDENTITY;
+      }
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("is idempotent — re-running after a successful migration is a no-op", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "mink-v3-idem-"));
+    try {
+      execSync(`git init -q "${cwd}"`);
+      execSync(`git -C "${cwd}" remote add origin git@github.com:owner/repo.git`);
+
+      const { generateProjectId } = await import("../../src/core/project-id");
+      const oldId = generateProjectId(cwd);
+      const projDir = join(mockRoot, "projects", oldId);
+      mkdirSync(projDir, { recursive: true });
+      writeFileSync(
+        join(projDir, "project-meta.json"),
+        JSON.stringify({ cwd, name: "repo", initTimestamp: "x", version: "0.1.0" })
+      );
+
+      process.env.MINK_PROJECTS_IDENTITY = "git-remote";
+      try {
+        const { migrateSyncLayout } = await import(
+          "../../src/commands/sync-migrate"
+        );
+        migrateSyncLayout();
+        // Second run finds nothing to rename — alias list does not gain a
+        // duplicate, pathsByDevice does not corrupt.
+        migrateSyncLayout();
+
+        const { resolveProjectIdentity } = await import(
+          "../../src/core/project-id"
+        );
+        const newId = resolveProjectIdentity(cwd).id;
+        const raw = JSON.parse(
+          readFileSync(
+            join(mockRoot, "projects", newId, "project-meta.json"),
+            "utf-8"
+          )
+        );
+        const aliasCount = (raw.aliases ?? []).filter(
+          (a: string) => a === oldId
+        ).length;
+        expect(aliasCount).toBe(1);
+      } finally {
+        delete process.env.MINK_PROJECTS_IDENTITY;
+      }
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("skips projects whose cwd does not exist on this device", async () => {
+    process.env.MINK_PROJECTS_IDENTITY = "git-remote";
+    try {
+      const phantomId = "phantom-abc123";
+      const projDir = join(mockRoot, "projects", phantomId);
+      mkdirSync(projDir, { recursive: true });
+      writeFileSync(
+        join(projDir, "project-meta.json"),
+        JSON.stringify({
+          cwd: "/nonexistent/elsewhere",
+          name: "phantom",
+          initTimestamp: "x",
+          version: "0.1.0",
+        })
+      );
+
+      const { migrateSyncLayout } = await import(
+        "../../src/commands/sync-migrate"
+      );
+      migrateSyncLayout();
+
+      // Directory left alone — the device that owns the cwd will migrate it.
+      expect(existsSync(projDir)).toBe(true);
+    } finally {
+      delete process.env.MINK_PROJECTS_IDENTITY;
+    }
   });
 });

--- a/tests/integration/sync-migrate.test.ts
+++ b/tests/integration/sync-migrate.test.ts
@@ -337,6 +337,72 @@ describe("sync v2 → v3 identity migration", () => {
       delete process.env.MINK_PROJECTS_IDENTITY;
     }
   });
+
+  // Regression: with sync initialised, migrateSyncLayout stashes uncommitted
+  // edits before running so the migration commit stays clean. If the user has
+  // an uncommitted `projects.identity=git-remote` write in ~/.mink/config, the
+  // stash temporarily reverts the working tree to the committed config (which
+  // doesn't have the key). Reading the flag inside the stash window then
+  // returns "path-derived" (the default), the identity migration no-ops, and
+  // the user reports "I set the flag and migrate but nothing happens." The
+  // fix: snapshot the identity mode BEFORE the stash and thread it through
+  // planIdentityMigration / migrateProjectIdentities / resolveProjectIdentity
+  // so all downstream decisions agree with the caller's intent.
+  test("renames when projects.identity was set but not yet committed", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "mink-v3-stash-bug-"));
+    try {
+      execSync(`git init -q "${cwd}"`);
+      execSync(`git -C "${cwd}" remote add origin git@github.com:owner/repo.git`);
+
+      const { generateProjectId } = await import("../../src/core/project-id");
+      const oldId = generateProjectId(cwd);
+      const projDir = join(mockRoot, "projects", oldId);
+      mkdirSync(projDir, { recursive: true });
+      writeFileSync(
+        join(projDir, "project-meta.json"),
+        JSON.stringify({ cwd, name: "repo", initTimestamp: "x", version: "0.1.0" })
+      );
+
+      // Commit ~/.mink with the original config (no projects.identity) so the
+      // stash has a meaningful "last committed" version to revert to.
+      const configPath = join(mockRoot, "config");
+      writeFileSync(configPath, JSON.stringify({ "sync.enabled": "true" }));
+      execSync(`git init -q "${mockRoot}"`);
+      execSync(`git -C "${mockRoot}" config user.email "t@t"`);
+      execSync(`git -C "${mockRoot}" config user.name "t"`);
+      execSync(`git -C "${mockRoot}" add -A`);
+      execSync(`git -C "${mockRoot}" commit -q -m initial`);
+
+      // Now write projects.identity=git-remote into the working tree but DO
+      // NOT commit it. This is exactly what `mink config projects.identity
+      // git-remote` produces: a dirty config file.
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          "sync.enabled": "true",
+          "projects.identity": "git-remote",
+        })
+      );
+
+      const { migrateSyncLayout } = await import(
+        "../../src/commands/sync-migrate"
+      );
+      const result = migrateSyncLayout();
+      expect(result.ranMigration).toBe(true);
+
+      // The bug: pre-fix, the dir would NOT be renamed because the migration
+      // re-read the (stashed) config and saw path-derived → newId === oldId.
+      const { resolveProjectIdentity } = await import(
+        "../../src/core/project-id"
+      );
+      const newId = resolveProjectIdentity(cwd, "git-remote").id;
+      expect(newId).not.toBe(oldId);
+      expect(existsSync(join(mockRoot, "projects", newId))).toBe(true);
+      expect(existsSync(projDir)).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("identity migration safety: dry-run, backup, rollback", () => {

--- a/tests/integration/sync-migrate.test.ts
+++ b/tests/integration/sync-migrate.test.ts
@@ -338,3 +338,135 @@ describe("sync v2 → v3 identity migration", () => {
     }
   });
 });
+
+describe("identity migration safety: dry-run, backup, rollback", () => {
+  function seedRenameableProject(): { cwd: string; oldId: string } {
+    const cwd = mkdtempSync(join(tmpdir(), "mink-safety-"));
+    execSync(`git init -q "${cwd}"`);
+    execSync(`git -C "${cwd}" remote add origin git@github.com:owner/repo.git`);
+
+    // Compute the path-derived id and seed the project at that location.
+    const oldId = require("../../src/core/project-id").generateProjectId(cwd);
+    const projDir = join(mockRoot, "projects", oldId);
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(
+      join(projDir, "project-meta.json"),
+      JSON.stringify({ cwd, name: "repo", initTimestamp: "x", version: "0.1.0" })
+    );
+    writeFileSync(join(projDir, "marker.txt"), "before migration");
+    return { cwd, oldId };
+  }
+
+  test("--dry-run prints the rename plan without touching disk", async () => {
+    const { cwd, oldId } = seedRenameableProject();
+    try {
+      process.env.MINK_PROJECTS_IDENTITY = "git-remote";
+      try {
+        const { planIdentityMigration } = await import(
+          "../../src/commands/sync-migrate"
+        );
+        const plan = planIdentityMigration();
+        expect(plan.length).toBe(1);
+        expect(plan[0].action).toBe("rename");
+        expect(plan[0].oldId).toBe(oldId);
+        expect(plan[0].newId).not.toBe(oldId);
+
+        // Disk untouched
+        expect(existsSync(join(mockRoot, "projects", oldId))).toBe(true);
+        expect(
+          existsSync(join(mockRoot, "projects", plan[0].newId!))
+        ).toBe(false);
+      } finally {
+        delete process.env.MINK_PROJECTS_IDENTITY;
+      }
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("migration writes a per-project backup under .identity-rollback before renaming", async () => {
+    const { cwd, oldId } = seedRenameableProject();
+    try {
+      process.env.MINK_PROJECTS_IDENTITY = "git-remote";
+      try {
+        const { migrateSyncLayout } = await import(
+          "../../src/commands/sync-migrate"
+        );
+        migrateSyncLayout();
+
+        const backupRoot = join(mockRoot, ".identity-rollback");
+        expect(existsSync(backupRoot)).toBe(true);
+        const stamps = require("fs").readdirSync(backupRoot);
+        expect(stamps.length).toBeGreaterThanOrEqual(1);
+        const snapshot = join(backupRoot, stamps[0], oldId);
+        expect(existsSync(join(snapshot, "marker.txt"))).toBe(true);
+        expect(
+          require("fs")
+            .readFileSync(join(snapshot, "marker.txt"), "utf-8")
+            .toString()
+        ).toBe("before migration");
+      } finally {
+        delete process.env.MINK_PROJECTS_IDENTITY;
+      }
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("--rollback renames back, pops the alias, leaves the project usable", async () => {
+    const { cwd, oldId } = seedRenameableProject();
+    try {
+      process.env.MINK_PROJECTS_IDENTITY = "git-remote";
+      try {
+        const { migrateSyncLayout, rollbackProjectIdentities, planIdentityMigration } =
+          await import("../../src/commands/sync-migrate");
+
+        const plan = planIdentityMigration();
+        const newId = plan[0].newId!;
+
+        migrateSyncLayout();
+        expect(existsSync(join(mockRoot, "projects", newId))).toBe(true);
+        expect(existsSync(join(mockRoot, "projects", oldId))).toBe(false);
+
+        const results = rollbackProjectIdentities();
+        const ok = results.filter((r) => r.ok);
+        expect(ok.length).toBe(1);
+        expect(ok[0].currentId).toBe(newId);
+        expect(ok[0].restoredId).toBe(oldId);
+
+        // After rollback: original dir name restored, marker preserved, alias gone.
+        expect(existsSync(join(mockRoot, "projects", oldId))).toBe(true);
+        expect(existsSync(join(mockRoot, "projects", newId))).toBe(false);
+        expect(
+          require("fs")
+            .readFileSync(
+              join(mockRoot, "projects", oldId, "marker.txt"),
+              "utf-8"
+            )
+            .toString()
+        ).toBe("before migration");
+        const meta = JSON.parse(
+          require("fs")
+            .readFileSync(
+              join(mockRoot, "projects", oldId, "project-meta.json"),
+              "utf-8"
+            )
+            .toString()
+        );
+        expect(meta.aliases ?? []).toEqual([]);
+      } finally {
+        delete process.env.MINK_PROJECTS_IDENTITY;
+      }
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("--rollback is a no-op when nothing has aliases", async () => {
+    const { rollbackProjectIdentities } = await import(
+      "../../src/commands/sync-migrate"
+    );
+    const results = rollbackProjectIdentities();
+    expect(results.length).toBe(0);
+  });
+});

--- a/tests/integration/sync-migrate.test.ts
+++ b/tests/integration/sync-migrate.test.ts
@@ -582,6 +582,93 @@ describe("sync v2 → v3 identity migration", () => {
     }
   });
 
+  // Regression: when the new (git-derived) dir exists but has no
+  // project-meta.json, addProjectAlias would silently no-op and the old dir
+  // would be stranded forever — dry-run would keep proposing the same
+  // converge action forever, and the migrate's converged-count stayed at 0.
+  // Real-world trigger: the running daemon writes state to the new path
+  // under the git-derived id before any init or migrate has run, leaving a
+  // dir with state files but no meta. The migrator must repair the meta
+  // forward from the old dir so convergence can complete.
+  test("skip-converged repairs a meta-less new dir from the old meta", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "mink-v3-repair-meta-"));
+    try {
+      execSync(`git init -q "${cwd}"`);
+      execSync(`git -C "${cwd}" remote add origin git@github.com:owner/repo.git`);
+
+      const { generateProjectId, resolveProjectIdentity } = await import(
+        "../../src/core/project-id"
+      );
+      const oldId = generateProjectId(cwd);
+      const newId = resolveProjectIdentity(cwd, "git-remote").id;
+
+      const oldProjDir = join(mockRoot, "projects", oldId);
+      const newProjDir = join(mockRoot, "projects", newId);
+
+      // Old dir: full project-meta.json (this is the source of truth).
+      mkdirSync(oldProjDir, { recursive: true });
+      writeFileSync(
+        join(oldProjDir, "project-meta.json"),
+        JSON.stringify({
+          cwd,
+          name: "repo",
+          initTimestamp: "2026-04-01T00:00:00.000Z",
+          version: "0.1.0",
+        })
+      );
+
+      // New dir: exists with daemon-written state but NO project-meta.json.
+      // Includes a state shard so v1→v2 migration skips it — mirroring the
+      // real-world condition where the daemon was writing to a v2-shaped
+      // dir at the git-derived id before any init recorded a meta.
+      const { getOrCreateDeviceId } = await import("../../src/core/device");
+      const deviceId = getOrCreateDeviceId();
+      mkdirSync(join(newProjDir, "state", deviceId), { recursive: true });
+      writeFileSync(
+        join(newProjDir, "file-index.json"),
+        JSON.stringify({ header: {}, entries: {} })
+      );
+      writeFileSync(
+        join(newProjDir, "state", deviceId, "action-log.md"),
+        "# Action log\n"
+      );
+
+      process.env.MINK_PROJECTS_IDENTITY = "git-remote";
+      try {
+        const { migrateSyncLayout } = await import(
+          "../../src/commands/sync-migrate"
+        );
+        const result = migrateSyncLayout();
+        expect(result.ranMigration).toBe(true);
+
+        // New dir now has a meta, with the alias recorded.
+        const repairedMeta = JSON.parse(
+          readFileSync(join(newProjDir, "project-meta.json"), "utf-8")
+        );
+        expect(repairedMeta.aliases).toContain(oldId);
+        expect(repairedMeta.cwd).toBe(cwd);
+        expect(repairedMeta.name).toBe("repo");
+
+        // Daemon-written state preserved (not overwritten by the meta-repair).
+        expect(existsSync(join(newProjDir, "file-index.json"))).toBe(true);
+        expect(
+          existsSync(join(newProjDir, "state", deviceId, "action-log.md"))
+        ).toBe(true);
+
+        // Old dir evicted.
+        expect(existsSync(oldProjDir)).toBe(false);
+
+        // Outcome reports the converge.
+        expect(result.identity?.converged).toBeGreaterThanOrEqual(1);
+        expect(result.identity?.evicted).toBeGreaterThanOrEqual(1);
+      } finally {
+        delete process.env.MINK_PROJECTS_IDENTITY;
+      }
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   // Regression: .identity-rollback/ must be in the synced .gitignore so
   // per-device recovery snapshots don't propagate. Reporter saw machine A's
   // rollback dir appear on machine B via sync, which made it look like

--- a/tests/integration/sync-migrate.test.ts
+++ b/tests/integration/sync-migrate.test.ts
@@ -403,6 +403,195 @@ describe("sync v2 → v3 identity migration", () => {
       rmSync(cwd, { recursive: true, force: true });
     }
   });
+
+  // Regression: skip-converged eviction policy + idempotent planner.
+  //
+  // Convergence happens when another device finished the rename and the new
+  // dir arrived via sync, so both old and new dirs exist locally. Pre-fix the
+  // migrator would record the alias but leave the old dir on disk; dry-run
+  // would then keep proposing the same skip-converged action forever because
+  // it only checked "is the old dir still here?". Post-fix the migrator
+  // evicts the old dir to .identity-rollback/ and the planner short-circuits
+  // to skip-unchanged on subsequent runs.
+  test("skip-converged evicts the old dir and a second migrate is a no-op", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "mink-v3-converge-evict-"));
+    try {
+      execSync(`git init -q "${cwd}"`);
+      execSync(`git -C "${cwd}" remote add origin git@github.com:owner/repo.git`);
+
+      const { generateProjectId } = await import("../../src/core/project-id");
+      const oldId = generateProjectId(cwd);
+      const oldProjDir = join(mockRoot, "projects", oldId);
+
+      process.env.MINK_PROJECTS_IDENTITY = "git-remote";
+      try {
+        const { resolveProjectIdentity } = await import(
+          "../../src/core/project-id"
+        );
+        const newId = resolveProjectIdentity(cwd, "git-remote").id;
+        const newProjDir = join(mockRoot, "projects", newId);
+
+        // Seed both old (path-derived) and new (git-derived) directories to
+        // simulate the converged-via-sync state.
+        mkdirSync(oldProjDir, { recursive: true });
+        writeFileSync(
+          join(oldProjDir, "project-meta.json"),
+          JSON.stringify({
+            cwd,
+            name: "repo",
+            initTimestamp: "x",
+            version: "0.1.0",
+          })
+        );
+        writeFileSync(join(oldProjDir, "marker.txt"), "local-only-state");
+
+        mkdirSync(newProjDir, { recursive: true });
+        writeFileSync(
+          join(newProjDir, "project-meta.json"),
+          JSON.stringify({
+            cwd,
+            name: "repo",
+            initTimestamp: "x",
+            version: "0.1.0",
+          })
+        );
+
+        const { migrateSyncLayout, planIdentityMigration } = await import(
+          "../../src/commands/sync-migrate"
+        );
+
+        // First plan: skip-converged (record alias + evict).
+        const planBefore = planIdentityMigration("git-remote").filter(
+          (p) => p.oldId === oldId
+        );
+        expect(planBefore.length).toBe(1);
+        expect(planBefore[0].action).toBe("skip-converged");
+
+        // Run the migration.
+        const result = migrateSyncLayout();
+        expect(result.ranMigration).toBe(true);
+
+        // Old dir evicted; alias recorded on new meta.
+        expect(existsSync(oldProjDir)).toBe(false);
+        const newMeta = JSON.parse(
+          readFileSync(join(newProjDir, "project-meta.json"), "utf-8")
+        );
+        expect(newMeta.aliases).toContain(oldId);
+
+        // Eviction backup contains the local-only state we seeded.
+        const rollbackRoot = join(mockRoot, ".identity-rollback");
+        expect(existsSync(rollbackRoot)).toBe(true);
+        const snapshots = require("fs")
+          .readdirSync(rollbackRoot)
+          .filter((n: string) => existsSync(join(rollbackRoot, n, oldId)));
+        expect(snapshots.length).toBeGreaterThan(0);
+        const evictedMarker = join(
+          rollbackRoot,
+          snapshots[0],
+          oldId,
+          "marker.txt"
+        );
+        expect(readFileSync(evictedMarker, "utf-8")).toBe("local-only-state");
+
+        // Second plan: nothing left for this project — old dir is gone.
+        const planAfter = planIdentityMigration("git-remote").filter(
+          (p) => p.oldId === oldId
+        );
+        expect(planAfter.length).toBe(0);
+      } finally {
+        delete process.env.MINK_PROJECTS_IDENTITY;
+      }
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  // Regression: skip-evict action — alias was already recorded by a prior
+  // partial run, the old dir is still on disk. The planner used to keep
+  // proposing skip-converged in this case, so dry-run was never idempotent.
+  // Now the planner classifies it as skip-evict and the migrator removes the
+  // leftover directory.
+  test("skip-evict cleans up a leftover old dir whose alias is already recorded", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "mink-v3-evict-only-"));
+    try {
+      execSync(`git init -q "${cwd}"`);
+      execSync(`git -C "${cwd}" remote add origin git@github.com:owner/repo.git`);
+
+      const { generateProjectId, resolveProjectIdentity } = await import(
+        "../../src/core/project-id"
+      );
+      const oldId = generateProjectId(cwd);
+      const newId = resolveProjectIdentity(cwd, "git-remote").id;
+
+      const oldProjDir = join(mockRoot, "projects", oldId);
+      const newProjDir = join(mockRoot, "projects", newId);
+
+      // Old dir exists.
+      mkdirSync(oldProjDir, { recursive: true });
+      writeFileSync(
+        join(oldProjDir, "project-meta.json"),
+        JSON.stringify({ cwd, name: "repo", initTimestamp: "x", version: "0.1.0" })
+      );
+
+      // New dir exists AND already has the alias recorded — the partial-state
+      // we'd land in if a prior migration recorded the alias but failed to
+      // evict.
+      mkdirSync(newProjDir, { recursive: true });
+      writeFileSync(
+        join(newProjDir, "project-meta.json"),
+        JSON.stringify({
+          cwd,
+          name: "repo",
+          initTimestamp: "x",
+          version: "0.1.0",
+          aliases: [oldId],
+        })
+      );
+
+      process.env.MINK_PROJECTS_IDENTITY = "git-remote";
+      try {
+        const { migrateSyncLayout, planIdentityMigration } = await import(
+          "../../src/commands/sync-migrate"
+        );
+
+        const planBefore = planIdentityMigration("git-remote").filter(
+          (p) => p.oldId === oldId
+        );
+        expect(planBefore.length).toBe(1);
+        expect(planBefore[0].action).toBe("skip-evict");
+
+        migrateSyncLayout();
+
+        // Old dir evicted; alias still recorded (untouched).
+        expect(existsSync(oldProjDir)).toBe(false);
+        const newMeta = JSON.parse(
+          readFileSync(join(newProjDir, "project-meta.json"), "utf-8")
+        );
+        expect(newMeta.aliases).toContain(oldId);
+
+        // Subsequent plan: nothing left.
+        const planAfter = planIdentityMigration("git-remote").filter(
+          (p) => p.oldId === oldId
+        );
+        expect(planAfter.length).toBe(0);
+      } finally {
+        delete process.env.MINK_PROJECTS_IDENTITY;
+      }
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  // Regression: .identity-rollback/ must be in the synced .gitignore so
+  // per-device recovery snapshots don't propagate. Reporter saw machine A's
+  // rollback dir appear on machine B via sync, which made it look like
+  // machine B silently evicted dirs.
+  test(".identity-rollback/ is excluded by the synced .gitignore", async () => {
+    const { ensureGitignore } = await import("../../src/core/sync");
+    ensureGitignore();
+    const gitignore = readFileSync(join(mockRoot, ".gitignore"), "utf-8");
+    expect(gitignore).toContain(".identity-rollback/");
+  });
 });
 
 describe("identity migration safety: dry-run, backup, rollback", () => {

--- a/tests/unit/git-identity.test.ts
+++ b/tests/unit/git-identity.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeRemoteUrl } from "../../src/core/git-identity";
+
+describe("normalizeRemoteUrl", () => {
+  test("collapses SSH and HTTPS forms of the same remote", () => {
+    const ssh = normalizeRemoteUrl("git@github.com:owner/repo.git");
+    const https = normalizeRemoteUrl("https://github.com/owner/repo.git");
+    expect(ssh).toBe(https);
+    expect(ssh).toBe("github.com/owner/repo");
+  });
+
+  test("strips embedded credentials", () => {
+    const withCreds = normalizeRemoteUrl(
+      "https://user:tok@github.com/owner/repo.git"
+    );
+    const plain = normalizeRemoteUrl("https://github.com/owner/repo.git");
+    expect(withCreds).toBe(plain);
+  });
+
+  test("ignores trailing slash and .git suffix", () => {
+    expect(normalizeRemoteUrl("https://github.com/owner/repo/")).toBe(
+      "github.com/owner/repo"
+    );
+    expect(normalizeRemoteUrl("https://github.com/owner/repo")).toBe(
+      "github.com/owner/repo"
+    );
+    expect(normalizeRemoteUrl("https://github.com/owner/repo.git")).toBe(
+      "github.com/owner/repo"
+    );
+  });
+
+  test("lowercases the entire path so case-only differences unify", () => {
+    expect(normalizeRemoteUrl("git@GitHub.com:Owner/Repo.git")).toBe(
+      "github.com/owner/repo"
+    );
+  });
+
+  test("handles ssh:// scheme", () => {
+    expect(normalizeRemoteUrl("ssh://git@github.com/owner/repo")).toBe(
+      "github.com/owner/repo"
+    );
+  });
+
+  test("rejects file:// and relative paths so they fall back to path-derived", () => {
+    expect(normalizeRemoteUrl("file:///tmp/repo")).toBe("");
+    expect(normalizeRemoteUrl("../sibling-repo")).toBe("");
+    expect(normalizeRemoteUrl("/absolute/path")).toBe("");
+  });
+
+  test("handles self-hosted forges without choking", () => {
+    expect(normalizeRemoteUrl("git@git.example.com:team/svc.git")).toBe(
+      "git.example.com/team/svc"
+    );
+  });
+});

--- a/tests/unit/global-config.test.ts
+++ b/tests/unit/global-config.test.ts
@@ -36,8 +36,8 @@ describe("config types", () => {
     expect(isValidConfigKey("wiki")).toBe(false);
   });
 
-  test("CONFIG_KEYS has 18 entries", () => {
-    expect(CONFIG_KEYS.length).toBe(18);
+  test("CONFIG_KEYS has 19 entries", () => {
+    expect(CONFIG_KEYS.length).toBe(19);
   });
 
   test("each CONFIG_KEY has required fields", () => {
@@ -138,7 +138,7 @@ describe("resolveConfigValue", () => {
       delete process.env[meta.envVar];
     }
     const all = resolveAllConfig();
-    expect(all.length).toBe(18);
+    expect(all.length).toBe(19);
     for (const entry of all) {
       expect(entry.key).toBeTruthy();
       expect(entry.value).toBeDefined();

--- a/tests/unit/project-id.test.ts
+++ b/tests/unit/project-id.test.ts
@@ -1,5 +1,19 @@
-import { describe, expect, test } from "bun:test";
-import { generateProjectId } from "../../src/core/project-id";
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { execSync } from "child_process";
+import {
+  generateProjectId,
+  resolveProjectIdentity,
+  readProjectOverride,
+  validateProjectIdentifier,
+} from "../../src/core/project-id";
 
 describe("generateProjectId", () => {
   test("returns slugified basename with hash suffix", () => {
@@ -29,5 +43,169 @@ describe("generateProjectId", () => {
     const a = generateProjectId("/Users/drew/dev/my-project");
     const b = generateProjectId("/Users/drew/dev/my-project/");
     expect(a).toBe(b);
+  });
+});
+
+describe("validateProjectIdentifier", () => {
+  test("accepts well-formed identifiers", () => {
+    expect(validateProjectIdentifier("my-project")).toBe(true);
+    expect(validateProjectIdentifier("svc.api.v2")).toBe(true);
+    expect(validateProjectIdentifier("a1b2c3")).toBe(true);
+  });
+
+  test("rejects malformed identifiers", () => {
+    expect(validateProjectIdentifier("")).toBe(false);
+    expect(validateProjectIdentifier("-leading-dash")).toBe(false);
+    expect(validateProjectIdentifier("UPPER")).toBe(false);
+    expect(validateProjectIdentifier("has spaces")).toBe(false);
+    expect(validateProjectIdentifier("a".repeat(129))).toBe(false);
+    expect(validateProjectIdentifier(null)).toBe(false);
+    expect(validateProjectIdentifier(42)).toBe(false);
+  });
+});
+
+describe("resolveProjectIdentity (path-derived mode)", () => {
+  let prior: string | undefined;
+  beforeEach(() => {
+    prior = process.env.MINK_PROJECTS_IDENTITY;
+    process.env.MINK_PROJECTS_IDENTITY = "path-derived";
+  });
+  afterEach(() => {
+    if (prior === undefined) delete process.env.MINK_PROJECTS_IDENTITY;
+    else process.env.MINK_PROJECTS_IDENTITY = prior;
+  });
+
+  test("returns the path-derived identifier and never consults the override", () => {
+    const r = resolveProjectIdentity("/Users/drew/dev/my-project");
+    expect(r.source).toBe("path-derived");
+    expect(r.id).toBe(generateProjectId("/Users/drew/dev/my-project"));
+  });
+});
+
+describe("resolveProjectIdentity (git-remote mode)", () => {
+  let workdir: string;
+  let prior: string | undefined;
+  beforeEach(() => {
+    prior = process.env.MINK_PROJECTS_IDENTITY;
+    process.env.MINK_PROJECTS_IDENTITY = "git-remote";
+    workdir = mkdtempSync(join(tmpdir(), "mink-resolver-test-"));
+  });
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true });
+    if (prior === undefined) delete process.env.MINK_PROJECTS_IDENTITY;
+    else process.env.MINK_PROJECTS_IDENTITY = prior;
+  });
+
+  function initRepoWithRemote(dir: string, remoteUrl: string): void {
+    execSync(`git init -q "${dir}"`);
+    execSync(`git -C "${dir}" remote add origin "${remoteUrl}"`);
+  }
+
+  test("falls back to path-derived when cwd is not a git repo", () => {
+    const r = resolveProjectIdentity(workdir);
+    expect(r.source).toBe("path-derived");
+  });
+
+  test("falls back to path-derived when git repo has no remote", () => {
+    execSync(`git init -q "${workdir}"`);
+    const r = resolveProjectIdentity(workdir);
+    expect(r.source).toBe("path-derived");
+  });
+
+  test("derives stable id from remote + empty subpath at repo root", () => {
+    initRepoWithRemote(workdir, "git@github.com:owner/repo.git");
+    const r = resolveProjectIdentity(workdir);
+    expect(r.source).toBe("git-remote");
+    expect(r.id).toMatch(/-[a-f0-9]{6}$/);
+  });
+
+  test("two URL forms of the same remote produce the same id", () => {
+    const a = mkdtempSync(join(tmpdir(), "mink-a-"));
+    const b = mkdtempSync(join(tmpdir(), "mink-b-"));
+    try {
+      initRepoWithRemote(a, "git@github.com:Owner/Repo.git");
+      initRepoWithRemote(b, "https://github.com/owner/repo");
+      const ra = resolveProjectIdentity(a);
+      const rb = resolveProjectIdentity(b);
+      expect(ra.id).toBe(rb.id);
+    } finally {
+      rmSync(a, { recursive: true, force: true });
+      rmSync(b, { recursive: true, force: true });
+    }
+  });
+
+  test("monorepo subdirectories get distinct identifiers", () => {
+    initRepoWithRemote(workdir, "git@github.com:org/monorepo.git");
+    mkdirSync(join(workdir, "svc-a"), { recursive: true });
+    mkdirSync(join(workdir, "svc-b"), { recursive: true });
+    const rootId = resolveProjectIdentity(workdir).id;
+    const aId = resolveProjectIdentity(join(workdir, "svc-a")).id;
+    const bId = resolveProjectIdentity(join(workdir, "svc-b")).id;
+    expect(aId).not.toBe(bId);
+    expect(aId).not.toBe(rootId);
+    expect(bId).not.toBe(rootId);
+  });
+
+  test("respects override file when present", () => {
+    initRepoWithRemote(workdir, "git@github.com:owner/repo.git");
+    mkdirSync(join(workdir, ".mink"), { recursive: true });
+    writeFileSync(
+      join(workdir, ".mink", "project.json"),
+      JSON.stringify({ projectId: "pinned-id" })
+    );
+    const r = resolveProjectIdentity(workdir);
+    expect(r.source).toBe("override");
+    expect(r.id).toBe("pinned-id");
+  });
+
+  test("rejects malformed override and falls through to git-derived", () => {
+    initRepoWithRemote(workdir, "git@github.com:owner/repo.git");
+    mkdirSync(join(workdir, ".mink"), { recursive: true });
+    writeFileSync(
+      join(workdir, ".mink", "project.json"),
+      JSON.stringify({ projectId: "Has Spaces" })
+    );
+    const r = resolveProjectIdentity(workdir);
+    expect(r.source).toBe("git-remote");
+  });
+
+  test("rejects override that is not valid JSON and falls through", () => {
+    initRepoWithRemote(workdir, "git@github.com:owner/repo.git");
+    mkdirSync(join(workdir, ".mink"), { recursive: true });
+    writeFileSync(join(workdir, ".mink", "project.json"), "{not json");
+    const r = resolveProjectIdentity(workdir);
+    expect(r.source).toBe("git-remote");
+  });
+});
+
+describe("readProjectOverride", () => {
+  let workdir: string;
+  beforeEach(() => {
+    workdir = mkdtempSync(join(tmpdir(), "mink-override-test-"));
+  });
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  test("returns null when override file is missing", () => {
+    expect(readProjectOverride(workdir)).toBeNull();
+  });
+
+  test("returns the validated identifier", () => {
+    mkdirSync(join(workdir, ".mink"), { recursive: true });
+    writeFileSync(
+      join(workdir, ".mink", "project.json"),
+      JSON.stringify({ projectId: "good-id" })
+    );
+    expect(readProjectOverride(workdir)).toBe("good-id");
+  });
+
+  test("returns null when projectId is missing entirely", () => {
+    mkdirSync(join(workdir, ".mink"), { recursive: true });
+    writeFileSync(
+      join(workdir, ".mink", "project.json"),
+      JSON.stringify({ other: "field" })
+    );
+    expect(readProjectOverride(workdir)).toBeNull();
   });
 });

--- a/tests/unit/project-registry.test.ts
+++ b/tests/unit/project-registry.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  getProjectMeta,
+  addProjectAlias,
+  setProjectPathForDevice,
+  findProjectDirByIdOrAlias,
+  listRegisteredProjects,
+} from "../../src/core/project-registry";
+
+let mockRoot: string;
+
+beforeEach(() => {
+  mockRoot = mkdtempSync(join(tmpdir(), "mink-registry-test-"));
+  process.env.MINK_ROOT_OVERRIDE = mockRoot;
+});
+
+afterEach(() => {
+  delete process.env.MINK_ROOT_OVERRIDE;
+  rmSync(mockRoot, { recursive: true, force: true });
+});
+
+function seedProject(id: string, meta: Record<string, unknown>): string {
+  const projDir = join(mockRoot, "projects", id);
+  mkdirSync(projDir, { recursive: true });
+  writeFileSync(join(projDir, "project-meta.json"), JSON.stringify(meta));
+  return projDir;
+}
+
+describe("getProjectMeta", () => {
+  test("reads legacy v2 meta without aliases or pathsByDevice", () => {
+    const dir = seedProject("legacy", {
+      cwd: "/path/legacy",
+      name: "legacy",
+      version: "0.1.0",
+      initTimestamp: "2026-01-01T00:00:00Z",
+    });
+    const meta = getProjectMeta(dir);
+    expect(meta).not.toBeNull();
+    expect(meta!.cwd).toBe("/path/legacy");
+    expect(meta!.aliases).toBeUndefined();
+    expect(meta!.pathsByDevice).toBeUndefined();
+  });
+
+  test("reads v3 meta with aliases and pathsByDevice", () => {
+    const dir = seedProject("modern", {
+      cwd: "/path/modern",
+      name: "modern",
+      version: "0.1.0",
+      initTimestamp: "2026-01-01T00:00:00Z",
+      aliases: ["old-id-1", "old-id-2"],
+      pathsByDevice: { "dev-A": "/path/modern-a", "dev-B": "/path/modern-b" },
+    });
+    const meta = getProjectMeta(dir);
+    expect(meta!.aliases).toEqual(["old-id-1", "old-id-2"]);
+    expect(meta!.pathsByDevice).toEqual({
+      "dev-A": "/path/modern-a",
+      "dev-B": "/path/modern-b",
+    });
+  });
+
+  test("filters out non-string entries from aliases and pathsByDevice", () => {
+    const dir = seedProject("corrupt", {
+      cwd: "/path/c",
+      name: "c",
+      aliases: ["good", 42, null, "also-good"],
+      pathsByDevice: { good: "/p", broken: 99 },
+    });
+    const meta = getProjectMeta(dir);
+    expect(meta!.aliases).toEqual(["good", "also-good"]);
+    expect(meta!.pathsByDevice).toEqual({ good: "/p" });
+  });
+});
+
+describe("addProjectAlias", () => {
+  test("appends an alias and deduplicates", () => {
+    const dir = seedProject("p", { cwd: "/p", name: "p" });
+    expect(addProjectAlias(dir, "old-a")).toBe(true);
+    expect(addProjectAlias(dir, "old-a")).toBe(false);
+    expect(addProjectAlias(dir, "old-b")).toBe(true);
+    const meta = getProjectMeta(dir);
+    expect(meta!.aliases).toEqual(["old-a", "old-b"]);
+  });
+
+  test("preserves unknown fields on write", () => {
+    const dir = seedProject("p", {
+      cwd: "/p",
+      name: "p",
+      projectType: "notes",
+      futureField: { nested: true },
+    });
+    addProjectAlias(dir, "old-id");
+    const raw = JSON.parse(
+      readFileSync(join(dir, "project-meta.json"), "utf-8")
+    );
+    expect(raw.projectType).toBe("notes");
+    expect(raw.futureField).toEqual({ nested: true });
+    expect(raw.aliases).toEqual(["old-id"]);
+  });
+});
+
+describe("setProjectPathForDevice", () => {
+  test("seeds map from legacy singular cwd when the map is empty", () => {
+    const dir = seedProject("p", { cwd: "/old-cwd", name: "p" });
+    setProjectPathForDevice(dir, "dev-NEW", "/new-cwd");
+    const meta = getProjectMeta(dir);
+    // The legacy cwd was kept under a deterministic device id (the prior
+    // owner). The new device's entry was added too.
+    expect(meta!.pathsByDevice).toBeDefined();
+    expect(meta!.pathsByDevice!["dev-NEW"]).toBe("/new-cwd");
+  });
+
+  test("overwrites only the current device's entry", () => {
+    const dir = seedProject("p", {
+      cwd: "/p",
+      name: "p",
+      pathsByDevice: { "dev-A": "/a", "dev-B": "/b" },
+    });
+    setProjectPathForDevice(dir, "dev-A", "/new-a");
+    const meta = getProjectMeta(dir);
+    expect(meta!.pathsByDevice).toEqual({
+      "dev-A": "/new-a",
+      "dev-B": "/b",
+    });
+  });
+});
+
+describe("findProjectDirByIdOrAlias", () => {
+  test("returns the primary directory when the id matches a directory name", () => {
+    const dir = seedProject("primary", { cwd: "/p", name: "primary" });
+    expect(findProjectDirByIdOrAlias("primary")).toBe(dir);
+  });
+
+  test("walks alias lists when the id is not a directory name", () => {
+    const dir = seedProject("new-id", {
+      cwd: "/p",
+      name: "new-id",
+      aliases: ["old-id-A", "old-id-B"],
+    });
+    expect(findProjectDirByIdOrAlias("old-id-A")).toBe(dir);
+    expect(findProjectDirByIdOrAlias("old-id-B")).toBe(dir);
+    expect(findProjectDirByIdOrAlias("never-existed")).toBeNull();
+  });
+});
+
+describe("listRegisteredProjects", () => {
+  test("surfaces aliases and pathsByDevice on the registered project record", () => {
+    seedProject("p", {
+      cwd: "/p",
+      name: "p",
+      aliases: ["legacy"],
+      pathsByDevice: { d1: "/p1" },
+    });
+    const list = listRegisteredProjects();
+    const found = list.find((p) => p.id === "p");
+    expect(found).toBeDefined();
+    expect(found!.aliases).toEqual(["legacy"]);
+    expect(found!.pathsByDevice).toEqual({ d1: "/p1" });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `specs/20-stable-project-identity.md` and the implementation that fulfills it. Same-repo checkouts on different machines now unify into one logical project when the user opts in.

## What ships

**Spec** (`specs/20-stable-project-identity.md`, 349 lines)
- Three-tier resolver: explicit override → normalized git remote + repo-root subpath → existing path-derived fallback.
- Monorepo-aware: identity includes the repo-root-relative subpath so sibling services don't collide.
- Per-device `pathsByDevice` map replaces the singular `cwd` field; alias list preserves historical references.
- Eager v2→v3 migration on session-start, reusing the existing `MINK_SYNC_VERSION` mechanism (lock, idempotent, resumable).
- Cross-device convergence: two devices migrate independently and pick the same target identifier from the same git remote.
- Opt-in feature flag `projects.identity = path-derived | git-remote`; `path-derived` remains the default during rollout.

**Implementation** (~1.1k lines source + tests)

| Module | What it adds |
|---|---|
| `src/core/git-identity.ts` (new) | `getRepoRoot/Remote/Subpath`, `normalizeRemoteUrl`, `deriveGitIdentity`. Collapses SSH/HTTPS/credentialed/case-variant forms to one canonical string. |
| `src/core/project-id.ts` | `resolveProjectIdentity`, `readProjectOverride`, `validateProjectIdentifier`, `projectIdFor`. Legacy `generateProjectId` retained for fallback + migration. |
| `src/types/config.ts` | New `projects.identity` config key (default `path-derived`, env override `MINK_PROJECTS_IDENTITY`). |
| `src/core/project-registry.ts` | `ProjectMeta` extended with `aliases[]` and `pathsByDevice{}`. New `addProjectAlias`, `setProjectPathForDevice`, `findProjectDirByIdOrAlias`. Preserves unknown fields on write for downgrade safety. |
| `src/core/paths.ts` | `projectDir(cwd)` now uses the resolver and walks aliases on a cold miss. |
| `src/commands/sync-migrate.ts` | New `migrateProjectIdentities` step in `migrateSyncLayout`. Bumped `MINK_SYNC_VERSION` to 3. |
| `src/commands/session-start.ts` | Re-triggers migration when `projects.identity = git-remote` so a flag-flip after the version stamp still rekeys projects. |
| `src/core/dashboard-server.ts` | Routing tolerates aliased identifiers; project list includes aliases + pathsByDevice. |
| `src/commands/init.ts` | Prints identity source; surfaces a one-time hint when a git repo has no remote. |
| `src/commands/note.ts` | `source_project` uses the resolved identifier. |

## Tests

- **Unit** (`tests/unit/git-identity.test.ts`, `project-id.test.ts`, `project-registry.test.ts`): normalization across remote URL forms, identifier validation, resolver priority, override parsing, monorepo subpath disambiguation, alias idempotency, pathsByDevice upgrade-on-read.
- **Integration** (`tests/integration/sync-migrate.test.ts`): v2→v3 migration end-to-end (rename + alias + path map), idempotency, no-op when flag is off, skip-when-cwd-missing.

**Test results**: 1027 pass, 2 fail. Both failures are pre-existing environmental (dashboard frontend not pre-built locally; a real `mink` daemon running on the dev machine where the suite ran) and unrelated to this change.

## Rollout

Default is `path-derived` so existing users see no change. To opt in:

```sh
mink config projects.identity git-remote
# next session-start runs the v3 identity migration
```

## Out of scope (left for follow-ups)

- A `mink project alias <remote>` CLI for manual alias management (auto-aliasing during migration covers the common case).
- A user-facing `mink migrate-projects` command (eager session-start migration is sufficient).
- Default-flipping the feature flag to `git-remote` (separate release decision once opt-in proves out).

## Test plan

- [x] Spec passes manual review against issue #72's body — every concern has a capability, AC, or edge case
- [x] `bunx tsc --noEmit` clean
- [x] New unit tests pass (36 tests across git-identity / project-id / project-registry)
- [x] New integration tests pass (4 v3-migration scenarios)
- [x] Existing v1→v2 migration tests still pass after version bump
- [ ] Manual: `mink config projects.identity git-remote` then `mink session-start` against a real repo to confirm the migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)