### PR TITLE
fix(dashboard): allow `mink dashboard` from any directory

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -163,19 +163,598 @@ function isSessionState(value) {
 }
 var init_session = () => {};
 
+// src/core/git-identity.ts
+import { execSync } from "child_process";
+import { existsSync, realpathSync } from "fs";
+function gitOut(cwd, args) {
+  if (!existsSync(cwd))
+    return null;
+  try {
+    return execSync(`git ${args}`, {
+      cwd,
+      timeout: GIT_TIMEOUT_MS,
+      stdio: ["pipe", "pipe", "pipe"]
+    }).toString().trim();
+  } catch {
+    return null;
+  }
+}
+function canonicalCwd(cwd) {
+  try {
+    return realpathSync(cwd);
+  } catch {
+    return cwd;
+  }
+}
+function getRepoRoot(cwd) {
+  const root = gitOut(canonicalCwd(cwd), "rev-parse --show-toplevel");
+  return root && root.length > 0 ? root : null;
+}
+function getRepoSubpath(cwd) {
+  const prefix = gitOut(canonicalCwd(cwd), "rev-parse --show-prefix");
+  if (prefix === null)
+    return "";
+  return prefix.replace(/\\/g, "/").replace(/\/+$/, "").replace(/^\/+/, "");
+}
+function getRepoRemote(cwd) {
+  const c = canonicalCwd(cwd);
+  const origin = gitOut(c, "config --get remote.origin.url");
+  if (origin && origin.length > 0)
+    return origin;
+  const list = gitOut(c, "remote");
+  if (!list)
+    return null;
+  const remotes = list.split(`
+`).map((s) => s.trim()).filter((s) => s.length > 0).sort();
+  if (remotes.length === 0)
+    return null;
+  const url = gitOut(c, `config --get remote.${remotes[0]}.url`);
+  return url && url.length > 0 ? url : null;
+}
+function normalizeRemoteUrl(url) {
+  if (!url)
+    return "";
+  let s = url.trim();
+  if (s.length === 0)
+    return "";
+  if (/^(file:|\.\.?\/|\/)/i.test(s))
+    return "";
+  const scp = s.match(/^([^@\s]+)@([^:\s]+):(.+)$/);
+  if (scp) {
+    s = `ssh://${scp[1]}@${scp[2]}/${scp[3]}`;
+  }
+  s = s.replace(/^[a-z][a-z0-9+.-]*:\/\//i, "");
+  s = s.replace(/^[^@/]*@/, "");
+  s = s.replace(/\/+$/, "").replace(/\.git$/i, "");
+  return s.toLowerCase();
+}
+function deriveGitIdentity(cwd) {
+  const root = getRepoRoot(cwd);
+  if (!root)
+    return null;
+  const remoteRaw = getRepoRemote(cwd);
+  if (!remoteRaw)
+    return null;
+  const remote = normalizeRemoteUrl(remoteRaw);
+  if (!remote)
+    return null;
+  const subpath = getRepoSubpath(cwd);
+  return { remote, subpath };
+}
+var GIT_TIMEOUT_MS = 2000;
+var init_git_identity = () => {};
+
+// src/core/fs-utils.ts
+var exports_fs_utils = {};
+__export(exports_fs_utils, {
+  safeReadJson: () => safeReadJson,
+  safeAppendText: () => safeAppendText,
+  atomicWriteText: () => atomicWriteText,
+  atomicWriteJson: () => atomicWriteJson
+});
+import { writeFileSync, readFileSync, appendFileSync, renameSync, mkdirSync } from "fs";
+import { dirname } from "path";
+function atomicWriteJson(filePath, data) {
+  const tmp = filePath + ".tmp";
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(tmp, JSON.stringify(data, null, 2));
+  renameSync(tmp, filePath);
+}
+function atomicWriteText(filePath, content) {
+  const tmp = filePath + ".tmp";
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(tmp, content);
+  renameSync(tmp, filePath);
+}
+function safeAppendText(filePath, content) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  appendFileSync(filePath, content);
+}
+function safeReadJson(filePath) {
+  try {
+    const raw = readFileSync(filePath, "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+var init_fs_utils = () => {};
+
+// src/types/config.ts
+function isValidConfigKey(key) {
+  return VALID_KEYS.has(key);
+}
+function getConfigKeyMeta(key) {
+  return CONFIG_KEYS.find((k) => k.key === key);
+}
+var CONFIG_KEYS, VALID_KEYS;
+var init_config = __esm(() => {
+  CONFIG_KEYS = [
+    {
+      key: "wiki.path",
+      default: "~/.mink/wiki",
+      envVar: "MINK_WIKI_PATH",
+      description: "Wiki vault location",
+      scope: "local"
+    },
+    {
+      key: "wiki.enabled",
+      default: "true",
+      envVar: "MINK_WIKI_ENABLED",
+      description: "Enable/disable the wiki feature",
+      scope: "shared"
+    },
+    {
+      key: "wiki.sync-mode",
+      default: "immediate",
+      envVar: "MINK_WIKI_SYNC_MODE",
+      description: "Sync mode: immediate or batched",
+      scope: "shared"
+    },
+    {
+      key: "wiki.git-backup",
+      default: "false",
+      envVar: "MINK_WIKI_GIT_BACKUP",
+      description: "Deprecated: use sync.enabled instead",
+      scope: "shared"
+    },
+    {
+      key: "wiki.git-remote",
+      default: "origin",
+      envVar: "MINK_WIKI_GIT_REMOTE",
+      description: "Deprecated: use sync.remote-url instead",
+      scope: "shared"
+    },
+    {
+      key: "notes.default-category",
+      default: "inbox",
+      envVar: "MINK_NOTES_DEFAULT_CATEGORY",
+      description: "Default category for notes captured via CLI",
+      scope: "shared"
+    },
+    {
+      key: "sync.enabled",
+      default: "false",
+      envVar: "MINK_SYNC_ENABLED",
+      description: "Enable/disable automatic git sync of ~/.mink",
+      scope: "shared"
+    },
+    {
+      key: "sync.remote-url",
+      default: "",
+      envVar: "MINK_SYNC_REMOTE_URL",
+      description: "Git remote URL for ~/.mink sync",
+      scope: "shared"
+    },
+    {
+      key: "sync.last-push",
+      default: "",
+      envVar: "MINK_SYNC_LAST_PUSH",
+      description: "ISO timestamp of last successful sync push",
+      scope: "local"
+    },
+    {
+      key: "sync.last-pull",
+      default: "",
+      envVar: "MINK_SYNC_LAST_PULL",
+      description: "ISO timestamp of last successful sync pull",
+      scope: "local"
+    },
+    {
+      key: "channel.discord.bot-token",
+      default: "",
+      envVar: "MINK_CHANNEL_DISCORD_BOT_TOKEN",
+      description: "Discord bot token for Claude Code Channels",
+      scope: "local"
+    },
+    {
+      key: "channel.discord.enabled",
+      default: "false",
+      envVar: "MINK_CHANNEL_DISCORD_ENABLED",
+      description: "Auto-start Discord channel when daemon starts",
+      scope: "local"
+    },
+    {
+      key: "channel.discord.allowlist",
+      default: "",
+      envVar: "MINK_CHANNEL_DISCORD_ALLOWLIST",
+      description: "Comma-separated list of Discord user IDs permitted to DM the bot",
+      scope: "local"
+    },
+    {
+      key: "channel.default-platform",
+      default: "discord",
+      envVar: "MINK_CHANNEL_DEFAULT_PLATFORM",
+      description: "Default platform for mink channel start",
+      scope: "shared"
+    },
+    {
+      key: "channel.skip-permissions",
+      default: "true",
+      envVar: "MINK_CHANNEL_SKIP_PERMISSIONS",
+      description: "Pass --dangerously-skip-permissions so the channel can run without terminal prompts",
+      scope: "shared"
+    },
+    {
+      key: "cli.auto-update",
+      default: "false",
+      envVar: "MINK_CLI_AUTO_UPDATE",
+      description: "Auto-upgrade the mink CLI on schedule via the background scheduler",
+      scope: "shared"
+    },
+    {
+      key: "cli.auto-update-schedule",
+      default: "0 4 * * *",
+      envVar: "MINK_CLI_AUTO_UPDATE_SCHEDULE",
+      description: "Cron expression governing the cli-self-update scheduled task",
+      scope: "shared"
+    },
+    {
+      key: "cli.auto-update-package-manager",
+      default: "auto",
+      envVar: "MINK_CLI_AUTO_UPDATE_PACKAGE_MANAGER",
+      description: "Force a package manager (auto|npm|bun) for self-upgrade installs",
+      scope: "local"
+    },
+    {
+      key: "projects.identity",
+      default: "path-derived",
+      envVar: "MINK_PROJECTS_IDENTITY",
+      description: "Project identity strategy: path-derived (legacy) or git-remote (stable across machines)",
+      scope: "shared"
+    }
+  ];
+  VALID_KEYS = new Set(CONFIG_KEYS.map((k) => k.key));
+});
+
+// src/core/global-config.ts
+var exports_global_config = {};
+__export(exports_global_config, {
+  setConfigValue: () => setConfigValue,
+  saveLocalConfig: () => saveLocalConfig,
+  saveGlobalConfig: () => saveGlobalConfig,
+  resolveConfigValue: () => resolveConfigValue,
+  resolveAllConfig: () => resolveAllConfig,
+  resetConfigKey: () => resetConfigKey,
+  resetAllConfig: () => resetAllConfig,
+  migrateConfigIfNeeded: () => migrateConfigIfNeeded,
+  loadLocalConfig: () => loadLocalConfig,
+  loadGlobalConfig: () => loadGlobalConfig
+});
+function loadConfigFile(path) {
+  const raw = safeReadJson(path);
+  if (raw === null)
+    return {};
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    console.warn("[mink] warning: corrupt config file at " + path);
+    return {};
+  }
+  return raw;
+}
+function loadGlobalConfig() {
+  return loadConfigFile(globalConfigPath());
+}
+function saveGlobalConfig(config) {
+  atomicWriteJson(globalConfigPath(), config);
+}
+function loadLocalConfig() {
+  return loadConfigFile(localConfigPath());
+}
+function saveLocalConfig(config) {
+  atomicWriteJson(localConfigPath(), config);
+}
+function loadConfigForScope(scope) {
+  return scope === "local" ? loadLocalConfig() : loadGlobalConfig();
+}
+function saveConfigForScope(scope, config) {
+  if (scope === "local") {
+    saveLocalConfig(config);
+  } else {
+    saveGlobalConfig(config);
+  }
+}
+function resolveConfigValue(key) {
+  const meta = getConfigKeyMeta(key);
+  const config = loadConfigForScope(meta.scope);
+  const envValue = process.env[meta.envVar];
+  const fileValue = config[key];
+  if (envValue !== undefined && envValue !== "") {
+    return {
+      value: envValue,
+      source: "environment variable",
+      scope: meta.scope,
+      configFileValue: fileValue
+    };
+  }
+  if (fileValue !== undefined) {
+    return { value: fileValue, source: "config file", scope: meta.scope };
+  }
+  return { value: meta.default, source: "default", scope: meta.scope };
+}
+function resolveAllConfig() {
+  return CONFIG_KEYS.map((meta) => ({
+    key: meta.key,
+    ...resolveConfigValue(meta.key)
+  }));
+}
+function setConfigValue(key, value) {
+  const meta = getConfigKeyMeta(key);
+  const config = loadConfigForScope(meta.scope);
+  config[key] = value;
+  saveConfigForScope(meta.scope, config);
+}
+function resetConfigKey(key) {
+  const meta = getConfigKeyMeta(key);
+  const config = loadConfigForScope(meta.scope);
+  delete config[key];
+  saveConfigForScope(meta.scope, config);
+}
+function resetAllConfig() {
+  saveGlobalConfig({});
+  saveLocalConfig({});
+}
+function migrateConfigIfNeeded() {
+  if (migrationRan)
+    return;
+  migrationRan = true;
+  const { existsSync: existsSync2 } = __require("fs");
+  if (existsSync2(localConfigPath()))
+    return;
+  const shared = loadGlobalConfig();
+  const localKeys = CONFIG_KEYS.filter((k) => k.scope === "local");
+  const localConfig = {};
+  let hasLocal = false;
+  for (const meta of localKeys) {
+    const val = shared[meta.key];
+    if (val !== undefined) {
+      localConfig[meta.key] = val;
+      delete shared[meta.key];
+      hasLocal = true;
+    }
+  }
+  if (hasLocal) {
+    saveLocalConfig(localConfig);
+    saveGlobalConfig(shared);
+  }
+}
+var migrationRan = false;
+var init_global_config = __esm(() => {
+  init_paths();
+  init_fs_utils();
+  init_config();
+});
+
 // src/core/project-id.ts
 import { createHash } from "crypto";
-import { basename } from "path";
+import { basename, join } from "path";
+import { existsSync as existsSync2, readFileSync as readFileSync2 } from "fs";
 function slugify(name) {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+function shortHash(input) {
+  return createHash("sha256").update(input).digest("hex").slice(0, 6);
 }
 function generateProjectId(absolutePath) {
   const normalized = absolutePath.replace(/\/+$/, "");
   const slug = slugify(basename(normalized));
-  const hash = createHash("sha256").update(normalized).digest("hex").slice(0, 6);
+  const hash = shortHash(normalized);
   return `${slug}-${hash}`;
 }
-var init_project_id = () => {};
+function validateProjectIdentifier(id) {
+  return typeof id === "string" && IDENTIFIER_PATTERN.test(id);
+}
+function readProjectOverride(cwd) {
+  const root = getRepoRoot(cwd) ?? cwd;
+  const overridePath = join(root, OVERRIDE_RELATIVE_PATH);
+  if (!existsSync2(overridePath))
+    return null;
+  let raw;
+  try {
+    raw = readFileSync2(overridePath, "utf-8");
+  } catch {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    warnInvalidOverride(overridePath, "file is not valid JSON");
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    warnInvalidOverride(overridePath, "expected a JSON object");
+    return null;
+  }
+  const id = parsed.projectId;
+  if (id === undefined)
+    return null;
+  if (!validateProjectIdentifier(id)) {
+    warnInvalidOverride(overridePath, "projectId must start with a letter or digit, contain only [a-z0-9._-], and be 1–128 characters");
+    return null;
+  }
+  return id;
+}
+function warnInvalidOverride(path, reason) {
+  if (warnedOverrides.has(path))
+    return;
+  warnedOverrides.add(path);
+  console.warn(`[mink] ignoring ${path}: ${reason}`);
+}
+function gitDerivedIdentity(cwd) {
+  const components = deriveGitIdentity(cwd);
+  if (!components)
+    return null;
+  const remoteLeaf = components.remote.split("/").filter((p) => p).pop();
+  const slugSource = components.subpath ? components.subpath.split("/").pop() : remoteLeaf ?? "project";
+  const slug = slugify(slugSource);
+  const hash = shortHash(`git:${components.remote}:${components.subpath}`);
+  return `${slug}-${hash}`;
+}
+function readIdentityMode() {
+  const envOverride = process.env.MINK_PROJECTS_IDENTITY;
+  if (envOverride === "git-remote" || envOverride === "path-derived") {
+    return envOverride;
+  }
+  try {
+    const { resolveConfigValue: resolveConfigValue2 } = (init_global_config(), __toCommonJS(exports_global_config));
+    const v = resolveConfigValue2("projects.identity").value;
+    if (v === "git-remote")
+      return "git-remote";
+  } catch {}
+  return "path-derived";
+}
+function resolveProjectIdentity(cwd, modeOverride) {
+  const mode = modeOverride ?? readIdentityMode();
+  if (mode === "path-derived") {
+    return { id: generateProjectId(cwd), source: "path-derived" };
+  }
+  const override = readProjectOverride(cwd);
+  if (override)
+    return { id: override, source: "override" };
+  const git = gitDerivedIdentity(cwd);
+  if (git)
+    return { id: git, source: "git-remote" };
+  return { id: generateProjectId(cwd), source: "path-derived" };
+}
+function projectIdFor(cwd) {
+  return resolveProjectIdentity(cwd).id;
+}
+var IDENTIFIER_PATTERN, OVERRIDE_RELATIVE_PATH = ".mink/project.json", warnedOverrides;
+var init_project_id = __esm(() => {
+  init_git_identity();
+  IDENTIFIER_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+  warnedOverrides = new Set;
+});
+
+// src/core/project-registry.ts
+var exports_project_registry = {};
+__export(exports_project_registry, {
+  setProjectPathForDevice: () => setProjectPathForDevice,
+  listRegisteredProjects: () => listRegisteredProjects,
+  getProjectMeta: () => getProjectMeta,
+  findProjectDirByIdOrAlias: () => findProjectDirByIdOrAlias,
+  addProjectAlias: () => addProjectAlias
+});
+import { readdirSync, existsSync as existsSync3 } from "fs";
+import { join as join2 } from "path";
+function projectMetaFilePath(projDir) {
+  return join2(projDir, "project-meta.json");
+}
+function getProjectMeta(projDir) {
+  const raw = safeReadJson(projectMetaFilePath(projDir));
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw))
+    return null;
+  const obj = raw;
+  if (typeof obj.cwd !== "string" || typeof obj.name !== "string")
+    return null;
+  const aliases = Array.isArray(obj.aliases) ? obj.aliases.filter((s) => typeof s === "string") : undefined;
+  const pathsByDevice = obj.pathsByDevice && typeof obj.pathsByDevice === "object" && !Array.isArray(obj.pathsByDevice) ? Object.fromEntries(Object.entries(obj.pathsByDevice).filter(([, v]) => typeof v === "string")) : undefined;
+  return {
+    cwd: obj.cwd,
+    name: obj.name,
+    initTimestamp: obj.initTimestamp ?? "",
+    version: obj.version ?? "0.1.0",
+    aliases,
+    pathsByDevice
+  };
+}
+function addProjectAlias(projDir, aliasId) {
+  const path = projectMetaFilePath(projDir);
+  const raw = safeReadJson(path);
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw))
+    return false;
+  const obj = raw;
+  const existing = Array.isArray(obj.aliases) ? obj.aliases.filter((s) => typeof s === "string") : [];
+  if (existing.includes(aliasId))
+    return false;
+  obj.aliases = [...existing, aliasId];
+  atomicWriteJson(path, obj);
+  return true;
+}
+function setProjectPathForDevice(projDir, deviceId, cwd) {
+  const path = projectMetaFilePath(projDir);
+  const raw = safeReadJson(path);
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw))
+    return;
+  const obj = raw;
+  const existing = obj.pathsByDevice && typeof obj.pathsByDevice === "object" && !Array.isArray(obj.pathsByDevice) ? { ...obj.pathsByDevice } : {};
+  if (Object.keys(existing).length === 0 && typeof obj.cwd === "string" && obj.cwd !== cwd) {
+    existing[deviceId] = obj.cwd;
+  }
+  existing[deviceId] = cwd;
+  obj.pathsByDevice = existing;
+  obj.cwd = cwd;
+  atomicWriteJson(path, obj);
+}
+function listRegisteredProjects() {
+  const projectsDir = join2(minkRoot(), "projects");
+  if (!existsSync3(projectsDir))
+    return [];
+  const entries = readdirSync(projectsDir, { withFileTypes: true });
+  const projects = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory())
+      continue;
+    const projDir = join2(projectsDir, entry.name);
+    const meta = getProjectMeta(projDir);
+    if (meta) {
+      projects.push({
+        id: entry.name,
+        cwd: meta.cwd,
+        name: meta.name,
+        version: meta.version,
+        aliases: meta.aliases ?? [],
+        pathsByDevice: meta.pathsByDevice ?? {}
+      });
+    }
+  }
+  return projects;
+}
+function findProjectDirByIdOrAlias(id) {
+  const projectsDir = join2(minkRoot(), "projects");
+  if (!existsSync3(projectsDir))
+    return null;
+  const primary = join2(projectsDir, id);
+  if (existsSync3(primary))
+    return primary;
+  let entries;
+  try {
+    entries = readdirSync(projectsDir);
+  } catch {
+    return null;
+  }
+  for (const name of entries) {
+    const projDir = join2(projectsDir, name);
+    const meta = getProjectMeta(projDir);
+    if (meta?.aliases?.includes(id))
+      return projDir;
+  }
+  return null;
+}
+var init_project_registry = __esm(() => {
+  init_paths();
+  init_fs_utils();
+});
 
 // src/core/paths.ts
 var exports_paths = {};
@@ -215,10 +794,11 @@ __export(exports_paths, {
   actionLogShardPath: () => actionLogShardPath,
   actionLogPath: () => actionLogPath
 });
-import { join } from "path";
+import { join as join3 } from "path";
+import { existsSync as existsSync4 } from "fs";
 import { homedir } from "os";
 function resolveMinkRoot() {
-  return process.env.MINK_ROOT_OVERRIDE || join(homedir(), ".mink");
+  return process.env.MINK_ROOT_OVERRIDE || join3(homedir(), ".mink");
 }
 function minkRoot() {
   if (process.env.MINK_ROOT_OVERRIDE) {
@@ -227,146 +807,119 @@ function minkRoot() {
   return MINK_ROOT;
 }
 function projectDir(cwd) {
-  const id = generateProjectId(cwd);
-  return join(minkRoot(), "projects", id);
+  const id = projectIdFor(cwd);
+  const primary = join3(minkRoot(), "projects", id);
+  if (existsSync4(primary))
+    return primary;
+  try {
+    const { findProjectDirByIdOrAlias: findProjectDirByIdOrAlias2 } = (init_project_registry(), __toCommonJS(exports_project_registry));
+    const aliased = findProjectDirByIdOrAlias2(id);
+    if (aliased)
+      return aliased;
+  } catch {}
+  return primary;
 }
 function sessionPath(cwd) {
-  return join(projectDir(cwd), "session.json");
+  return join3(projectDir(cwd), "session.json");
 }
 function fileIndexPath(cwd) {
-  return join(projectDir(cwd), "file-index.json");
+  return join3(projectDir(cwd), "file-index.json");
 }
 function configPath(cwd) {
-  return join(projectDir(cwd), "config.json");
+  return join3(projectDir(cwd), "config.json");
 }
 function learningMemoryPath(cwd) {
-  return join(projectDir(cwd), "learning-memory.md");
+  return join3(projectDir(cwd), "learning-memory.md");
 }
 function tokenLedgerPath(cwd) {
-  return join(projectDir(cwd), "token-ledger.json");
+  return join3(projectDir(cwd), "token-ledger.json");
 }
 function tokenLedgerArchivePath(cwd) {
-  return join(projectDir(cwd), "token-ledger-archive.json");
+  return join3(projectDir(cwd), "token-ledger-archive.json");
 }
 function bugMemoryPath(cwd) {
-  return join(projectDir(cwd), "bug-memory.json");
+  return join3(projectDir(cwd), "bug-memory.json");
 }
 function actionLogPath(cwd) {
-  return join(projectDir(cwd), "action-log.md");
+  return join3(projectDir(cwd), "action-log.md");
 }
 function schedulerPidPath() {
-  return join(minkRoot(), "scheduler.pid");
+  return join3(minkRoot(), "scheduler.pid");
 }
 function schedulerLogPath() {
-  return join(minkRoot(), "scheduler.log");
+  return join3(minkRoot(), "scheduler.log");
 }
 function schedulerManifestPath(cwd) {
-  return join(projectDir(cwd), "scheduler-manifest.json");
+  return join3(projectDir(cwd), "scheduler-manifest.json");
 }
 function channelPidPath() {
-  return join(minkRoot(), "channel.pid");
+  return join3(minkRoot(), "channel.pid");
 }
 function channelLogPath() {
-  return join(minkRoot(), "channel.log");
+  return join3(minkRoot(), "channel.log");
 }
 function globalConfigPath() {
-  return join(minkRoot(), "config");
+  return join3(minkRoot(), "config");
 }
 function localConfigPath() {
-  return join(minkRoot(), "config.local");
+  return join3(minkRoot(), "config.local");
 }
 function deviceIdPath() {
-  return join(minkRoot(), "device-id");
+  return join3(minkRoot(), "device-id");
 }
 function deviceRegistryPath() {
-  return join(minkRoot(), "devices.json");
+  return join3(minkRoot(), "devices.json");
 }
 function projectMetaPath(cwd) {
-  return join(projectDir(cwd), "project-meta.json");
+  return join3(projectDir(cwd), "project-meta.json");
 }
 function backupDirPath(cwd) {
-  return join(projectDir(cwd), "backups");
+  return join3(projectDir(cwd), "backups");
 }
 function syncVersionPath() {
-  return join(minkRoot(), ".mink-sync-version");
+  return join3(minkRoot(), ".mink-sync-version");
 }
 function projectStateDir(cwd) {
-  return join(projectDir(cwd), "state");
+  return join3(projectDir(cwd), "state");
 }
 function deviceShardDir(cwd, deviceId) {
-  return join(projectStateDir(cwd), deviceId);
+  return join3(projectStateDir(cwd), deviceId);
 }
 function tokenLedgerShardPath(cwd, deviceId) {
-  return join(deviceShardDir(cwd, deviceId), "token-ledger.json");
+  return join3(deviceShardDir(cwd, deviceId), "token-ledger.json");
 }
 function tokenLedgerArchiveShardPath(cwd, deviceId) {
-  return join(deviceShardDir(cwd, deviceId), "token-ledger-archive.json");
+  return join3(deviceShardDir(cwd, deviceId), "token-ledger-archive.json");
 }
 function bugMemoryShardPath(cwd, deviceId) {
-  return join(deviceShardDir(cwd, deviceId), "bug-memory.json");
+  return join3(deviceShardDir(cwd, deviceId), "bug-memory.json");
 }
 function actionLogShardPath(cwd, deviceId) {
-  return join(deviceShardDir(cwd, deviceId), "action-log.md");
+  return join3(deviceShardDir(cwd, deviceId), "action-log.md");
 }
 function learningMemorySidecarPath(cwd, deviceId) {
-  return join(projectDir(cwd), `learning-memory.${deviceId}.md`);
+  return join3(projectDir(cwd), `learning-memory.${deviceId}.md`);
 }
 function fileIndexCountersPath(cwd) {
-  return join(projectDir(cwd), ".mink-state-counters.json");
+  return join3(projectDir(cwd), ".mink-state-counters.json");
 }
 function designCapturesDir(cwd) {
-  return join(projectDir(cwd), "design-captures");
+  return join3(projectDir(cwd), "design-captures");
 }
 function designReportPath(cwd) {
-  return join(projectDir(cwd), "design-report.json");
+  return join3(projectDir(cwd), "design-report.json");
 }
 function frameworkAdvisorPath(cwd) {
-  return join(projectDir(cwd), "framework-advisor.md");
+  return join3(projectDir(cwd), "framework-advisor.md");
 }
 function frameworkAdvisorJsonPath(cwd) {
-  return join(projectDir(cwd), "framework-advisor.json");
+  return join3(projectDir(cwd), "framework-advisor.json");
 }
 var MINK_ROOT;
 var init_paths = __esm(() => {
   init_project_id();
   MINK_ROOT = resolveMinkRoot();
 });
-
-// src/core/fs-utils.ts
-var exports_fs_utils = {};
-__export(exports_fs_utils, {
-  safeReadJson: () => safeReadJson,
-  safeAppendText: () => safeAppendText,
-  atomicWriteText: () => atomicWriteText,
-  atomicWriteJson: () => atomicWriteJson
-});
-import { writeFileSync, readFileSync, appendFileSync, renameSync, mkdirSync } from "fs";
-import { dirname } from "path";
-function atomicWriteJson(filePath, data) {
-  const tmp = filePath + ".tmp";
-  mkdirSync(dirname(filePath), { recursive: true });
-  writeFileSync(tmp, JSON.stringify(data, null, 2));
-  renameSync(tmp, filePath);
-}
-function atomicWriteText(filePath, content) {
-  const tmp = filePath + ".tmp";
-  mkdirSync(dirname(filePath), { recursive: true });
-  writeFileSync(tmp, content);
-  renameSync(tmp, filePath);
-}
-function safeAppendText(filePath, content) {
-  mkdirSync(dirname(filePath), { recursive: true });
-  appendFileSync(filePath, content);
-}
-function safeReadJson(filePath) {
-  try {
-    const raw = readFileSync(filePath, "utf-8");
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
-}
-var init_fs_utils = () => {};
 
 // src/core/action-log.ts
 var exports_action_log = {};
@@ -386,7 +939,7 @@ __export(exports_action_log, {
   consolidateLog: () => consolidateLog,
   appendToLog: () => appendToLog
 });
-import { readFileSync as readFileSync2 } from "fs";
+import { readFileSync as readFileSync3 } from "fs";
 function truncatePath(filePath, maxLen = 60) {
   if (filePath.length <= maxLen)
     return filePath;
@@ -473,7 +1026,7 @@ function appendToLog(logPath, text) {
 }
 function safeReadLog(logPath) {
   try {
-    return readFileSync2(logPath, "utf-8");
+    return readFileSync3(logPath, "utf-8");
   } catch {
     return "";
   }
@@ -618,14 +1171,14 @@ __export(exports_device, {
   listDevices: () => listDevices,
   getOrCreateDeviceId: () => getOrCreateDeviceId
 });
-import { existsSync, readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2 } from "fs";
+import { existsSync as existsSync5, readFileSync as readFileSync4, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2 } from "fs";
 import { dirname as dirname2 } from "path";
 import { hostname, platform } from "os";
 import { randomUUID } from "crypto";
 function getOrCreateDeviceId() {
   const idPath = deviceIdPath();
-  if (existsSync(idPath)) {
-    return readFileSync3(idPath, "utf-8").trim();
+  if (existsSync5(idPath)) {
+    return readFileSync4(idPath, "utf-8").trim();
   }
   const id = randomUUID();
   mkdirSync2(dirname2(idPath), { recursive: true });
@@ -683,263 +1236,6 @@ var init_device = __esm(() => {
   init_fs_utils();
 });
 
-// src/types/config.ts
-function isValidConfigKey(key) {
-  return VALID_KEYS.has(key);
-}
-function getConfigKeyMeta(key) {
-  return CONFIG_KEYS.find((k) => k.key === key);
-}
-var CONFIG_KEYS, VALID_KEYS;
-var init_config = __esm(() => {
-  CONFIG_KEYS = [
-    {
-      key: "wiki.path",
-      default: "~/.mink/wiki",
-      envVar: "MINK_WIKI_PATH",
-      description: "Wiki vault location",
-      scope: "local"
-    },
-    {
-      key: "wiki.enabled",
-      default: "true",
-      envVar: "MINK_WIKI_ENABLED",
-      description: "Enable/disable the wiki feature",
-      scope: "shared"
-    },
-    {
-      key: "wiki.sync-mode",
-      default: "immediate",
-      envVar: "MINK_WIKI_SYNC_MODE",
-      description: "Sync mode: immediate or batched",
-      scope: "shared"
-    },
-    {
-      key: "wiki.git-backup",
-      default: "false",
-      envVar: "MINK_WIKI_GIT_BACKUP",
-      description: "Deprecated: use sync.enabled instead",
-      scope: "shared"
-    },
-    {
-      key: "wiki.git-remote",
-      default: "origin",
-      envVar: "MINK_WIKI_GIT_REMOTE",
-      description: "Deprecated: use sync.remote-url instead",
-      scope: "shared"
-    },
-    {
-      key: "notes.default-category",
-      default: "inbox",
-      envVar: "MINK_NOTES_DEFAULT_CATEGORY",
-      description: "Default category for notes captured via CLI",
-      scope: "shared"
-    },
-    {
-      key: "sync.enabled",
-      default: "false",
-      envVar: "MINK_SYNC_ENABLED",
-      description: "Enable/disable automatic git sync of ~/.mink",
-      scope: "shared"
-    },
-    {
-      key: "sync.remote-url",
-      default: "",
-      envVar: "MINK_SYNC_REMOTE_URL",
-      description: "Git remote URL for ~/.mink sync",
-      scope: "shared"
-    },
-    {
-      key: "sync.last-push",
-      default: "",
-      envVar: "MINK_SYNC_LAST_PUSH",
-      description: "ISO timestamp of last successful sync push",
-      scope: "local"
-    },
-    {
-      key: "sync.last-pull",
-      default: "",
-      envVar: "MINK_SYNC_LAST_PULL",
-      description: "ISO timestamp of last successful sync pull",
-      scope: "local"
-    },
-    {
-      key: "channel.discord.bot-token",
-      default: "",
-      envVar: "MINK_CHANNEL_DISCORD_BOT_TOKEN",
-      description: "Discord bot token for Claude Code Channels",
-      scope: "local"
-    },
-    {
-      key: "channel.discord.enabled",
-      default: "false",
-      envVar: "MINK_CHANNEL_DISCORD_ENABLED",
-      description: "Auto-start Discord channel when daemon starts",
-      scope: "local"
-    },
-    {
-      key: "channel.discord.allowlist",
-      default: "",
-      envVar: "MINK_CHANNEL_DISCORD_ALLOWLIST",
-      description: "Comma-separated list of Discord user IDs permitted to DM the bot",
-      scope: "local"
-    },
-    {
-      key: "channel.default-platform",
-      default: "discord",
-      envVar: "MINK_CHANNEL_DEFAULT_PLATFORM",
-      description: "Default platform for mink channel start",
-      scope: "shared"
-    },
-    {
-      key: "channel.skip-permissions",
-      default: "true",
-      envVar: "MINK_CHANNEL_SKIP_PERMISSIONS",
-      description: "Pass --dangerously-skip-permissions so the channel can run without terminal prompts",
-      scope: "shared"
-    },
-    {
-      key: "cli.auto-update",
-      default: "false",
-      envVar: "MINK_CLI_AUTO_UPDATE",
-      description: "Auto-upgrade the mink CLI on schedule via the background scheduler",
-      scope: "shared"
-    },
-    {
-      key: "cli.auto-update-schedule",
-      default: "0 4 * * *",
-      envVar: "MINK_CLI_AUTO_UPDATE_SCHEDULE",
-      description: "Cron expression governing the cli-self-update scheduled task",
-      scope: "shared"
-    },
-    {
-      key: "cli.auto-update-package-manager",
-      default: "auto",
-      envVar: "MINK_CLI_AUTO_UPDATE_PACKAGE_MANAGER",
-      description: "Force a package manager (auto|npm|bun) for self-upgrade installs",
-      scope: "local"
-    }
-  ];
-  VALID_KEYS = new Set(CONFIG_KEYS.map((k) => k.key));
-});
-
-// src/core/global-config.ts
-var exports_global_config = {};
-__export(exports_global_config, {
-  setConfigValue: () => setConfigValue,
-  saveLocalConfig: () => saveLocalConfig,
-  saveGlobalConfig: () => saveGlobalConfig,
-  resolveConfigValue: () => resolveConfigValue,
-  resolveAllConfig: () => resolveAllConfig,
-  resetConfigKey: () => resetConfigKey,
-  resetAllConfig: () => resetAllConfig,
-  migrateConfigIfNeeded: () => migrateConfigIfNeeded,
-  loadLocalConfig: () => loadLocalConfig,
-  loadGlobalConfig: () => loadGlobalConfig
-});
-function loadConfigFile(path) {
-  const raw = safeReadJson(path);
-  if (raw === null)
-    return {};
-  if (typeof raw !== "object" || Array.isArray(raw)) {
-    console.warn("[mink] warning: corrupt config file at " + path);
-    return {};
-  }
-  return raw;
-}
-function loadGlobalConfig() {
-  return loadConfigFile(globalConfigPath());
-}
-function saveGlobalConfig(config) {
-  atomicWriteJson(globalConfigPath(), config);
-}
-function loadLocalConfig() {
-  return loadConfigFile(localConfigPath());
-}
-function saveLocalConfig(config) {
-  atomicWriteJson(localConfigPath(), config);
-}
-function loadConfigForScope(scope) {
-  return scope === "local" ? loadLocalConfig() : loadGlobalConfig();
-}
-function saveConfigForScope(scope, config) {
-  if (scope === "local") {
-    saveLocalConfig(config);
-  } else {
-    saveGlobalConfig(config);
-  }
-}
-function resolveConfigValue(key) {
-  const meta = getConfigKeyMeta(key);
-  const config = loadConfigForScope(meta.scope);
-  const envValue = process.env[meta.envVar];
-  const fileValue = config[key];
-  if (envValue !== undefined && envValue !== "") {
-    return {
-      value: envValue,
-      source: "environment variable",
-      scope: meta.scope,
-      configFileValue: fileValue
-    };
-  }
-  if (fileValue !== undefined) {
-    return { value: fileValue, source: "config file", scope: meta.scope };
-  }
-  return { value: meta.default, source: "default", scope: meta.scope };
-}
-function resolveAllConfig() {
-  return CONFIG_KEYS.map((meta) => ({
-    key: meta.key,
-    ...resolveConfigValue(meta.key)
-  }));
-}
-function setConfigValue(key, value) {
-  const meta = getConfigKeyMeta(key);
-  const config = loadConfigForScope(meta.scope);
-  config[key] = value;
-  saveConfigForScope(meta.scope, config);
-}
-function resetConfigKey(key) {
-  const meta = getConfigKeyMeta(key);
-  const config = loadConfigForScope(meta.scope);
-  delete config[key];
-  saveConfigForScope(meta.scope, config);
-}
-function resetAllConfig() {
-  saveGlobalConfig({});
-  saveLocalConfig({});
-}
-function migrateConfigIfNeeded() {
-  if (migrationRan)
-    return;
-  migrationRan = true;
-  const { existsSync: existsSync2 } = __require("fs");
-  if (existsSync2(localConfigPath()))
-    return;
-  const shared = loadGlobalConfig();
-  const localKeys = CONFIG_KEYS.filter((k) => k.scope === "local");
-  const localConfig = {};
-  let hasLocal = false;
-  for (const meta of localKeys) {
-    const val = shared[meta.key];
-    if (val !== undefined) {
-      localConfig[meta.key] = val;
-      delete shared[meta.key];
-      hasLocal = true;
-    }
-  }
-  if (hasLocal) {
-    saveLocalConfig(localConfig);
-    saveGlobalConfig(shared);
-  }
-}
-var migrationRan = false;
-var init_global_config = __esm(() => {
-  init_paths();
-  init_fs_utils();
-  init_config();
-});
-
 // src/core/vault.ts
 var exports_vault = {};
 __export(exports_vault, {
@@ -966,54 +1262,54 @@ __export(exports_vault, {
   ensureVaultStructure: () => ensureVaultStructure,
   categoryToDir: () => categoryToDir
 });
-import { join as join2, basename as basename2, resolve } from "path";
+import { join as join4, basename as basename2, resolve } from "path";
 import { homedir as homedir2 } from "os";
-import { existsSync as existsSync2, mkdirSync as mkdirSync3, symlinkSync, unlinkSync, lstatSync, readlinkSync } from "fs";
+import { existsSync as existsSync6, mkdirSync as mkdirSync3, symlinkSync, unlinkSync, lstatSync, readlinkSync } from "fs";
 function resolveVaultPath() {
   const resolved = resolveConfigValue("wiki.path");
   const raw = resolved.value;
-  const expanded = raw.startsWith("~/") ? join2(homedir2(), raw.slice(2)) : raw;
+  const expanded = raw.startsWith("~/") ? join4(homedir2(), raw.slice(2)) : raw;
   return resolve(expanded);
 }
 function vaultRoot() {
   return resolveVaultPath();
 }
 function vaultInbox() {
-  return join2(resolveVaultPath(), "inbox");
+  return join4(resolveVaultPath(), "inbox");
 }
 function vaultProjects(slug) {
-  const base = join2(resolveVaultPath(), "projects");
-  return slug ? join2(base, slug) : base;
+  const base = join4(resolveVaultPath(), "projects");
+  return slug ? join4(base, slug) : base;
 }
 function vaultAreas() {
-  return join2(resolveVaultPath(), "areas");
+  return join4(resolveVaultPath(), "areas");
 }
 function vaultDailyDir() {
-  return join2(resolveVaultPath(), "areas", "daily");
+  return join4(resolveVaultPath(), "areas", "daily");
 }
 function vaultResources() {
-  return join2(resolveVaultPath(), "resources");
+  return join4(resolveVaultPath(), "resources");
 }
 function vaultArchives() {
-  return join2(resolveVaultPath(), "archives");
+  return join4(resolveVaultPath(), "archives");
 }
 function vaultTemplates() {
-  return join2(resolveVaultPath(), "templates");
+  return join4(resolveVaultPath(), "templates");
 }
 function vaultPatterns() {
-  return join2(resolveVaultPath(), "patterns");
+  return join4(resolveVaultPath(), "patterns");
 }
 function vaultManifestPath() {
-  return join2(resolveVaultPath(), ".mink-vault.json");
+  return join4(resolveVaultPath(), ".mink-vault.json");
 }
 function vaultIndexPath() {
-  return join2(resolveVaultPath(), ".mink-index.json");
+  return join4(resolveVaultPath(), ".mink-index.json");
 }
 function vaultMasterIndexPath() {
-  return join2(resolveVaultPath(), "_index.md");
+  return join4(resolveVaultPath(), "_index.md");
 }
 function isVaultInitialized() {
-  return existsSync2(vaultManifestPath());
+  return existsSync6(vaultManifestPath());
 }
 function isInsideVault(cwd) {
   const vault = resolveVaultPath();
@@ -1034,23 +1330,23 @@ function loadVaultManifest() {
 function ensureVaultStructure() {
   const root = resolveVaultPath();
   for (const dir of VAULT_DIRS) {
-    mkdirSync3(join2(root, dir), { recursive: true });
+    mkdirSync3(join4(root, dir), { recursive: true });
   }
 }
 function categoryToDir(category, projectSlug) {
   const root = resolveVaultPath();
   switch (category) {
     case "projects":
-      return projectSlug ? join2(root, "projects", projectSlug) : join2(root, "projects");
+      return projectSlug ? join4(root, "projects", projectSlug) : join4(root, "projects");
     case "areas":
-      return join2(root, "areas");
+      return join4(root, "areas");
     case "resources":
-      return join2(root, "resources");
+      return join4(root, "resources");
     case "archives":
-      return join2(root, "archives");
+      return join4(root, "archives");
     case "inbox":
     default:
-      return join2(root, "inbox");
+      return join4(root, "inbox");
   }
 }
 function saveManifest(manifest) {
@@ -1058,16 +1354,16 @@ function saveManifest(manifest) {
 }
 function linkExternal(targetPath, name) {
   const root = resolveVaultPath();
-  const absTarget = targetPath.startsWith("~/") ? join2(homedir2(), targetPath.slice(2)) : resolve(targetPath);
-  if (!existsSync2(absTarget)) {
+  const absTarget = targetPath.startsWith("~/") ? join4(homedir2(), targetPath.slice(2)) : resolve(targetPath);
+  if (!existsSync6(absTarget)) {
     return { ok: false, error: `target does not exist: ${absTarget}` };
   }
   if (!lstatSync(absTarget).isDirectory()) {
     return { ok: false, error: `target is not a directory: ${absTarget}` };
   }
   const linkName = name ?? basename2(absTarget);
-  const linkPath = join2(root, linkName);
-  if (existsSync2(linkPath)) {
+  const linkPath = join4(root, linkName);
+  if (existsSync6(linkPath)) {
     if (lstatSync(linkPath).isSymbolicLink()) {
       const existing = readlinkSync(linkPath);
       if (existing === absTarget) {
@@ -1089,8 +1385,8 @@ function linkExternal(targetPath, name) {
 }
 function unlinkExternal(name) {
   const root = resolveVaultPath();
-  const linkPath = join2(root, name);
-  if (!existsSync2(linkPath)) {
+  const linkPath = join4(root, name);
+  if (!existsSync6(linkPath)) {
     return { ok: false, error: `no link named "${name}" in the vault` };
   }
   if (!lstatSync(linkPath).isSymbolicLink()) {
@@ -1113,7 +1409,7 @@ var init_vault = __esm(() => {
   init_global_config();
   init_fs_utils();
   init_fs_utils();
-  DEFAULT_VAULT_PATH = join2(homedir2(), ".mink", "wiki");
+  DEFAULT_VAULT_PATH = join4(homedir2(), ".mink", "wiki");
   VAULT_DIRS = [
     "",
     "inbox",
@@ -1128,8 +1424,8 @@ var init_vault = __esm(() => {
 });
 
 // src/core/note-index.ts
-import { join as join3 } from "path";
-import { readFileSync as readFileSync4, readdirSync, statSync } from "fs";
+import { join as join5 } from "path";
+import { readFileSync as readFileSync5, readdirSync as readdirSync2, statSync } from "fs";
 function createEmptyVaultIndex() {
   return {
     lastScanTimestamp: "",
@@ -1262,7 +1558,7 @@ function rebuildVaultIndex() {
   const files = collectAllMarkdown(root);
   for (const file of files) {
     try {
-      const content = readFileSync4(file.absolutePath, "utf-8");
+      const content = readFileSync5(file.absolutePath, "utf-8");
       const entry = buildEntryFromContent(file.relativePath, content, new Date(file.mtimeMs).toISOString());
       updateVaultEntry(index, entry);
     } catch {}
@@ -1320,13 +1616,13 @@ function collectAllMarkdown(rootPath) {
   const files = [];
   function walk(dir) {
     try {
-      const entries = readdirSync(dir, { withFileTypes: true });
+      const entries = readdirSync2(dir, { withFileTypes: true });
       for (const entry of entries) {
         if (VAULT_EXCLUDES.has(entry.name))
           continue;
         if (entry.name.startsWith("."))
           continue;
-        const fullPath = join3(dir, entry.name);
+        const fullPath = join5(dir, entry.name);
         if (entry.isDirectory()) {
           walk(fullPath);
         } else if (entry.name.endsWith(".md")) {
@@ -1357,11 +1653,11 @@ var init_note_index = __esm(() => {
 });
 
 // src/core/conflict-park.ts
-import { execSync } from "child_process";
-import { existsSync as existsSync4 } from "fs";
-import { join as join4 } from "path";
+import { execSync as execSync2 } from "child_process";
+import { existsSync as existsSync8 } from "fs";
+import { join as join6 } from "path";
 function git(args) {
-  return execSync(`git ${args}`, {
+  return execSync2(`git ${args}`, {
     cwd: minkRoot(),
     timeout: GIT_TIMEOUT,
     stdio: ["pipe", "pipe", "pipe"]
@@ -1376,7 +1672,7 @@ function gitSafe(args) {
 }
 function parkConflictingState(reason) {
   const root = minkRoot();
-  const inMerge = existsSync4(join4(root, ".git", "MERGE_HEAD")) || existsSync4(join4(root, ".git", "rebase-merge")) || existsSync4(join4(root, ".git", "rebase-apply"));
+  const inMerge = existsSync8(join6(root, ".git", "MERGE_HEAD")) || existsSync8(join6(root, ".git", "rebase-merge")) || existsSync8(join6(root, ".git", "rebase-apply"));
   if (inMerge) {
     gitSafe("merge --abort");
     gitSafe("rebase --abort");
@@ -1433,12 +1729,12 @@ __export(exports_sync, {
   disconnectSync: () => disconnectSync,
   MINK_SYNC_VERSION: () => MINK_SYNC_VERSION
 });
-import { existsSync as existsSync5, writeFileSync as writeFileSync3, readFileSync as readFileSync5 } from "fs";
-import { join as join5 } from "path";
-import { execSync as execSync2 } from "child_process";
+import { existsSync as existsSync9, writeFileSync as writeFileSync3, readFileSync as readFileSync6 } from "fs";
+import { join as join7 } from "path";
+import { execSync as execSync3 } from "child_process";
 function readSyncVersion() {
   try {
-    const raw = readFileSync5(syncVersionPath(), "utf-8").trim();
+    const raw = readFileSync6(syncVersionPath(), "utf-8").trim();
     const n = parseInt(raw, 10);
     return Number.isFinite(n) && n > 0 ? n : 1;
   } catch {
@@ -1450,7 +1746,7 @@ function writeSyncVersion(version) {
 `);
 }
 function git2(args, timeoutMs = GIT_TIMEOUT2) {
-  return execSync2(`git ${args}`, {
+  return execSync3(`git ${args}`, {
     cwd: minkRoot(),
     timeout: timeoutMs,
     stdio: ["pipe", "pipe", "pipe"]
@@ -1467,14 +1763,14 @@ function isSyncInitialized() {
   const enabled = resolveConfigValue("sync.enabled").value;
   if (enabled !== "true")
     return false;
-  return existsSync5(join5(minkRoot(), ".git"));
+  return existsSync9(join7(minkRoot(), ".git"));
 }
 function ensureGitignore() {
-  const gitignorePath = join5(minkRoot(), ".gitignore");
+  const gitignorePath = join7(minkRoot(), ".gitignore");
   writeFileSync3(gitignorePath, GITIGNORE_CONTENTS);
 }
 function ensureGitAttributes() {
-  const path = join5(minkRoot(), ".gitattributes");
+  const path = join7(minkRoot(), ".gitattributes");
   writeFileSync3(path, GITATTRIBUTES_CONTENTS);
 }
 function ensureMergeDriversRegistered() {
@@ -1488,7 +1784,7 @@ function ensureMergeDriversRegistered() {
 }
 function getSyncStatus() {
   const enabled = resolveConfigValue("sync.enabled").value === "true";
-  const gitInitialized = existsSync5(join5(minkRoot(), ".git"));
+  const gitInitialized = existsSync9(join7(minkRoot(), ".git"));
   const remoteUrl = resolveConfigValue("sync.remote-url").value;
   const lastPush = resolveConfigValue("sync.last-push").value;
   const lastPull = resolveConfigValue("sync.last-pull").value;
@@ -1514,8 +1810,8 @@ function getSyncStatus() {
 }
 function initSync(remoteUrl) {
   const root = minkRoot();
-  const gitDir = join5(root, ".git");
-  if (existsSync5(gitDir)) {
+  const gitDir = join7(root, ".git");
+  if (existsSync9(gitDir)) {
     console.log("[mink] sync is already initialized in " + root);
     console.log("[mink] run 'mink sync disconnect' first to reinitialize");
     return;
@@ -1656,8 +1952,8 @@ function syncPush(onMessage = (msg) => console.error(msg)) {
 }
 function disconnectSync() {
   const root = minkRoot();
-  const gitDir = join5(root, ".git");
-  if (!existsSync5(gitDir)) {
+  const gitDir = join7(root, ".git");
+  if (!existsSync9(gitDir)) {
     console.log("[mink] sync is not initialized — nothing to disconnect");
     return;
   }
@@ -1679,7 +1975,7 @@ function detectRemoteDefaultBranch() {
 `).map((b) => b.trim()).filter((b) => b.startsWith("origin/") && !b.includes("HEAD")).map((b) => b.replace("origin/", ""))[0];
   return first ?? "main";
 }
-var GIT_TIMEOUT2 = 5000, PUSH_TIMEOUT = 1e4, FETCH_TIMEOUT = 15000, MINK_SYNC_VERSION = 2, GITIGNORE_CONTENTS = `# Runtime state — machine-specific
+var GIT_TIMEOUT2 = 5000, PUSH_TIMEOUT = 1e4, FETCH_TIMEOUT = 15000, MINK_SYNC_VERSION = 3, GITIGNORE_CONTENTS = `# Runtime state — machine-specific
 scheduler.pid
 scheduler.log
 channel.pid
@@ -1691,6 +1987,13 @@ config.local
 
 # Migration coordination — never sync this
 .sync-migrate.lock
+
+# Per-device identity migration recovery snapshots — local recovery state
+# for the migrating device, not authoritative project state. A device that
+# needs to recover from its migration must do so from its own snapshot;
+# syncing would make rollback dirs appear on devices that never produced
+# the corresponding migration.
+.identity-rollback/
 
 # Local backups and per-device caches — machine-specific snapshots
 projects/*/backups/
@@ -1729,22 +2032,26 @@ var init_sync = __esm(() => {
 var exports_sync_migrate = {};
 __export(exports_sync_migrate, {
   syncMigrateCommand: () => syncMigrateCommand,
+  rollbackProjectIdentities: () => rollbackProjectIdentities,
+  planIdentityMigration: () => planIdentityMigration,
   migrateSyncLayout: () => migrateSyncLayout
 });
 import {
-  existsSync as existsSync6,
-  readdirSync as readdirSync2,
+  existsSync as existsSync10,
+  readdirSync as readdirSync3,
   statSync as statSync2,
   mkdirSync as mkdirSync4,
   writeFileSync as writeFileSync4,
+  readFileSync as readFileSync7,
   renameSync as renameSync2,
+  rmSync,
   unlinkSync as unlinkSync2
 } from "fs";
-import { join as join6 } from "path";
-import { execSync as execSync3 } from "child_process";
+import { join as join8 } from "path";
+import { execSync as execSync4 } from "child_process";
 function gitSafe3(args, timeoutMs = 5000) {
   try {
-    return execSync3(`git ${args}`, {
+    return execSync4(`git ${args}`, {
       cwd: minkRoot(),
       timeout: timeoutMs,
       stdio: ["pipe", "pipe", "pipe"]
@@ -1754,8 +2061,8 @@ function gitSafe3(args, timeoutMs = 5000) {
   }
 }
 function acquireLock() {
-  const path = join6(minkRoot(), MIGRATE_LOCK);
-  if (existsSync6(path)) {
+  const path = join8(minkRoot(), MIGRATE_LOCK);
+  if (existsSync10(path)) {
     try {
       const ageMs = Date.now() - statSync2(path).mtimeMs;
       if (ageMs < MIGRATE_LOCK_STALE_MS)
@@ -1772,13 +2079,13 @@ function acquireLock() {
 }
 function releaseLock() {
   try {
-    unlinkSync2(join6(minkRoot(), MIGRATE_LOCK));
+    unlinkSync2(join8(minkRoot(), MIGRATE_LOCK));
   } catch {}
 }
 function migrateFile(from, to) {
-  if (!existsSync6(from))
+  if (!existsSync10(from))
     return true;
-  mkdirSync4(join6(to, ".."), { recursive: true });
+  mkdirSync4(join8(to, ".."), { recursive: true });
   if (gitSafe3(`mv "${from}" "${to}"`) !== null)
     return true;
   try {
@@ -1789,7 +2096,7 @@ function migrateFile(from, to) {
   }
 }
 function migrateProject(projDir, deviceId) {
-  const shardDir = join6(projDir, "state", deviceId);
+  const shardDir = join8(projDir, "state", deviceId);
   mkdirSync4(shardDir, { recursive: true });
   for (const file of [
     "token-ledger.json",
@@ -1797,25 +2104,25 @@ function migrateProject(projDir, deviceId) {
     "bug-memory.json",
     "action-log.md"
   ]) {
-    const legacy = join6(projDir, file);
-    const shard = join6(shardDir, file);
-    if (existsSync6(shard))
+    const legacy = join8(projDir, file);
+    const shard = join8(shardDir, file);
+    if (existsSync10(shard))
       continue;
     migrateFile(legacy, shard);
   }
-  const sidecar = join6(projDir, `learning-memory.${deviceId}.md`);
-  if (!existsSync6(sidecar)) {
+  const sidecar = join8(projDir, `learning-memory.${deviceId}.md`);
+  if (!existsSync10(sidecar)) {
     try {
       writeFileSync4(sidecar, "");
     } catch {}
   }
   for (const f of ["session.json", "scheduler-manifest.json"]) {
-    if (existsSync6(join6(projDir, f))) {
-      gitSafe3(`rm --cached "${join6(projDir, f)}"`);
+    if (existsSync10(join8(projDir, f))) {
+      gitSafe3(`rm --cached "${join8(projDir, f)}"`);
     }
   }
-  const indexPath = join6(projDir, "file-index.json");
-  if (existsSync6(indexPath)) {
+  const indexPath = join8(projDir, "file-index.json");
+  if (existsSync10(indexPath)) {
     const raw = safeReadJson(indexPath);
     if (raw && typeof raw.header === "object" && raw.header !== null && (raw.header.lifetimeHits > 0 || raw.header.lifetimeMisses > 0)) {
       atomicWriteJson(fileIndexCountersPathFor(projDir), {
@@ -1829,31 +2136,31 @@ function migrateProject(projDir, deviceId) {
   }
 }
 function fileIndexCountersPathFor(projDir) {
-  return join6(projDir, ".mink-state-counters.json");
+  return join8(projDir, ".mink-state-counters.json");
 }
 function listProjects() {
-  const projectsRoot = join6(minkRoot(), "projects");
-  if (!existsSync6(projectsRoot))
+  const projectsRoot = join8(minkRoot(), "projects");
+  if (!existsSync10(projectsRoot))
     return [];
   try {
-    return readdirSync2(projectsRoot).filter((name) => {
+    return readdirSync3(projectsRoot).filter((name) => {
       try {
-        return statSync2(join6(projectsRoot, name)).isDirectory();
+        return statSync2(join8(projectsRoot, name)).isDirectory();
       } catch {
         return false;
       }
-    }).map((name) => join6(projectsRoot, name));
+    }).map((name) => join8(projectsRoot, name));
   } catch {
     return [];
   }
 }
 function projectNeedsMigration(projDir) {
-  const stateDir = join6(projDir, "state");
-  if (existsSync6(stateDir)) {
+  const stateDir = join8(projDir, "state");
+  if (existsSync10(stateDir)) {
     try {
-      const shards = readdirSync2(stateDir).filter((d) => {
+      const shards = readdirSync3(stateDir).filter((d) => {
         try {
-          return statSync2(join6(stateDir, d)).isDirectory();
+          return statSync2(join8(stateDir, d)).isDirectory();
         } catch {
           return false;
         }
@@ -1868,7 +2175,7 @@ function projectNeedsMigration(projDir) {
     "bug-memory.json",
     "action-log.md"
   ]) {
-    if (existsSync6(join6(projDir, f)))
+    if (existsSync10(join8(projDir, f)))
       return true;
   }
   return false;
@@ -1876,10 +2183,269 @@ function projectNeedsMigration(projDir) {
 function listProjectsNeedingMigration() {
   return listProjects().filter(projectNeedsMigration);
 }
+function planIdentityMigration(flagOverride) {
+  const plan = [];
+  const flag = flagOverride ?? resolveConfigValue("projects.identity").value;
+  if (flag !== "git-remote") {
+    return plan;
+  }
+  const projectsRoot = join8(minkRoot(), "projects");
+  if (!existsSync10(projectsRoot))
+    return plan;
+  let entries;
+  try {
+    entries = readdirSync3(projectsRoot);
+  } catch {
+    return plan;
+  }
+  for (const oldId of entries) {
+    const oldProjDir = join8(projectsRoot, oldId);
+    try {
+      if (!statSync2(oldProjDir).isDirectory())
+        continue;
+    } catch {
+      continue;
+    }
+    const meta = getProjectMeta(oldProjDir);
+    if (!meta)
+      continue;
+    if (!existsSync10(meta.cwd)) {
+      plan.push({
+        oldId,
+        newId: null,
+        cwd: meta.cwd,
+        action: "skip-no-cwd",
+        reason: "working-copy path not reachable on this device"
+      });
+      continue;
+    }
+    let newId;
+    try {
+      newId = resolveProjectIdentity(meta.cwd, flag === "git-remote" || flag === "path-derived" ? flag : undefined).id;
+    } catch {
+      continue;
+    }
+    if (newId === oldId) {
+      plan.push({ oldId, newId, cwd: meta.cwd, action: "skip-unchanged" });
+      continue;
+    }
+    const newProjDir = join8(projectsRoot, newId);
+    if (existsSync10(newProjDir)) {
+      const newMeta = getProjectMeta(newProjDir);
+      const aliasAlreadyRecorded = newMeta?.aliases?.includes(oldId) ?? false;
+      plan.push({
+        oldId,
+        newId,
+        cwd: meta.cwd,
+        action: aliasAlreadyRecorded ? "skip-evict" : "skip-converged",
+        reason: aliasAlreadyRecorded ? "alias already recorded; will evict leftover old directory" : "destination already exists (from sync); will record alias and evict old directory"
+      });
+      continue;
+    }
+    plan.push({ oldId, newId, cwd: meta.cwd, action: "rename" });
+  }
+  return plan;
+}
+function identityBackupRoot(timestamp) {
+  return join8(minkRoot(), IDENTITY_BACKUP_DIRNAME, timestamp);
+}
+function ensureIdentityBackupTimestamp() {
+  const now = new Date;
+  return `${now.getUTCFullYear()}${String(now.getUTCMonth() + 1).padStart(2, "0")}${String(now.getUTCDate()).padStart(2, "0")}-${String(now.getUTCHours()).padStart(2, "0")}${String(now.getUTCMinutes()).padStart(2, "0")}${String(now.getUTCSeconds()).padStart(2, "0")}`;
+}
+function backupProjectForRollback(srcDir, backupDir) {
+  try {
+    mkdirSync4(backupDir, { recursive: true });
+    copyDirRecursive(srcDir, backupDir, new Set(["backups"]));
+    return backupDir;
+  } catch {
+    return null;
+  }
+}
+function copyDirRecursive(src, dest, excludeNames) {
+  mkdirSync4(dest, { recursive: true });
+  const entries = readdirSync3(src, { withFileTypes: true });
+  for (const entry of entries) {
+    if (excludeNames.has(entry.name))
+      continue;
+    const srcPath = join8(src, entry.name);
+    const destPath = join8(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirRecursive(srcPath, destPath, excludeNames);
+    } else if (entry.isFile()) {
+      writeFileSync4(destPath, readFileSync7(srcPath));
+    }
+  }
+}
+function migrateProjectIdentities(deviceId, flag = resolveConfigValue("projects.identity").value) {
+  if (flag !== "git-remote") {
+    return {
+      renamed: 0,
+      converged: 0,
+      evicted: 0,
+      visited: 0,
+      backupDir: null,
+      renames: [],
+      evictions: []
+    };
+  }
+  const plan = planIdentityMigration(flag);
+  const willTouchOldDir = plan.filter((p) => p.action === "rename" || p.action === "skip-converged" || p.action === "skip-evict");
+  let backupRoot = null;
+  if (willTouchOldDir.length > 0) {
+    backupRoot = identityBackupRoot(ensureIdentityBackupTimestamp());
+  }
+  let renamed = 0;
+  let converged = 0;
+  let evicted = 0;
+  const renames = [];
+  const evictions = [];
+  let visited = plan.length;
+  const projectsRoot = join8(minkRoot(), "projects");
+  for (const entry of plan) {
+    const oldProjDir = join8(projectsRoot, entry.oldId);
+    if (entry.cwd && entry.action !== "skip-no-cwd") {
+      try {
+        setProjectPathForDevice(oldProjDir, deviceId, entry.cwd);
+      } catch {}
+    }
+    if ((entry.action === "skip-converged" || entry.action === "skip-evict") && entry.newId) {
+      const newProjDir2 = join8(projectsRoot, entry.newId);
+      let aliasOnRecord = false;
+      try {
+        if (entry.action === "skip-evict") {
+          aliasOnRecord = true;
+        } else {
+          addProjectAlias(newProjDir2, entry.oldId);
+          let newMeta = getProjectMeta(newProjDir2);
+          if (!newMeta) {
+            const oldMeta = getProjectMeta(oldProjDir);
+            if (oldMeta) {
+              atomicWriteJson(join8(newProjDir2, "project-meta.json"), {
+                cwd: oldMeta.cwd,
+                name: oldMeta.name,
+                initTimestamp: oldMeta.initTimestamp,
+                version: oldMeta.version,
+                aliases: [...oldMeta.aliases ?? [], entry.oldId],
+                pathsByDevice: oldMeta.pathsByDevice
+              });
+              newMeta = getProjectMeta(newProjDir2);
+            }
+          }
+          aliasOnRecord = newMeta?.aliases?.includes(entry.oldId) ?? false;
+        }
+        if (entry.cwd) {
+          setProjectPathForDevice(newProjDir2, deviceId, entry.cwd);
+        }
+      } catch {}
+      if (aliasOnRecord && backupRoot) {
+        const ok = backupProjectForRollback(oldProjDir, join8(backupRoot, entry.oldId));
+        if (ok) {
+          let removed = false;
+          try {
+            rmSync(oldProjDir, { recursive: true, force: true });
+            removed = true;
+          } catch {}
+          if (removed) {
+            evictions.push(entry.oldId);
+            evicted++;
+            if (entry.action === "skip-converged")
+              converged++;
+          }
+        }
+      }
+      continue;
+    }
+    if (entry.action !== "rename" || !entry.newId)
+      continue;
+    if (backupRoot) {
+      backupProjectForRollback(oldProjDir, join8(backupRoot, entry.oldId));
+    }
+    const newProjDir = join8(projectsRoot, entry.newId);
+    const moved = gitSafe3(`mv "${oldProjDir}" "${newProjDir}"`) !== null || (() => {
+      try {
+        renameSync2(oldProjDir, newProjDir);
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+    if (!moved)
+      continue;
+    try {
+      addProjectAlias(newProjDir, entry.oldId);
+      if (entry.cwd) {
+        setProjectPathForDevice(newProjDir, deviceId, entry.cwd);
+      }
+    } catch {}
+    renamed++;
+    renames.push({ from: entry.oldId, to: entry.newId });
+  }
+  return {
+    renamed,
+    converged,
+    evicted,
+    visited,
+    backupDir: backupRoot,
+    renames,
+    evictions
+  };
+}
+function rollbackProjectIdentities() {
+  const results = [];
+  const projectsRoot = join8(minkRoot(), "projects");
+  if (!existsSync10(projectsRoot))
+    return results;
+  let entries;
+  try {
+    entries = readdirSync3(projectsRoot);
+  } catch {
+    return results;
+  }
+  for (const currentId of entries) {
+    const projDir = join8(projectsRoot, currentId);
+    try {
+      if (!statSync2(projDir).isDirectory())
+        continue;
+    } catch {
+      continue;
+    }
+    const meta = getProjectMeta(projDir);
+    if (!meta || !meta.aliases || meta.aliases.length === 0)
+      continue;
+    const restoredId = meta.aliases[meta.aliases.length - 1];
+    const targetDir = join8(projectsRoot, restoredId);
+    if (existsSync10(targetDir)) {
+      results.push({ currentId, restoredId, ok: false });
+      continue;
+    }
+    const remainingAliases = meta.aliases.slice(0, -1);
+    const metaPath = join8(projDir, "project-meta.json");
+    try {
+      const raw = safeReadJson(metaPath);
+      if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+        const obj = raw;
+        obj.aliases = remainingAliases;
+        atomicWriteJson(metaPath, obj);
+      }
+    } catch {}
+    const moved = gitSafe3(`mv "${projDir}" "${targetDir}"`) !== null || (() => {
+      try {
+        renameSync2(projDir, targetDir);
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+    results.push({ currentId, restoredId, ok: moved });
+  }
+  return results;
+}
 function migrateSyncLayout() {
   const fromVersion = readSyncVersion();
   const pending = listProjectsNeedingMigration();
-  if (fromVersion >= MINK_SYNC_VERSION && pending.length === 0) {
+  const identityMode = resolveConfigValue("projects.identity").value;
+  if (fromVersion >= MINK_SYNC_VERSION && pending.length === 0 && identityMode !== "git-remote") {
     return {
       ranMigration: false,
       fromVersion,
@@ -1924,13 +2490,26 @@ function migrateSyncLayout() {
         processed++;
       } catch {}
     }
+    let identity = {
+      renamed: 0,
+      converged: 0,
+      evicted: 0,
+      visited: 0,
+      backupDir: null,
+      renames: [],
+      evictions: []
+    };
+    try {
+      identity = migrateProjectIdentities(deviceId, identityMode);
+    } catch {}
     if (remaining === 0 && listProjectsNeedingMigration().length === 0) {
       writeSyncVersion(MINK_SYNC_VERSION);
     }
-    if (isSyncInitialized() && processed > 0) {
+    if (isSyncInitialized() && (processed > 0 || identity.renamed > 0 || identity.evicted > 0)) {
       gitSafe3("add -A");
       gitSafe3(`reset HEAD ".sync-migrate.lock"`);
-      gitSafe3(`commit -m "mink: migrate sync layout v${fromVersion} -> v${MINK_SYNC_VERSION} (device ${deviceId.slice(0, 8)}, ${processed} projects)"`);
+      const identityNote = identity.renamed > 0 || identity.evicted > 0 ? `, ${identity.renamed} renamed + ${identity.evicted} evicted for identity v3` : "";
+      gitSafe3(`commit -m "mink: migrate sync layout v${fromVersion} -> v${MINK_SYNC_VERSION} (device ${deviceId.slice(0, 8)}, ${processed} projects${identityNote})"`);
     }
     if (stashed) {
       gitSafe3("stash pop");
@@ -1938,26 +2517,96 @@ function migrateSyncLayout() {
     return {
       ranMigration: true,
       fromVersion,
-      toVersion: MINK_SYNC_VERSION
+      toVersion: MINK_SYNC_VERSION,
+      identity
     };
   } finally {
     releaseLock();
   }
 }
-function syncMigrateCommand() {
+function syncMigrateCommand(args = []) {
+  const dryRun = args.includes("--dry-run");
+  const rollback = args.includes("--rollback");
+  if (rollback && dryRun) {
+    console.error("[mink] --rollback and --dry-run cannot be combined");
+    process.exit(1);
+  }
+  if (dryRun) {
+    const plan = planIdentityMigration();
+    if (plan.length === 0) {
+      console.log("[mink] sync migrate --dry-run: no projects to rename (flag is off or no projects on disk)");
+      return;
+    }
+    const renames = plan.filter((p) => p.action === "rename");
+    const converged = plan.filter((p) => p.action === "skip-converged");
+    const evictOnly = plan.filter((p) => p.action === "skip-evict");
+    const skippedNoCwd = plan.filter((p) => p.action === "skip-no-cwd");
+    const unchanged = plan.filter((p) => p.action === "skip-unchanged");
+    console.log(`[mink] sync migrate --dry-run: ${renames.length} rename(s), ${converged.length} converge (alias + evict), ${evictOnly.length} evict-only, ${skippedNoCwd.length} skipped (no cwd), ${unchanged.length} unchanged`);
+    for (const p of renames) {
+      console.log(`  rename:   ${p.oldId} → ${p.newId}`);
+    }
+    for (const p of converged) {
+      console.log(`  converge: ${p.oldId} → ${p.newId} (record alias on ${p.newId}, evict ${p.oldId} to .identity-rollback/)`);
+    }
+    for (const p of evictOnly) {
+      console.log(`  evict:    ${p.oldId} → .identity-rollback/ (alias already on ${p.newId})`);
+    }
+    for (const p of skippedNoCwd) {
+      console.log(`  skip:     ${p.oldId} — ${p.reason}`);
+    }
+    return;
+  }
+  if (rollback) {
+    const results = rollbackProjectIdentities();
+    if (results.length === 0) {
+      console.log("[mink] sync migrate --rollback: nothing to roll back");
+      return;
+    }
+    const ok = results.filter((r) => r.ok);
+    const failed = results.filter((r) => !r.ok);
+    console.log(`[mink] sync migrate --rollback: ${ok.length} restored, ${failed.length} failed`);
+    for (const r of ok) {
+      console.log(`  restored: ${r.currentId} → ${r.restoredId}`);
+    }
+    for (const r of failed) {
+      console.log(`  failed:   ${r.currentId} → ${r.restoredId} (destination already exists or rename blocked)`);
+    }
+    if (ok.length > 0) {
+      console.log(`
+[mink] tip: set projects.identity=path-derived to prevent the next session-start from re-migrating`);
+    }
+    return;
+  }
   const result = migrateSyncLayout();
   if (!result.ranMigration) {
     console.log(`[mink] sync migrate: ${result.message ?? "no-op"}`);
     return;
   }
   console.log(`[mink] sync migrate: v${result.fromVersion} → v${result.toVersion} complete`);
+  const identity = result.identity;
+  if (identity && (identity.renamed > 0 || identity.evicted > 0)) {
+    console.log(`  identity: ${identity.renamed} renamed, ${identity.converged} converged, ${identity.evicted} evicted`);
+    for (const r of identity.renames) {
+      console.log(`    renamed: ${r.from} → ${r.to}`);
+    }
+    for (const id of identity.evictions) {
+      console.log(`    evicted: ${id} → .identity-rollback/`);
+    }
+    if (identity.backupDir) {
+      console.log(`  rollback snapshot: ${identity.backupDir}`);
+    }
+  }
 }
-var MIGRATE_LOCK = ".sync-migrate.lock", MIGRATE_LOCK_STALE_MS = 300000, MIGRATE_BUDGET_MS = 5000;
+var MIGRATE_LOCK = ".sync-migrate.lock", MIGRATE_LOCK_STALE_MS = 300000, MIGRATE_BUDGET_MS = 5000, IDENTITY_BACKUP_DIRNAME = ".identity-rollback";
 var init_sync_migrate = __esm(() => {
   init_paths();
   init_sync();
   init_device();
   init_fs_utils();
+  init_project_id();
+  init_project_registry();
+  init_global_config();
 });
 
 // src/core/note-linker.ts
@@ -1968,8 +2617,8 @@ __export(exports_note_linker, {
   extractWikilinks: () => extractWikilinks,
   addBacklink: () => addBacklink
 });
-import { join as join7 } from "path";
-import { existsSync as existsSync7, readFileSync as readFileSync7, readdirSync as readdirSync3, statSync as statSync3 } from "fs";
+import { join as join9 } from "path";
+import { existsSync as existsSync11, readFileSync as readFileSync8, readdirSync as readdirSync4, statSync as statSync3 } from "fs";
 function extractWikilinks(content) {
   const links = [];
   let match;
@@ -1995,9 +2644,9 @@ function insertWikilinks(content, targets) {
   return result;
 }
 function addBacklink(targetNotePath, sourceTitle) {
-  if (!existsSync7(targetNotePath))
+  if (!existsSync11(targetNotePath))
     return;
-  const content = readFileSync7(targetNotePath, "utf-8");
+  const content = readFileSync8(targetNotePath, "utf-8");
   if (content.includes(`[[${sourceTitle}]]`))
     return;
   const backlinkSection = `
@@ -2039,8 +2688,8 @@ function updateMasterIndex(vaultRootPath) {
     { name: "Patterns", dir: "patterns", emoji: "" }
   ];
   for (const cat of categories) {
-    const dirPath = join7(vaultRootPath, cat.dir);
-    if (!existsSync7(dirPath))
+    const dirPath = join9(vaultRootPath, cat.dir);
+    if (!existsSync11(dirPath))
       continue;
     const files = collectMarkdownFiles(dirPath, vaultRootPath);
     if (files.length === 0 && cat.dir !== "inbox")
@@ -2067,9 +2716,9 @@ function updateMasterIndex(vaultRootPath) {
 function collectMarkdownFiles(dirPath, rootPath) {
   const files = [];
   try {
-    const entries = readdirSync3(dirPath, { withFileTypes: true });
+    const entries = readdirSync4(dirPath, { withFileTypes: true });
     for (const entry of entries) {
-      const fullPath = join7(dirPath, entry.name);
+      const fullPath = join9(dirPath, entry.name);
       if (entry.isDirectory()) {
         files.push(...collectMarkdownFiles(fullPath, rootPath));
       } else if (entry.name.endsWith(".md") && !entry.name.startsWith("_")) {
@@ -2202,7 +2851,7 @@ var init_learning_memory = __esm(() => {
 });
 
 // src/core/token-ledger.ts
-import { join as join8 } from "path";
+import { join as join10 } from "path";
 function addToLifetime(lifetime, session) {
   lifetime.totalTokens += session.totals.estimatedTokens;
   lifetime.totalReads += session.totals.readCount;
@@ -2333,13 +2982,13 @@ function createLedgerFinalizer(projectDir2, deviceIdOrThreshold, archiveThreshol
   let archivePath;
   let threshold;
   if (typeof deviceIdOrThreshold === "string") {
-    const shardDir = join8(projectDir2, "state", deviceIdOrThreshold);
-    ledgerPath = join8(shardDir, "token-ledger.json");
-    archivePath = join8(shardDir, "token-ledger-archive.json");
+    const shardDir = join10(projectDir2, "state", deviceIdOrThreshold);
+    ledgerPath = join10(shardDir, "token-ledger.json");
+    archivePath = join10(shardDir, "token-ledger-archive.json");
     threshold = archiveThreshold;
   } else {
-    ledgerPath = join8(projectDir2, "token-ledger.json");
-    archivePath = join8(projectDir2, "token-ledger-archive.json");
+    ledgerPath = join10(projectDir2, "token-ledger.json");
+    archivePath = join10(projectDir2, "token-ledger-archive.json");
     threshold = deviceIdOrThreshold ?? archiveThreshold;
   }
   return {
@@ -2479,16 +3128,16 @@ var init_bug_memory = __esm(() => {
 });
 
 // src/core/state-aggregator.ts
-import { existsSync as existsSync8, readdirSync as readdirSync4, readFileSync as readFileSync8, statSync as statSync4 } from "fs";
-import { join as join9 } from "path";
+import { existsSync as existsSync12, readdirSync as readdirSync5, readFileSync as readFileSync9, statSync as statSync4 } from "fs";
+import { join as join11 } from "path";
 function listDeviceShardsAt(projDir) {
-  const stateDir = join9(projDir, "state");
-  if (!existsSync8(stateDir))
+  const stateDir = join11(projDir, "state");
+  if (!existsSync12(stateDir))
     return [];
   try {
-    return readdirSync4(stateDir).filter((name) => {
+    return readdirSync5(stateDir).filter((name) => {
       try {
-        return statSync4(join9(stateDir, name)).isDirectory();
+        return statSync4(join11(stateDir, name)).isDirectory();
       } catch {
         return false;
       }
@@ -2498,16 +3147,16 @@ function listDeviceShardsAt(projDir) {
   }
 }
 function listLearningMemorySidecarPathsAt(projDir) {
-  if (!existsSync8(projDir))
+  if (!existsSync12(projDir))
     return [];
   try {
-    return readdirSync4(projDir).filter((f) => SIDECAR_RE.test(f)).map((f) => join9(projDir, f));
+    return readdirSync5(projDir).filter((f) => SIDECAR_RE.test(f)).map((f) => join11(projDir, f));
   } catch {
     return [];
   }
 }
 function shardPath(projDir, deviceId, file) {
-  return join9(projDir, "state", deviceId, file);
+  return join11(projDir, "state", deviceId, file);
 }
 function addLifetime(target, source) {
   target.totalTokens += source.totalTokens;
@@ -2524,12 +3173,12 @@ function aggregateTokenLedgerAt(projDir) {
   const seenSessions = new Set;
   const sources = [
     ...listDeviceShardsAt(projDir).map((id) => shardPath(projDir, id, "token-ledger.json")),
-    join9(projDir, "token-ledger.json")
+    join11(projDir, "token-ledger.json")
   ];
   const seenFlagKeys = new Set;
   const wasteFlags = [];
   for (const path of sources) {
-    if (!existsSync8(path))
+    if (!existsSync12(path))
       continue;
     const ledger = loadLedger(path);
     addLifetime(merged.lifetime, ledger.lifetime);
@@ -2563,10 +3212,10 @@ function aggregateBugMemoryAt(projDir) {
   let maxNextId = 1;
   const sources = [
     ...listDeviceShardsAt(projDir).map((id) => shardPath(projDir, id, "bug-memory.json")),
-    join9(projDir, "bug-memory.json")
+    join11(projDir, "bug-memory.json")
   ];
   for (const path of sources) {
-    if (!existsSync8(path))
+    if (!existsSync12(path))
       continue;
     const mem = loadBugMemory(path);
     if (mem.nextId > maxNextId)
@@ -2606,10 +3255,10 @@ function aggregateActionLogAt(projDir) {
   let order = 0;
   const sources = [
     ...listDeviceShardsAt(projDir).map((id) => shardPath(projDir, id, "action-log.md")),
-    join9(projDir, "action-log.md")
+    join11(projDir, "action-log.md")
   ];
   for (const path of sources) {
-    if (!existsSync8(path))
+    if (!existsSync12(path))
       continue;
     const content = safeReadLog(path);
     if (!content)
@@ -2634,11 +3283,11 @@ function aggregateActionLog(cwd) {
   return aggregateActionLogAt(projectDir(cwd));
 }
 function aggregateLearningMemoryAt(projDir) {
-  const canonicalPath = join9(projDir, "learning-memory.md");
+  const canonicalPath = join11(projDir, "learning-memory.md");
   let merged;
-  if (existsSync8(canonicalPath)) {
+  if (existsSync12(canonicalPath)) {
     try {
-      merged = parseLearningMemory(readFileSync8(canonicalPath, "utf-8"));
+      merged = parseLearningMemory(readFileSync9(canonicalPath, "utf-8"));
     } catch {
       merged = createEmptyLearningMemory("unknown");
     }
@@ -2648,7 +3297,7 @@ function aggregateLearningMemoryAt(projDir) {
   for (const sidecarPath of listLearningMemorySidecarPathsAt(projDir)) {
     let sidecar;
     try {
-      sidecar = parseLearningMemory(readFileSync8(sidecarPath, "utf-8"));
+      sidecar = parseLearningMemory(readFileSync9(sidecarPath, "utf-8"));
     } catch {
       continue;
     }
@@ -2955,12 +3604,12 @@ var exports_reflect = {};
 __export(exports_reflect, {
   reflect: () => reflect
 });
-import { existsSync as existsSync9 } from "fs";
+import { existsSync as existsSync13 } from "fs";
 import { dirname as dirname3 } from "path";
 function reflect(_cwd, memoryPath, configPath2) {
   const projDir = dirname3(memoryPath);
   const mem = aggregateLearningMemoryAt(projDir);
-  if (totalEntryCount(mem) === 0 && !existsSync9(memoryPath)) {
+  if (totalEntryCount(mem) === 0 && !existsSync13(memoryPath)) {
     console.log("[mink] no learning memory found");
     return null;
   }
@@ -3019,10 +3668,11 @@ __export(exports_paths2, {
   actionLogShardPath: () => actionLogShardPath2,
   actionLogPath: () => actionLogPath2
 });
-import { join as join11 } from "path";
+import { join as join13 } from "path";
+import { existsSync as existsSync15 } from "fs";
 import { homedir as homedir3 } from "os";
 function resolveMinkRoot2() {
-  return process.env.MINK_ROOT_OVERRIDE || join11(homedir3(), ".mink");
+  return process.env.MINK_ROOT_OVERRIDE || join13(homedir3(), ".mink");
 }
 function minkRoot2() {
   if (process.env.MINK_ROOT_OVERRIDE) {
@@ -3031,104 +3681,113 @@ function minkRoot2() {
   return MINK_ROOT2;
 }
 function projectDir2(cwd) {
-  const id = generateProjectId(cwd);
-  return join11(minkRoot2(), "projects", id);
+  const id = projectIdFor(cwd);
+  const primary = join13(minkRoot2(), "projects", id);
+  if (existsSync15(primary))
+    return primary;
+  try {
+    const { findProjectDirByIdOrAlias: findProjectDirByIdOrAlias2 } = (init_project_registry(), __toCommonJS(exports_project_registry));
+    const aliased = findProjectDirByIdOrAlias2(id);
+    if (aliased)
+      return aliased;
+  } catch {}
+  return primary;
 }
 function sessionPath2(cwd) {
-  return join11(projectDir2(cwd), "session.json");
+  return join13(projectDir2(cwd), "session.json");
 }
 function fileIndexPath2(cwd) {
-  return join11(projectDir2(cwd), "file-index.json");
+  return join13(projectDir2(cwd), "file-index.json");
 }
 function configPath2(cwd) {
-  return join11(projectDir2(cwd), "config.json");
+  return join13(projectDir2(cwd), "config.json");
 }
 function learningMemoryPath2(cwd) {
-  return join11(projectDir2(cwd), "learning-memory.md");
+  return join13(projectDir2(cwd), "learning-memory.md");
 }
 function tokenLedgerPath2(cwd) {
-  return join11(projectDir2(cwd), "token-ledger.json");
+  return join13(projectDir2(cwd), "token-ledger.json");
 }
 function tokenLedgerArchivePath2(cwd) {
-  return join11(projectDir2(cwd), "token-ledger-archive.json");
+  return join13(projectDir2(cwd), "token-ledger-archive.json");
 }
 function bugMemoryPath2(cwd) {
-  return join11(projectDir2(cwd), "bug-memory.json");
+  return join13(projectDir2(cwd), "bug-memory.json");
 }
 function actionLogPath2(cwd) {
-  return join11(projectDir2(cwd), "action-log.md");
+  return join13(projectDir2(cwd), "action-log.md");
 }
 function schedulerPidPath2() {
-  return join11(minkRoot2(), "scheduler.pid");
+  return join13(minkRoot2(), "scheduler.pid");
 }
 function schedulerLogPath2() {
-  return join11(minkRoot2(), "scheduler.log");
+  return join13(minkRoot2(), "scheduler.log");
 }
 function schedulerManifestPath2(cwd) {
-  return join11(projectDir2(cwd), "scheduler-manifest.json");
+  return join13(projectDir2(cwd), "scheduler-manifest.json");
 }
 function channelPidPath2() {
-  return join11(minkRoot2(), "channel.pid");
+  return join13(minkRoot2(), "channel.pid");
 }
 function channelLogPath2() {
-  return join11(minkRoot2(), "channel.log");
+  return join13(minkRoot2(), "channel.log");
 }
 function globalConfigPath2() {
-  return join11(minkRoot2(), "config");
+  return join13(minkRoot2(), "config");
 }
 function localConfigPath2() {
-  return join11(minkRoot2(), "config.local");
+  return join13(minkRoot2(), "config.local");
 }
 function deviceIdPath2() {
-  return join11(minkRoot2(), "device-id");
+  return join13(minkRoot2(), "device-id");
 }
 function deviceRegistryPath2() {
-  return join11(minkRoot2(), "devices.json");
+  return join13(minkRoot2(), "devices.json");
 }
 function projectMetaPath2(cwd) {
-  return join11(projectDir2(cwd), "project-meta.json");
+  return join13(projectDir2(cwd), "project-meta.json");
 }
 function backupDirPath2(cwd) {
-  return join11(projectDir2(cwd), "backups");
+  return join13(projectDir2(cwd), "backups");
 }
 function syncVersionPath2() {
-  return join11(minkRoot2(), ".mink-sync-version");
+  return join13(minkRoot2(), ".mink-sync-version");
 }
 function projectStateDir2(cwd) {
-  return join11(projectDir2(cwd), "state");
+  return join13(projectDir2(cwd), "state");
 }
 function deviceShardDir2(cwd, deviceId) {
-  return join11(projectStateDir2(cwd), deviceId);
+  return join13(projectStateDir2(cwd), deviceId);
 }
 function tokenLedgerShardPath2(cwd, deviceId) {
-  return join11(deviceShardDir2(cwd, deviceId), "token-ledger.json");
+  return join13(deviceShardDir2(cwd, deviceId), "token-ledger.json");
 }
 function tokenLedgerArchiveShardPath2(cwd, deviceId) {
-  return join11(deviceShardDir2(cwd, deviceId), "token-ledger-archive.json");
+  return join13(deviceShardDir2(cwd, deviceId), "token-ledger-archive.json");
 }
 function bugMemoryShardPath2(cwd, deviceId) {
-  return join11(deviceShardDir2(cwd, deviceId), "bug-memory.json");
+  return join13(deviceShardDir2(cwd, deviceId), "bug-memory.json");
 }
 function actionLogShardPath2(cwd, deviceId) {
-  return join11(deviceShardDir2(cwd, deviceId), "action-log.md");
+  return join13(deviceShardDir2(cwd, deviceId), "action-log.md");
 }
 function learningMemorySidecarPath2(cwd, deviceId) {
-  return join11(projectDir2(cwd), `learning-memory.${deviceId}.md`);
+  return join13(projectDir2(cwd), `learning-memory.${deviceId}.md`);
 }
 function fileIndexCountersPath3(cwd) {
-  return join11(projectDir2(cwd), ".mink-state-counters.json");
+  return join13(projectDir2(cwd), ".mink-state-counters.json");
 }
 function designCapturesDir2(cwd) {
-  return join11(projectDir2(cwd), "design-captures");
+  return join13(projectDir2(cwd), "design-captures");
 }
 function designReportPath2(cwd) {
-  return join11(projectDir2(cwd), "design-report.json");
+  return join13(projectDir2(cwd), "design-report.json");
 }
 function frameworkAdvisorPath2(cwd) {
-  return join11(projectDir2(cwd), "framework-advisor.md");
+  return join13(projectDir2(cwd), "framework-advisor.md");
 }
 function frameworkAdvisorJsonPath2(cwd) {
-  return join11(projectDir2(cwd), "framework-advisor.json");
+  return join13(projectDir2(cwd), "framework-advisor.json");
 }
 var MINK_ROOT2;
 var init_paths2 = __esm(() => {
@@ -3145,13 +3804,13 @@ __export(exports_backup, {
 });
 import {
   mkdirSync as mkdirSync6,
-  readdirSync as readdirSync5,
-  readFileSync as readFileSync10,
+  readdirSync as readdirSync6,
+  readFileSync as readFileSync11,
   writeFileSync as writeFileSync5,
-  existsSync as existsSync11,
+  existsSync as existsSync16,
   statSync as statSync6
 } from "fs";
-import { join as join12 } from "path";
+import { join as join14 } from "path";
 function formatTimestamp(date) {
   const y = date.getFullYear();
   const mo = String(date.getMonth() + 1).padStart(2, "0");
@@ -3164,14 +3823,14 @@ function formatTimestamp(date) {
 }
 function copyDirectoryFiles(srcDir, destDir, excludeDirs) {
   mkdirSync6(destDir, { recursive: true });
-  const entries = readdirSync5(srcDir, { withFileTypes: true });
+  const entries = readdirSync6(srcDir, { withFileTypes: true });
   for (const entry of entries) {
     if (entry.isDirectory()) {
       if (excludeDirs.includes(entry.name))
         continue;
-      copyDirectoryFiles(join12(srcDir, entry.name), join12(destDir, entry.name), excludeDirs);
+      copyDirectoryFiles(join14(srcDir, entry.name), join14(destDir, entry.name), excludeDirs);
     } else if (entry.isFile()) {
-      writeFileSync5(join12(destDir, entry.name), readFileSync10(join12(srcDir, entry.name)));
+      writeFileSync5(join14(destDir, entry.name), readFileSync11(join14(srcDir, entry.name)));
     }
   }
 }
@@ -3180,25 +3839,25 @@ function createBackup(cwd) {
   const dir = backupDirPath(cwd);
   let name = base;
   let suffix = 1;
-  while (existsSync11(join12(dir, name))) {
+  while (existsSync16(join14(dir, name))) {
     name = `${base}-${suffix}`;
     suffix++;
   }
   const src = projectDir(cwd);
-  const dest = join12(dir, name);
+  const dest = join14(dir, name);
   copyDirectoryFiles(src, dest, ["backups"]);
   return name;
 }
 function listBackups(cwd) {
   const dir = backupDirPath(cwd);
-  if (!existsSync11(dir))
+  if (!existsSync16(dir))
     return [];
-  const entries = readdirSync5(dir, { withFileTypes: true });
+  const entries = readdirSync6(dir, { withFileTypes: true });
   const backups = [];
   for (const entry of entries) {
     if (!entry.isDirectory() || !entry.name.startsWith("backup-"))
       continue;
-    const backupPath = join12(dir, entry.name);
+    const backupPath = join14(dir, entry.name);
     const match = entry.name.match(/^backup-(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})(\d{3})?(?:-\d+)?$/);
     let timestamp;
     if (match) {
@@ -3208,7 +3867,7 @@ function listBackups(cwd) {
     }
     let fileCount = 0;
     try {
-      fileCount = readdirSync5(backupPath).length;
+      fileCount = readdirSync6(backupPath).length;
     } catch {}
     backups.push({ name: entry.name, timestamp, path: backupPath, fileCount });
   }
@@ -3221,8 +3880,8 @@ function listBackups(cwd) {
   return backups;
 }
 function restoreBackup(cwd, backupName) {
-  const backupPath = join12(backupDirPath(cwd), backupName);
-  if (!existsSync11(backupPath)) {
+  const backupPath = join14(backupDirPath(cwd), backupName);
+  if (!existsSync16(backupPath)) {
     throw new Error(`backup not found: ${backupName}`);
   }
   createBackup(cwd);
@@ -3233,8 +3892,8 @@ var init_backup = __esm(() => {
 });
 
 // src/core/scanner.ts
-import { readdirSync as readdirSync6, statSync as statSync7 } from "fs";
-import { join as join13, relative } from "path";
+import { readdirSync as readdirSync7, statSync as statSync7 } from "fs";
+import { join as join15, relative } from "path";
 function matchesPattern(name, pattern) {
   if (pattern.includes("*")) {
     const regex = new RegExp("^" + pattern.replace(/\./g, "\\.").replace(/\*/g, ".*") + "$");
@@ -3248,7 +3907,7 @@ function isExcluded(name, excludes) {
 function walkDirectory(dir, projectRoot, excludes, results) {
   let entries;
   try {
-    entries = readdirSync6(dir, { withFileTypes: true });
+    entries = readdirSync7(dir, { withFileTypes: true });
   } catch {
     return;
   }
@@ -3258,14 +3917,14 @@ function walkDirectory(dir, projectRoot, excludes, results) {
     if (entry.isDirectory()) {
       if (isExcluded(entry.name, excludes))
         continue;
-      walkDirectory(join13(dir, entry.name), projectRoot, excludes, results);
+      walkDirectory(join15(dir, entry.name), projectRoot, excludes, results);
       continue;
     }
     if (entry.isFile()) {
       if (isExcluded(entry.name, excludes))
         continue;
       try {
-        const fullPath = join13(dir, entry.name);
+        const fullPath = join15(dir, entry.name);
         const stat = statSync7(fullPath);
         results.push({
           relativePath: relative(projectRoot, fullPath),
@@ -3591,8 +4250,8 @@ var exports_scan = {};
 __export(exports_scan, {
   scan: () => scan
 });
-import { readFileSync as readFileSync11 } from "fs";
-import { join as join14, relative as relative2 } from "path";
+import { readFileSync as readFileSync12 } from "fs";
+import { join as join16, relative as relative2 } from "path";
 function configRelativePath(cfgPath, cwd) {
   const rel = relative2(cwd, cfgPath);
   return rel.startsWith("..") ? cfgPath : rel;
@@ -3647,10 +4306,10 @@ function scan(cwd, options) {
   newIndex.header.lifetimeHits = index.header.lifetimeHits;
   newIndex.header.lifetimeMisses = index.header.lifetimeMisses;
   for (const file of scanned) {
-    const fullPath = join14(cwd, file.relativePath);
+    const fullPath = join16(cwd, file.relativePath);
     let content;
     try {
-      content = readFileSync11(fullPath, "utf-8");
+      content = readFileSync12(fullPath, "utf-8");
     } catch {
       continue;
     }
@@ -3691,13 +4350,13 @@ __export(exports_seed, {
   parseGoMod: () => parseGoMod,
   parseCargoToml: () => parseCargoToml
 });
-import { basename as basename4, join as join15 } from "path";
-import { readFileSync as readFileSync12, existsSync as existsSync12 } from "fs";
+import { basename as basename4, join as join17 } from "path";
+import { readFileSync as readFileSync13, existsSync as existsSync17 } from "fs";
 function readFile(filePath) {
-  if (!existsSync12(filePath))
+  if (!existsSync17(filePath))
     return null;
   try {
-    return readFileSync12(filePath, "utf-8");
+    return readFileSync13(filePath, "utf-8");
   } catch {
     return null;
   }
@@ -3787,10 +4446,10 @@ function parseGoMod(filePath) {
 }
 function seedLearningMemory(projectRoot) {
   const parsers = [
-    () => parsePackageJson(join15(projectRoot, "package.json")),
-    () => parsePyprojectToml(join15(projectRoot, "pyproject.toml")),
-    () => parseCargoToml(join15(projectRoot, "Cargo.toml")),
-    () => parseGoMod(join15(projectRoot, "go.mod"))
+    () => parsePackageJson(join17(projectRoot, "package.json")),
+    () => parsePyprojectToml(join17(projectRoot, "pyproject.toml")),
+    () => parseCargoToml(join17(projectRoot, "Cargo.toml")),
+    () => parseGoMod(join17(projectRoot, "go.mod"))
   ];
   const infos = parsers.map((fn) => fn()).filter((info) => info !== null);
   const projectName = infos.find((i) => i.projectName)?.projectName ?? basename4(projectRoot);
@@ -3874,12 +4533,12 @@ __export(exports_init, {
   detectRuntime: () => detectRuntime,
   buildHooksConfig: () => buildHooksConfig
 });
-import { execSync as execSync4 } from "child_process";
-import { mkdirSync as mkdirSync7, existsSync as existsSync13 } from "fs";
-import { resolve as resolve2, dirname as dirname5, basename as basename5, join as join16 } from "path";
+import { execSync as execSync5 } from "child_process";
+import { mkdirSync as mkdirSync7, existsSync as existsSync18 } from "fs";
+import { resolve as resolve2, dirname as dirname5, basename as basename5, join as join18 } from "path";
 function detectRuntime() {
   try {
-    execSync4("bun --version", { stdio: "ignore" });
+    execSync5("bun --version", { stdio: "ignore" });
     return "bun";
   } catch {
     return "node";
@@ -3892,8 +4551,8 @@ function resolveCliPath() {
     return selfPath;
   }
   const projectRoot = resolve2(selfDir, "../..");
-  const distPath = join16(projectRoot, "dist", "cli.js");
-  if (existsSync13(distPath))
+  const distPath = join18(projectRoot, "dist", "cli.js");
+  if (existsSync18(distPath))
     return distPath;
   return resolve2(selfDir, "../cli.ts");
 }
@@ -3953,9 +4612,9 @@ function mergeHooksIntoSettings(settingsPath, newHooks) {
 }
 function isExistingInstallation(cwd) {
   const dir = projectDir(cwd);
-  if (!existsSync13(dir))
+  if (!existsSync18(dir))
     return false;
-  return existsSync13(join16(dir, "file-index.json"));
+  return existsSync18(join18(dir, "file-index.json"));
 }
 async function init(cwd) {
   const runtime = detectRuntime();
@@ -3973,16 +4632,20 @@ async function init(cwd) {
   mergeHooksIntoSettings(settingsPath, hooks);
   const rulePath = writeMinkRule(cwd);
   mkdirSync7(dir, { recursive: true });
-  const projectId = generateProjectId(cwd);
+  const identity = resolveProjectIdentity(cwd);
+  const projectId = identity.id;
   const isNotesProject = isWikiEnabled() && isVaultInitialized() && isInsideVault(cwd);
   const metaPath = projectMetaPath(cwd);
   const existingMeta = safeReadJson(metaPath);
+  const deviceId = getOrCreateDeviceId();
+  const existingPathsByDevice = existingMeta?.pathsByDevice && typeof existingMeta.pathsByDevice === "object" && !Array.isArray(existingMeta.pathsByDevice) ? existingMeta.pathsByDevice : {};
   atomicWriteJson(metaPath, {
     ...existingMeta ?? {},
     cwd,
     name: basename5(cwd),
     initTimestamp: existingMeta?.initTimestamp ?? new Date().toISOString(),
     version: "0.1.0",
+    pathsByDevice: { ...existingPathsByDevice, [deviceId]: cwd },
     ...isNotesProject ? { projectType: "notes" } : {}
   });
   if (upgrading) {
@@ -3992,17 +4655,23 @@ async function init(cwd) {
     console.log(`  rule:     ${rulePath}`);
   } else {
     console.log(`[mink] initialized`);
-    console.log(`  project:  ${projectId}`);
+    console.log(`  project:  ${projectId} (${identity.source})`);
     console.log(`  state:    ${dir}`);
     console.log(`  runtime:  ${runtime}`);
     console.log(`  hooks:    ${settingsPath}`);
     console.log(`  rule:     ${rulePath}`);
   }
+  if (identity.source === "path-derived") {
+    const root = getRepoRoot(cwd);
+    if (root && !getRepoRemote(cwd)) {
+      console.log(`  note:     this repo has no remote configured. Project state will not unify across machines until you add one and run \`mink config projects.identity git-remote\`.`);
+    }
+  }
   const { scan: scan2 } = await Promise.resolve().then(() => (init_scan(), exports_scan));
   scan2(cwd, { check: false });
   const { learningMemoryPath: learningMemoryPath3 } = await Promise.resolve().then(() => (init_paths(), exports_paths));
   const memPath = learningMemoryPath3(cwd);
-  if (!existsSync13(memPath)) {
+  if (!existsSync18(memPath)) {
     const { seedLearningMemory: seedLearningMemory2 } = await Promise.resolve().then(() => (init_seed(), exports_seed));
     const { serializeLearningMemory: serializeLearningMemory2 } = await Promise.resolve().then(() => (init_learning_memory(), exports_learning_memory));
     const mem = seedLearningMemory2(cwd);
@@ -4011,8 +4680,8 @@ async function init(cwd) {
   if (isWikiEnabled() && isVaultInitialized() && !isNotesProject) {
     try {
       const projectSlug = basename5(cwd);
-      const overviewPath = join16(vaultProjects(projectSlug), "overview.md");
-      if (!existsSync13(overviewPath)) {
+      const overviewPath = join18(vaultProjects(projectSlug), "overview.md");
+      if (!existsSync18(overviewPath)) {
         const now = new Date().toISOString();
         const overview = [
           `---`,
@@ -4061,6 +4730,8 @@ var init_init = __esm(() => {
   init_paths();
   init_project_id();
   init_fs_utils();
+  init_device();
+  init_git_identity();
   init_vault();
 });
 
@@ -4099,12 +4770,12 @@ var init_state_counters = __esm(() => {
 });
 
 // src/core/channel-templates.ts
-import { join as join17 } from "path";
-import { existsSync as existsSync14, writeFileSync as writeFileSync6, mkdirSync as mkdirSync8 } from "fs";
+import { join as join19 } from "path";
+import { existsSync as existsSync19, writeFileSync as writeFileSync6, mkdirSync as mkdirSync8 } from "fs";
 function writeCompanionClaudeMd(vaultPath, overwrite = false) {
   mkdirSync8(vaultPath, { recursive: true });
-  const claudeMdPath = join17(vaultPath, "CLAUDE.md");
-  if (existsSync14(claudeMdPath) && !overwrite) {
+  const claudeMdPath = join19(vaultPath, "CLAUDE.md");
+  if (existsSync19(claudeMdPath) && !overwrite) {
     return false;
   }
   writeFileSync6(claudeMdPath, COMPANION_CLAUDE_MD);
@@ -4256,12 +4927,12 @@ mink wiki rebuild-index
 var init_channel_templates = () => {};
 
 // src/core/channel-process.ts
-import { readFileSync as readFileSync13, writeFileSync as writeFileSync7, unlinkSync as unlinkSync3, mkdirSync as mkdirSync9, existsSync as existsSync15 } from "fs";
-import { dirname as dirname6, join as join18 } from "path";
+import { readFileSync as readFileSync14, writeFileSync as writeFileSync7, unlinkSync as unlinkSync3, mkdirSync as mkdirSync9, existsSync as existsSync20 } from "fs";
+import { dirname as dirname6, join as join20 } from "path";
 import { spawnSync } from "child_process";
 function readChannelPidFile() {
   try {
-    const raw = readFileSync13(channelPidPath(), "utf-8");
+    const raw = readFileSync14(channelPidPath(), "utf-8");
     const data = JSON.parse(raw);
     if (data && typeof data.session === "string" && typeof data.platform === "string" && typeof data.startedAt === "string" && typeof data.vaultPath === "string") {
       return data;
@@ -4403,18 +5074,18 @@ function getChannelLogs() {
     return null;
   if (!screenSessionExists(pidData.session))
     return null;
-  const tmpPath = join18(minkRoot(), `.channel-capture-${Date.now()}-${process.pid}.txt`);
+  const tmpPath = join20(minkRoot(), `.channel-capture-${Date.now()}-${process.pid}.txt`);
   const result = spawnSync("screen", ["-S", pidData.session, "-X", "hardcopy", "-h", tmpPath], { stdio: "ignore" });
   if (result.status !== 0)
     return null;
   for (let i = 0;i < 20; i++) {
-    if (existsSync15(tmpPath))
+    if (existsSync20(tmpPath))
       break;
     const delayUntil = Date.now() + 50;
     while (Date.now() < delayUntil) {}
   }
   try {
-    const content = readFileSync13(tmpPath, "utf-8");
+    const content = readFileSync14(tmpPath, "utf-8");
     try {
       unlinkSync3(tmpPath);
     } catch {}
@@ -4588,12 +5259,12 @@ var init_runtime = __esm(() => {
 });
 
 // src/core/daemon.ts
-import { readFileSync as readFileSync14, writeFileSync as writeFileSync8, unlinkSync as unlinkSync4, openSync } from "fs";
+import { readFileSync as readFileSync15, writeFileSync as writeFileSync8, unlinkSync as unlinkSync4, openSync } from "fs";
 import { mkdirSync as mkdirSync10 } from "fs";
 import { dirname as dirname7, resolve as resolve3 } from "path";
 function readPidFile() {
   try {
-    const raw = readFileSync14(schedulerPidPath(), "utf-8");
+    const raw = readFileSync15(schedulerPidPath(), "utf-8");
     const data = JSON.parse(raw);
     if (data && typeof data.pid === "number" && typeof data.startedAt === "string" && typeof data.projectCwd === "string") {
       return data;
@@ -4747,9 +5418,9 @@ var exports_status = {};
 __export(exports_status, {
   status: () => status
 });
-import { existsSync as existsSync17, readFileSync as readFileSync15, statSync as statSync8 } from "fs";
+import { existsSync as existsSync22, readFileSync as readFileSync16, statSync as statSync8 } from "fs";
 function checkJsonFile(name, filePath, validator) {
-  if (!existsSync17(filePath))
+  if (!existsSync22(filePath))
     return { name, path: filePath, status: "missing" };
   const data = safeReadJson(filePath);
   if (data === null)
@@ -4759,10 +5430,10 @@ function checkJsonFile(name, filePath, validator) {
   return { name, path: filePath, status: "ok" };
 }
 function checkTextFile(name, filePath) {
-  if (!existsSync17(filePath))
+  if (!existsSync22(filePath))
     return { name, path: filePath, status: "missing" };
   try {
-    readFileSync15(filePath, "utf-8");
+    readFileSync16(filePath, "utf-8");
     return { name, path: filePath, status: "ok" };
   } catch {
     return { name, path: filePath, status: "corrupt" };
@@ -4836,7 +5507,7 @@ function status(cwd) {
       console.log(`    Decision Log: ${mem.sections["Decision Log"].length}`);
       console.log(`    Total entries: ${total}`);
       const memPath = learningMemoryPath(cwd);
-      if (existsSync17(memPath)) {
+      if (existsSync22(memPath)) {
         const mtime = statSync8(memPath).mtime;
         console.log(`    Canonical last modified: ${mtime.toISOString()}`);
       }
@@ -4881,8 +5552,8 @@ var exports_scan2 = {};
 __export(exports_scan2, {
   scan: () => scan2
 });
-import { readFileSync as readFileSync16 } from "fs";
-import { join as join19, relative as relative3 } from "path";
+import { readFileSync as readFileSync17 } from "fs";
+import { join as join21, relative as relative3 } from "path";
 function configRelativePath2(cfgPath, cwd) {
   const rel = relative3(cwd, cfgPath);
   return rel.startsWith("..") ? cfgPath : rel;
@@ -4937,10 +5608,10 @@ function scan2(cwd, options) {
   newIndex.header.lifetimeHits = index.header.lifetimeHits;
   newIndex.header.lifetimeMisses = index.header.lifetimeMisses;
   for (const file of scanned) {
-    const fullPath = join19(cwd, file.relativePath);
+    const fullPath = join21(cwd, file.relativePath);
     let content;
     try {
-      content = readFileSync16(fullPath, "utf-8");
+      content = readFileSync17(fullPath, "utf-8");
     } catch {
       continue;
     }
@@ -4977,12 +5648,12 @@ var exports_reflect2 = {};
 __export(exports_reflect2, {
   reflect: () => reflect2
 });
-import { existsSync as existsSync18 } from "fs";
+import { existsSync as existsSync23 } from "fs";
 import { dirname as dirname8 } from "path";
 function reflect2(_cwd, memoryPath, configPath3) {
   const projDir = dirname8(memoryPath);
   const mem = aggregateLearningMemoryAt(projDir);
-  if (totalEntryCount(mem) === 0 && !existsSync18(memoryPath)) {
+  if (totalEntryCount(mem) === 0 && !existsSync23(memoryPath)) {
     console.log("[mink] no learning memory found");
     return null;
   }
@@ -5380,7 +6051,7 @@ __export(exports_post_write, {
   analyzePostWrite: () => analyzePostWrite
 });
 import { relative as relative7 } from "path";
-import { readFileSync as readFileSync17 } from "fs";
+import { readFileSync as readFileSync18 } from "fs";
 function analyzePostWrite(filePath, fileContent, index) {
   if (isWriteExcluded(filePath)) {
     return {
@@ -5444,7 +6115,7 @@ async function postWrite(cwd) {
     const filePath = relative7(cwd, absolutePath);
     let fileContent = null;
     try {
-      fileContent = readFileSync17(absolutePath, "utf-8");
+      fileContent = readFileSync18(absolutePath, "utf-8");
     } catch {}
     const rawState = safeReadJson(sessionPath(cwd));
     const state = isSessionState(rawState) ? rawState : createSessionState();
@@ -5806,9 +6477,9 @@ __export(exports_self_update, {
   PACKAGE_NAME: () => PACKAGE_NAME
 });
 import { spawnSync as spawnSync2 } from "child_process";
-import { existsSync as existsSync19, readFileSync as readFileSync18 } from "fs";
+import { existsSync as existsSync24, readFileSync as readFileSync19 } from "fs";
 import { dirname as dirname9 } from "path";
-import { join as join20 } from "path";
+import { join as join22 } from "path";
 function parseSemver(input) {
   const trimmed = input.trim().replace(/^v/, "");
   if (!trimmed)
@@ -5858,8 +6529,8 @@ function getInstallInfo() {
   let dir = dirname9(selfPath);
   let packageJsonPath = null;
   for (let i = 0;i < 10; i++) {
-    const candidate = join20(dir, "package.json");
-    if (existsSync19(candidate)) {
+    const candidate = join22(dir, "package.json");
+    if (existsSync24(candidate)) {
       packageJsonPath = candidate;
       break;
     }
@@ -5873,7 +6544,7 @@ function getInstallInfo() {
   }
   let currentVersion = "0.0.0";
   try {
-    const pkg = JSON.parse(readFileSync18(packageJsonPath, "utf-8"));
+    const pkg = JSON.parse(readFileSync19(packageJsonPath, "utf-8"));
     if (typeof pkg.version === "string")
       currentVersion = pkg.version;
   } catch {}
@@ -5933,7 +6604,7 @@ function buildInstallCommand(pm, version) {
   return ["npm", "install", "-g", ref];
 }
 function selfUpdateLogPath() {
-  return join20(minkRoot(), "self-update.log");
+  return join22(minkRoot(), "self-update.log");
 }
 function appendLogEntry(entry) {
   const path = selfUpdateLogPath();
@@ -5946,7 +6617,7 @@ function appendLogEntry(entry) {
 }
 function rotateLogIfNeeded(path) {
   try {
-    const content = readFileSync18(path, "utf-8");
+    const content = readFileSync19(path, "utf-8");
     const lines = content.split(`
 `);
     if (lines.length <= LOG_MAX_LINES + 1)
@@ -6049,7 +6720,7 @@ async function runSelfUpgradeInner(opts) {
   }
   let verifiedVersion = latest;
   try {
-    const pkg = JSON.parse(readFileSync18(info.packageJsonPath, "utf-8"));
+    const pkg = JSON.parse(readFileSync19(info.packageJsonPath, "utf-8"));
     if (typeof pkg.version === "string")
       verifiedVersion = pkg.version;
   } catch {}
@@ -6155,10 +6826,10 @@ async function executeTask(taskId, projectCwd) {
       if (task.actionType === "ai-cli") {
         try {
           const { learningMemoryPath: learningMemoryPath5 } = await Promise.resolve().then(() => (init_paths(), exports_paths));
-          const { readFileSync: readFileSync19 } = await import("fs");
+          const { readFileSync: readFileSync20 } = await import("fs");
           let memoryContent;
           try {
-            memoryContent = readFileSync19(learningMemoryPath5(projectCwd), "utf-8");
+            memoryContent = readFileSync20(learningMemoryPath5(projectCwd), "utf-8");
           } catch {
             console.log("[mink] no learning memory found, skipping reflection");
             return;
@@ -6722,22 +7393,22 @@ var init_cron = __esm(() => {
 });
 
 // src/core/vault-templates.ts
-import { join as join21 } from "path";
-import { existsSync as existsSync20, writeFileSync as writeFileSync9, readFileSync as readFileSync19, mkdirSync as mkdirSync11 } from "fs";
+import { join as join23 } from "path";
+import { existsSync as existsSync25, writeFileSync as writeFileSync9, readFileSync as readFileSync20, mkdirSync as mkdirSync11 } from "fs";
 function seedTemplates(templatesDir) {
   mkdirSync11(templatesDir, { recursive: true });
   for (const [name, content] of Object.entries(DEFAULT_TEMPLATES)) {
-    const filePath = join21(templatesDir, `${name}.md`);
-    if (!existsSync20(filePath)) {
+    const filePath = join23(templatesDir, `${name}.md`);
+    if (!existsSync25(filePath)) {
       writeFileSync9(filePath, content);
     }
   }
 }
 function loadTemplate(templatesDir, templateName, vars) {
-  const filePath = join21(templatesDir, `${templateName}.md`);
+  const filePath = join23(templatesDir, `${templateName}.md`);
   let content;
-  if (existsSync20(filePath)) {
-    content = readFileSync19(filePath, "utf-8");
+  if (existsSync25(filePath)) {
+    content = readFileSync20(filePath, "utf-8");
   } else if (DEFAULT_TEMPLATES[templateName]) {
     content = DEFAULT_TEMPLATES[templateName];
   } else {
@@ -6890,33 +7561,33 @@ category: resources
 });
 
 // src/core/note-writer.ts
-import { join as join22 } from "path";
-import { existsSync as existsSync21, readFileSync as readFileSync20 } from "fs";
+import { join as join24 } from "path";
+import { existsSync as existsSync26, readFileSync as readFileSync21 } from "fs";
 import { createHash as createHash2 } from "crypto";
 function sha256(content) {
   return createHash2("sha256").update(content).digest("hex");
 }
 function resolveUniqueNotePath(dir, baseSlug, content) {
   const targetHash = sha256(content);
-  const primary = join22(dir, `${baseSlug}.md`);
-  if (!existsSync21(primary))
+  const primary = join24(dir, `${baseSlug}.md`);
+  if (!existsSync26(primary))
     return primary;
   if (sameContent(primary, targetHash))
     return primary;
   const dev4 = getOrCreateDeviceId().replace(/-/g, "").slice(0, 4);
   for (let i = 0;i < MAX_COLLISION_ATTEMPTS; i++) {
     const suffix = i === 0 ? dev4 : `${dev4}-${i + 1}`;
-    const candidate = join22(dir, `${baseSlug}-${suffix}.md`);
-    if (!existsSync21(candidate))
+    const candidate = join24(dir, `${baseSlug}-${suffix}.md`);
+    if (!existsSync26(candidate))
       return candidate;
     if (sameContent(candidate, targetHash))
       return candidate;
   }
-  return join22(dir, `${baseSlug}-${Date.now()}.md`);
+  return join24(dir, `${baseSlug}-${Date.now()}.md`);
 }
 function sameContent(filePath, expectedHash) {
   try {
-    return sha256(readFileSync20(filePath, "utf-8")) === expectedHash;
+    return sha256(readFileSync21(filePath, "utf-8")) === expectedHash;
   } catch {
     return false;
   }
@@ -6987,8 +7658,8 @@ ${meta.body}
 }
 function appendToDaily(date, content) {
   const dir = vaultDailyDir();
-  const filePath = join22(dir, `${date}.md`);
-  if (existsSync21(filePath)) {
+  const filePath = join24(dir, `${date}.md`);
+  if (existsSync26(filePath)) {
     const timestamp = new Date().toLocaleTimeString("en-US", {
       hour: "2-digit",
       minute: "2-digit",
@@ -7025,7 +7696,7 @@ ${content}
   return filePath;
 }
 function ingestFile(sourcePath, meta) {
-  const raw = readFileSync20(sourcePath, "utf-8");
+  const raw = readFileSync21(sourcePath, "utf-8");
   const now = new Date().toISOString();
   const headingMatch = raw.match(/^#\s+(.+)$/m);
   const title = headingMatch?.[1] ?? sourcePath.split("/").pop().replace(/\.md$/, "");
@@ -7097,10 +7768,10 @@ var init_design_eval = __esm(() => {
 });
 
 // src/core/dashboard-api.ts
-import { existsSync as existsSync22, readFileSync as readFileSync21 } from "fs";
-import { readdirSync as readdirSync7, readFileSync as readFileSyncFS, existsSync as fsExistsSync } from "fs";
-import { join as join23, resolve as resolve5, normalize, sep } from "path";
-import { execSync as execSync5 } from "child_process";
+import { existsSync as existsSync27, readFileSync as readFileSync22 } from "fs";
+import { readdirSync as readdirSync8, readFileSync as readFileSyncFS, existsSync as fsExistsSync } from "fs";
+import { join as join25, resolve as resolve5, normalize, sep } from "path";
+import { execSync as execSync6 } from "child_process";
 function isSecretKey(key) {
   return SECRET_KEY_PATTERNS.some((re) => re.test(key));
 }
@@ -7112,7 +7783,7 @@ function maskSecret(value, showLast = 4) {
   return "••••" + value.slice(-showLast);
 }
 function checkJsonFile2(name, filePath, validator) {
-  if (!existsSync22(filePath))
+  if (!existsSync27(filePath))
     return { name, status: "missing" };
   const data = safeReadJson(filePath);
   if (data === null)
@@ -7122,10 +7793,10 @@ function checkJsonFile2(name, filePath, validator) {
   return { name, status: "ok" };
 }
 function checkTextFile2(name, filePath) {
-  if (!existsSync22(filePath))
+  if (!existsSync27(filePath))
     return { name, status: "missing" };
   try {
-    readFileSync21(filePath, "utf-8");
+    readFileSync22(filePath, "utf-8");
     return { name, status: "ok" };
   } catch {
     return { name, status: "corrupt" };
@@ -7297,7 +7968,7 @@ function getAheadBehind(branch) {
   if (!branch)
     return { ahead: 0, behind: 0 };
   try {
-    const raw = execSync5(`git rev-list --left-right --count origin/${branch}...${branch}`, { cwd: minkRoot(), timeout: 5000, stdio: ["pipe", "pipe", "pipe"] }).toString().trim();
+    const raw = execSync6(`git rev-list --left-right --count origin/${branch}...${branch}`, { cwd: minkRoot(), timeout: 5000, stdio: ["pipe", "pipe", "pipe"] }).toString().trim();
     const [behindStr, aheadStr] = raw.split(/\s+/);
     return {
       behind: Number(behindStr) || 0,
@@ -7309,7 +7980,7 @@ function getAheadBehind(branch) {
 }
 function getPendingChanges() {
   try {
-    const raw = execSync5("git status --porcelain", {
+    const raw = execSync6("git status --porcelain", {
       cwd: minkRoot(),
       timeout: 5000,
       stdio: ["pipe", "pipe", "pipe"]
@@ -7378,10 +8049,10 @@ function loadChannelPanel() {
 function countMarkdownIn(dir) {
   let count = 0;
   try {
-    for (const entry of readdirSync7(dir, { withFileTypes: true })) {
+    for (const entry of readdirSync8(dir, { withFileTypes: true })) {
       if (WIKI_TREE_EXCLUDES.has(entry.name) || entry.name.startsWith("."))
         continue;
-      const fullPath = join23(dir, entry.name);
+      const fullPath = join25(dir, entry.name);
       if (entry.isDirectory()) {
         count += countMarkdownIn(fullPath);
       } else if (entry.name.endsWith(".md") && !entry.name.startsWith("_")) {
@@ -7398,7 +8069,7 @@ function buildVaultTree(root) {
       return;
     let entries = [];
     try {
-      entries = readdirSync7(dir, { withFileTypes: true }).filter((e) => !WIKI_TREE_EXCLUDES.has(e.name) && !e.name.startsWith(".")).map((e) => ({ name: e.name, isDir: e.isDirectory() }));
+      entries = readdirSync8(dir, { withFileTypes: true }).filter((e) => !WIKI_TREE_EXCLUDES.has(e.name) && !e.name.startsWith(".")).map((e) => ({ name: e.name, isDir: e.isDirectory() }));
     } catch {
       return;
     }
@@ -7410,7 +8081,7 @@ function buildVaultTree(root) {
     for (const entry of entries) {
       if (!entry.isDir)
         continue;
-      const fullPath = join23(dir, entry.name);
+      const fullPath = join25(dir, entry.name);
       const relPath = fullPath.slice(root.length + 1);
       const count = countMarkdownIn(fullPath);
       nodes.push({ name: entry.name, path: relPath, count, depth });
@@ -7833,7 +8504,7 @@ async function triggerIngestFile(sourcePath, category, tags, dedupKey) {
     if (!isValidCategory(category)) {
       return { success: false, error: `Invalid category: ${category}` };
     }
-    const expanded = sourcePath.startsWith("~/") ? join23(process.env.HOME ?? "", sourcePath.slice(2)) : sourcePath;
+    const expanded = sourcePath.startsWith("~/") ? join25(process.env.HOME ?? "", sourcePath.slice(2)) : sourcePath;
     if (!fsExistsSync(expanded)) {
       return { success: false, error: `Source file not found: ${sourcePath}` };
     }
@@ -7912,61 +8583,14 @@ var init_dashboard_api = __esm(() => {
   dedupCache = new Map;
 });
 
-// src/core/project-registry.ts
-import { readdirSync as readdirSync8, existsSync as existsSync23 } from "fs";
-import { join as join24 } from "path";
-function getProjectMeta(projDir) {
-  const metaPath = join24(projDir, "project-meta.json");
-  const raw = safeReadJson(metaPath);
-  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
-    return null;
-  }
-  const obj = raw;
-  if (typeof obj.cwd !== "string" || typeof obj.name !== "string") {
-    return null;
-  }
-  return {
-    cwd: obj.cwd,
-    name: obj.name,
-    initTimestamp: obj.initTimestamp ?? "",
-    version: obj.version ?? "0.1.0"
-  };
-}
-function listRegisteredProjects() {
-  const projectsDir = join24(minkRoot(), "projects");
-  if (!existsSync23(projectsDir))
-    return [];
-  const entries = readdirSync8(projectsDir, { withFileTypes: true });
-  const projects = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory())
-      continue;
-    const projDir = join24(projectsDir, entry.name);
-    const meta = getProjectMeta(projDir);
-    if (meta) {
-      projects.push({
-        id: entry.name,
-        cwd: meta.cwd,
-        name: meta.name,
-        version: meta.version
-      });
-    }
-  }
-  return projects;
-}
-var init_project_registry = __esm(() => {
-  init_paths();
-  init_fs_utils();
-});
-
 // src/core/dashboard-server.ts
 var exports_dashboard_server = {};
 __export(exports_dashboard_server, {
   startDashboardServer: () => startDashboardServer
 });
 import { watch } from "fs";
-import { existsSync as existsSync24 } from "fs";
-import { basename as basename7, dirname as dirname10, join as join25, extname as extname2 } from "path";
+import { existsSync as existsSync28 } from "fs";
+import { basename as basename7, dirname as dirname10, join as join26, extname as extname2 } from "path";
 
 class SSEManager {
   clients = new Map;
@@ -8027,18 +8651,18 @@ function resolveProjectCwd(url, defaultCwd) {
   const projectId = url.searchParams.get("project");
   if (!projectId)
     return defaultCwd;
-  if (projectId === generateProjectId(defaultCwd))
+  if (projectId === projectIdFor(defaultCwd))
     return defaultCwd;
   const projects = listRegisteredProjects();
-  const match = projects.find((p) => p.id === projectId);
+  const match = projects.find((p) => p.id === projectId) ?? projects.find((p) => p.aliases.includes(projectId));
   if (!match)
     return null;
   return match.cwd;
 }
 function getProjectsList(startupCwd, activeCwd) {
-  const activeId = generateProjectId(activeCwd);
+  const activeId = projectIdFor(activeCwd);
   const registered = listRegisteredProjects();
-  const startupId = generateProjectId(startupCwd);
+  const startupId = projectIdFor(startupCwd);
   const hasStartup = registered.some((p) => p.id === startupId);
   if (!hasStartup) {
     const meta = getProjectMeta(projectDir(startupCwd));
@@ -8046,7 +8670,9 @@ function getProjectsList(startupCwd, activeCwd) {
       id: startupId,
       cwd: startupCwd,
       name: meta?.name ?? basename7(startupCwd),
-      version: meta?.version ?? "0.1.0"
+      version: meta?.version ?? "0.1.0",
+      aliases: meta?.aliases ?? [],
+      pathsByDevice: meta?.pathsByDevice ?? {}
     });
   }
   if (activeId !== startupId) {
@@ -8057,7 +8683,9 @@ function getProjectsList(startupCwd, activeCwd) {
         id: activeId,
         cwd: activeCwd,
         name: meta?.name ?? basename7(activeCwd),
-        version: meta?.version ?? "0.1.0"
+        version: meta?.version ?? "0.1.0",
+        aliases: meta?.aliases ?? [],
+        pathsByDevice: meta?.pathsByDevice ?? {}
       });
     }
   }
@@ -8142,12 +8770,12 @@ async function startDashboardServer(cwd, options = {}) {
   const __dir = dirname10(new URL(import.meta.url).pathname);
   let pkgRoot = __dir;
   while (pkgRoot !== dirname10(pkgRoot)) {
-    if (existsSync24(join25(pkgRoot, "package.json")))
+    if (existsSync28(join26(pkgRoot, "package.json")))
       break;
     pkgRoot = dirname10(pkgRoot);
   }
-  const dashboardOutDir = join25(pkgRoot, "dashboard", "out");
-  const dashboardBuilt = existsSync24(join25(dashboardOutDir, "index.html"));
+  const dashboardOutDir = join26(pkgRoot, "dashboard", "out");
+  const dashboardBuilt = existsSync28(join26(dashboardOutDir, "index.html"));
   let clientIdCounter = 0;
   if (!dashboardBuilt) {
     console.warn("[mink] dashboard not built. Run: cd dashboard && bun run build");
@@ -8177,9 +8805,9 @@ async function startDashboardServer(cwd, options = {}) {
         } else {
           let filePath;
           if (pathname === "/") {
-            filePath = join25(dashboardOutDir, "index.html");
+            filePath = join26(dashboardOutDir, "index.html");
           } else {
-            filePath = join25(dashboardOutDir, pathname);
+            filePath = join26(dashboardOutDir, pathname);
           }
           if (!filePath.startsWith(dashboardOutDir)) {
             return jsonResponse({ error: "Forbidden" }, 403);
@@ -8192,7 +8820,7 @@ async function startDashboardServer(cwd, options = {}) {
           const htmlServed = await serveFile(filePath + ".html", "text/html; charset=utf-8");
           if (htmlServed)
             return htmlServed;
-          const indexServed = await serveFile(join25(dashboardOutDir, "index.html"), "text/html; charset=utf-8");
+          const indexServed = await serveFile(join26(dashboardOutDir, "index.html"), "text/html; charset=utf-8");
           if (indexServed)
             return indexServed;
         }
@@ -8301,7 +8929,7 @@ retry: 3000
             if (!filename || filename.includes("..") || filename.includes("/")) {
               return jsonResponse({ error: "Invalid filename" }, 400);
             }
-            const imgPath = join25(designCapturesDir(resolvedCwd), filename);
+            const imgPath = join26(designCapturesDir(resolvedCwd), filename);
             const served = await serveFile(imgPath, "image/jpeg");
             if (served) {
               served.headers.set("Cache-Control", "public, max-age=60");
@@ -8533,30 +9161,50 @@ var init_dashboard_server = __esm(() => {
 // src/commands/dashboard.ts
 var exports_dashboard = {};
 __export(exports_dashboard, {
+  resolveStartupCwd: () => resolveStartupCwd,
   dashboard: () => dashboard
 });
-import { existsSync as existsSync25 } from "fs";
+import { existsSync as existsSync29 } from "fs";
+function resolveStartupCwd(cwd, registered = listRegisteredProjects()) {
+  if (existsSync29(projectDir(cwd))) {
+    return { kind: "active", cwd };
+  }
+  if (registered.length === 0) {
+    return { kind: "none" };
+  }
+  const fallback = [...registered].sort((a, b) => a.name.localeCompare(b.name))[0];
+  return { kind: "fallback", cwd: fallback.cwd, project: fallback };
+}
 async function dashboard(cwd, args) {
-  if (!existsSync25(projectDir(cwd))) {
-    console.error("[mink] project not initialized. Run: mink init");
+  const resolution = resolveStartupCwd(cwd);
+  if (resolution.kind === "none") {
+    console.error("[mink] no mink projects found. Run `mink init` in a project first.");
     process.exit(1);
   }
+  if (resolution.kind === "fallback") {
+    console.log(`[mink] not in a mink project — starting dashboard with "${resolution.project.name}". ` + "Use the in-app project switcher to change projects.");
+  }
+  const startupCwd = resolution.cwd;
   const portArg = args.find((a) => a.startsWith("--port="));
   const port = portArg ? parseInt(portArg.split("=")[1], 10) : 4040;
   const noOpen = args.includes("--no-open");
   const { startDashboardServer: startDashboardServer2 } = await Promise.resolve().then(() => (init_dashboard_server(), exports_dashboard_server));
-  const { url } = await startDashboardServer2(cwd, { port, open: !noOpen });
+  const { url } = await startDashboardServer2(startupCwd, {
+    port,
+    open: !noOpen
+  });
   console.log(`[mink] dashboard running at ${url}`);
   console.log("[mink] press Ctrl+C to stop");
   await new Promise(() => {});
 }
 var init_dashboard = __esm(() => {
   init_paths();
+  init_project_registry();
 });
 
 // src/commands/init.ts
-import { mkdirSync as mkdirSync12, existsSync as existsSync26 } from "fs";
-import { resolve as resolve6, dirname as dirname11, basename as basename8, join as join26 } from "path";
+import { mkdirSync as mkdirSync12, existsSync as existsSync30 } from "fs";
+import { resolve as resolve6, dirname as dirname11, basename as basename8, join as join27 } from "path";
 function resolveCliPath2() {
   const selfPath = new URL(import.meta.url).pathname;
   const selfDir = dirname11(selfPath);
@@ -8564,8 +9212,8 @@ function resolveCliPath2() {
     return selfPath;
   }
   const projectRoot = resolve6(selfDir, "../..");
-  const distPath = join26(projectRoot, "dist", "cli.js");
-  if (existsSync26(distPath))
+  const distPath = join27(projectRoot, "dist", "cli.js");
+  if (existsSync30(distPath))
     return distPath;
   return resolve6(selfDir, "../cli.ts");
 }
@@ -8621,14 +9269,16 @@ var init_init2 = __esm(() => {
   init_paths();
   init_project_id();
   init_fs_utils();
+  init_device();
+  init_git_identity();
   init_vault();
 });
 
 // src/core/daemon-service.ts
-import { execSync as execSync6 } from "child_process";
-import { existsSync as existsSync27, mkdirSync as mkdirSync13, unlinkSync as unlinkSync5, writeFileSync as writeFileSync10 } from "fs";
+import { execSync as execSync7 } from "child_process";
+import { existsSync as existsSync31, mkdirSync as mkdirSync13, unlinkSync as unlinkSync5, writeFileSync as writeFileSync10 } from "fs";
 import { homedir as homedir4 } from "os";
-import { dirname as dirname12, join as join27 } from "path";
+import { dirname as dirname12, join as join28 } from "path";
 function detectPlatform() {
   if (process.platform === "linux")
     return "systemd";
@@ -8638,7 +9288,7 @@ function detectPlatform() {
 }
 function resolveServiceInvocation() {
   const entry = process.argv[1];
-  if (entry && !/\.(js|ts|mjs|cjs)$/.test(entry) && existsSync27(entry)) {
+  if (entry && !/\.(js|ts|mjs|cjs)$/.test(entry) && existsSync31(entry)) {
     return {
       executable: entry,
       args: ["daemon", "start"],
@@ -8656,11 +9306,11 @@ function resolveServiceInvocation() {
 function servicePaths(platform2) {
   const home = homedir4();
   if (platform2 === "systemd") {
-    const unitDir2 = join27(home, ".config", "systemd", "user");
-    return { unitDir: unitDir2, unitFile: join27(unitDir2, "mink-daemon.service") };
+    const unitDir2 = join28(home, ".config", "systemd", "user");
+    return { unitDir: unitDir2, unitFile: join28(unitDir2, "mink-daemon.service") };
   }
-  const unitDir = join27(home, "Library", "LaunchAgents");
-  return { unitDir, unitFile: join27(unitDir, "com.mink.daemon.plist") };
+  const unitDir = join28(home, "Library", "LaunchAgents");
+  return { unitDir, unitFile: join28(unitDir, "com.mink.daemon.plist") };
 }
 function renderSystemdUnit(inv) {
   const execStart = [inv.executable, ...inv.args].join(" ");
@@ -8734,7 +9384,7 @@ function installService(options = {}) {
     process.exit(1);
   }
   const paths = servicePaths(platform2);
-  if (existsSync27(paths.unitFile) && !options.force) {
+  if (existsSync31(paths.unitFile) && !options.force) {
     console.error(`[mink] unit file already exists: ${paths.unitFile}`);
     console.error("       re-run with --force to overwrite, or run `mink daemon uninstall` first");
     process.exit(1);
@@ -8744,7 +9394,7 @@ function installService(options = {}) {
   if (platform2 === "systemd") {
     writeFileSync10(paths.unitFile, renderSystemdUnit(inv));
     try {
-      execSync6("systemctl --user daemon-reload", { stdio: "ignore" });
+      execSync7("systemctl --user daemon-reload", { stdio: "ignore" });
     } catch {}
     console.log(`[mink] wrote ${paths.unitFile}`);
     console.log("[mink] next steps:");
@@ -8767,24 +9417,24 @@ function uninstallService() {
     process.exit(1);
   }
   const paths = servicePaths(platform2);
-  if (!existsSync27(paths.unitFile)) {
+  if (!existsSync31(paths.unitFile)) {
     console.log(`[mink] no unit file at ${paths.unitFile} — nothing to uninstall`);
     return;
   }
   if (platform2 === "systemd") {
     try {
-      execSync6("systemctl --user disable --now mink-daemon.service", {
+      execSync7("systemctl --user disable --now mink-daemon.service", {
         stdio: "ignore"
       });
     } catch {}
     unlinkSync5(paths.unitFile);
     try {
-      execSync6("systemctl --user daemon-reload", { stdio: "ignore" });
+      execSync7("systemctl --user daemon-reload", { stdio: "ignore" });
     } catch {}
     console.log(`[mink] removed ${paths.unitFile}`);
   } else {
     try {
-      execSync6(`launchctl unload -w ${paths.unitFile}`, { stdio: "ignore" });
+      execSync7(`launchctl unload -w ${paths.unitFile}`, { stdio: "ignore" });
     } catch {}
     unlinkSync5(paths.unitFile);
     console.log(`[mink] removed ${paths.unitFile}`);
@@ -8799,7 +9449,7 @@ var exports_daemon = {};
 __export(exports_daemon, {
   daemon: () => daemon
 });
-import { readFileSync as readFileSync22, existsSync as existsSync28 } from "fs";
+import { readFileSync as readFileSync23, existsSync as existsSync32 } from "fs";
 async function daemon(cwd, args) {
   const subcommand = args[0];
   switch (subcommand) {
@@ -8815,12 +9465,12 @@ async function daemon(cwd, args) {
       break;
     case "logs": {
       const logPath = schedulerLogPath();
-      if (!existsSync28(logPath)) {
+      if (!existsSync32(logPath)) {
         console.log("[mink] no log file found");
         return;
       }
       try {
-        const content = readFileSync22(logPath, "utf-8");
+        const content = readFileSync23(logPath, "utf-8");
         const lines = content.split(`
 `);
         const tail = lines.slice(-50).join(`
@@ -9401,8 +10051,8 @@ var init_restore = __esm(() => {
 });
 
 // src/core/design-eval/server-detect.ts
-import { readFileSync as readFileSync23 } from "fs";
-import { join as join28 } from "path";
+import { readFileSync as readFileSync24 } from "fs";
+import { join as join29 } from "path";
 async function probePort(port) {
   try {
     const controller = new AbortController;
@@ -9424,7 +10074,7 @@ async function findRunningServer(ports = DEFAULT_PROBE_PORTS) {
 }
 function detectDevCommand(cwd) {
   try {
-    const raw = readFileSync23(join28(cwd, "package.json"), "utf-8");
+    const raw = readFileSync24(join29(cwd, "package.json"), "utf-8");
     const pkg = JSON.parse(raw);
     const scripts = pkg.scripts;
     if (!scripts || typeof scripts !== "object")
@@ -9444,10 +10094,10 @@ var init_server_detect = __esm(() => {
 });
 
 // src/core/design-eval/route-detect.ts
-import { existsSync as existsSync29, readdirSync as readdirSync9, statSync as statSync11 } from "fs";
-import { join as join29, relative as relative8, sep as sep2 } from "path";
+import { existsSync as existsSync33, readdirSync as readdirSync9, statSync as statSync11 } from "fs";
+import { join as join30, relative as relative8, sep as sep2 } from "path";
 function detectFramework(cwd) {
-  const has = (name) => ["js", "mjs", "ts", "cjs"].some((ext) => existsSync29(join29(cwd, `${name}.${ext}`))) || existsSync29(join29(cwd, name));
+  const has = (name) => ["js", "mjs", "ts", "cjs"].some((ext) => existsSync33(join30(cwd, `${name}.${ext}`))) || existsSync33(join30(cwd, name));
   if (has("next.config"))
     return "nextjs";
   if (has("svelte.config"))
@@ -9472,8 +10122,8 @@ function detectRoutes(cwd) {
 }
 function detectNextRoutes(cwd) {
   const routes = [];
-  const appDir = join29(cwd, "app");
-  if (existsSync29(appDir)) {
+  const appDir = join30(cwd, "app");
+  if (existsSync33(appDir)) {
     const pageFiles = findFiles(appDir, /^page\.(tsx?|jsx?)$/);
     for (const file of pageFiles) {
       const rel = relative8(appDir, file);
@@ -9484,8 +10134,8 @@ function detectNextRoutes(cwd) {
       routes.push(route);
     }
   }
-  const pagesDir = join29(cwd, "pages");
-  if (existsSync29(pagesDir)) {
+  const pagesDir = join30(cwd, "pages");
+  if (existsSync33(pagesDir)) {
     const pageFiles = findFiles(pagesDir, /\.(tsx?|jsx?)$/);
     for (const file of pageFiles) {
       const rel = relative8(pagesDir, file);
@@ -9504,8 +10154,8 @@ function detectNextRoutes(cwd) {
   return unique.length > 0 ? unique.sort() : ["/"];
 }
 function detectSvelteKitRoutes(cwd) {
-  const routesDir = join29(cwd, "src", "routes");
-  if (!existsSync29(routesDir))
+  const routesDir = join30(cwd, "src", "routes");
+  if (!existsSync33(routesDir))
     return ["/"];
   const routes = [];
   const pageFiles = findFiles(routesDir, /^\+page\.svelte$/);
@@ -9520,8 +10170,8 @@ function detectSvelteKitRoutes(cwd) {
   return routes.length > 0 ? routes.sort() : ["/"];
 }
 function detectNuxtRoutes(cwd) {
-  const pagesDir = join29(cwd, "pages");
-  if (!existsSync29(pagesDir))
+  const pagesDir = join30(cwd, "pages");
+  if (!existsSync33(pagesDir))
     return ["/"];
   const routes = [];
   const vueFiles = findFiles(pagesDir, /\.vue$/);
@@ -9547,7 +10197,7 @@ function findFiles(dir, pattern) {
     for (const entry of entries) {
       if (entry.startsWith(".") || entry === "node_modules")
         continue;
-      const full = join29(current, entry);
+      const full = join30(current, entry);
       try {
         const stat2 = statSync11(full);
         if (stat2.isDirectory()) {
@@ -58251,7 +58901,7 @@ var require_util2 = __commonJS((exports) => {
     return path;
   }
   exports.normalize = normalize2;
-  function join30(aRoot, aPath) {
+  function join31(aRoot, aPath) {
     if (aRoot === "") {
       aRoot = ".";
     }
@@ -58283,7 +58933,7 @@ var require_util2 = __commonJS((exports) => {
     }
     return joined;
   }
-  exports.join = join30;
+  exports.join = join31;
   exports.isAbsolute = function(aPath) {
     return aPath.charAt(0) === "/" || urlRegexp.test(aPath);
   };
@@ -58456,7 +59106,7 @@ var require_util2 = __commonJS((exports) => {
           parsed.path = parsed.path.substring(0, index + 1);
         }
       }
-      sourceURL = join30(urlGenerate(parsed), sourceURL);
+      sourceURL = join31(urlGenerate(parsed), sourceURL);
     }
     return normalize2(sourceURL);
   }
@@ -60188,7 +60838,7 @@ var require_escodegen = __commonJS((exports) => {
     function noEmptySpace() {
       return space ? space : " ";
     }
-    function join30(left, right) {
+    function join31(left, right) {
       var leftSource, rightSource, leftCharCode, rightCharCode;
       leftSource = toSourceNodeWhenNeeded(left).toString();
       if (leftSource.length === 0) {
@@ -60529,8 +61179,8 @@ var require_escodegen = __commonJS((exports) => {
         } else {
           result.push(that.generateExpression(stmt.left, Precedence.Call, E_TTT));
         }
-        result = join30(result, operator);
-        result = [join30(result, that.generateExpression(stmt.right, Precedence.Assignment, E_TTT)), ")"];
+        result = join31(result, operator);
+        result = [join31(result, that.generateExpression(stmt.right, Precedence.Assignment, E_TTT)), ")"];
       });
       result.push(this.maybeBlock(stmt.body, flags));
       return result;
@@ -60668,11 +61318,11 @@ var require_escodegen = __commonJS((exports) => {
         var result, fragment;
         result = ["class"];
         if (stmt.id) {
-          result = join30(result, this.generateExpression(stmt.id, Precedence.Sequence, E_TTT));
+          result = join31(result, this.generateExpression(stmt.id, Precedence.Sequence, E_TTT));
         }
         if (stmt.superClass) {
-          fragment = join30("extends", this.generateExpression(stmt.superClass, Precedence.Unary, E_TTT));
-          result = join30(result, fragment);
+          fragment = join31("extends", this.generateExpression(stmt.superClass, Precedence.Unary, E_TTT));
+          result = join31(result, fragment);
         }
         result.push(space);
         result.push(this.generateStatement(stmt.body, S_TFFT));
@@ -60685,9 +61335,9 @@ var require_escodegen = __commonJS((exports) => {
         return escapeDirective(stmt.directive) + this.semicolon(flags);
       },
       DoWhileStatement: function(stmt, flags) {
-        var result = join30("do", this.maybeBlock(stmt.body, S_TFFF));
+        var result = join31("do", this.maybeBlock(stmt.body, S_TFFF));
         result = this.maybeBlockSuffix(stmt.body, result);
-        return join30(result, [
+        return join31(result, [
           "while" + space + "(",
           this.generateExpression(stmt.test, Precedence.Sequence, E_TTT),
           ")" + this.semicolon(flags)
@@ -60723,11 +61373,11 @@ var require_escodegen = __commonJS((exports) => {
       ExportDefaultDeclaration: function(stmt, flags) {
         var result = ["export"], bodyFlags;
         bodyFlags = flags & F_SEMICOLON_OPT ? S_TFFT : S_TFFF;
-        result = join30(result, "default");
+        result = join31(result, "default");
         if (isStatement(stmt.declaration)) {
-          result = join30(result, this.generateStatement(stmt.declaration, bodyFlags));
+          result = join31(result, this.generateStatement(stmt.declaration, bodyFlags));
         } else {
-          result = join30(result, this.generateExpression(stmt.declaration, Precedence.Assignment, E_TTT) + this.semicolon(flags));
+          result = join31(result, this.generateExpression(stmt.declaration, Precedence.Assignment, E_TTT) + this.semicolon(flags));
         }
         return result;
       },
@@ -60735,15 +61385,15 @@ var require_escodegen = __commonJS((exports) => {
         var result = ["export"], bodyFlags, that = this;
         bodyFlags = flags & F_SEMICOLON_OPT ? S_TFFT : S_TFFF;
         if (stmt.declaration) {
-          return join30(result, this.generateStatement(stmt.declaration, bodyFlags));
+          return join31(result, this.generateStatement(stmt.declaration, bodyFlags));
         }
         if (stmt.specifiers) {
           if (stmt.specifiers.length === 0) {
-            result = join30(result, "{" + space + "}");
+            result = join31(result, "{" + space + "}");
           } else if (stmt.specifiers[0].type === Syntax.ExportBatchSpecifier) {
-            result = join30(result, this.generateExpression(stmt.specifiers[0], Precedence.Sequence, E_TTT));
+            result = join31(result, this.generateExpression(stmt.specifiers[0], Precedence.Sequence, E_TTT));
           } else {
-            result = join30(result, "{");
+            result = join31(result, "{");
             withIndent(function(indent2) {
               var i, iz;
               result.push(newline);
@@ -60761,7 +61411,7 @@ var require_escodegen = __commonJS((exports) => {
             result.push(base + "}");
           }
           if (stmt.source) {
-            result = join30(result, [
+            result = join31(result, [
               "from" + space,
               this.generateExpression(stmt.source, Precedence.Sequence, E_TTT),
               this.semicolon(flags)
@@ -60845,7 +61495,7 @@ var require_escodegen = __commonJS((exports) => {
         ];
         cursor = 0;
         if (stmt.specifiers[cursor].type === Syntax.ImportDefaultSpecifier) {
-          result = join30(result, [
+          result = join31(result, [
             this.generateExpression(stmt.specifiers[cursor], Precedence.Sequence, E_TTT)
           ]);
           ++cursor;
@@ -60855,7 +61505,7 @@ var require_escodegen = __commonJS((exports) => {
             result.push(",");
           }
           if (stmt.specifiers[cursor].type === Syntax.ImportNamespaceSpecifier) {
-            result = join30(result, [
+            result = join31(result, [
               space,
               this.generateExpression(stmt.specifiers[cursor], Precedence.Sequence, E_TTT)
             ]);
@@ -60884,7 +61534,7 @@ var require_escodegen = __commonJS((exports) => {
             }
           }
         }
-        result = join30(result, [
+        result = join31(result, [
           "from" + space,
           this.generateExpression(stmt.source, Precedence.Sequence, E_TTT),
           this.semicolon(flags)
@@ -60938,7 +61588,7 @@ var require_escodegen = __commonJS((exports) => {
         return result;
       },
       ThrowStatement: function(stmt, flags) {
-        return [join30("throw", this.generateExpression(stmt.argument, Precedence.Sequence, E_TTT)), this.semicolon(flags)];
+        return [join31("throw", this.generateExpression(stmt.argument, Precedence.Sequence, E_TTT)), this.semicolon(flags)];
       },
       TryStatement: function(stmt, flags) {
         var result, i, iz, guardedHandlers;
@@ -60946,7 +61596,7 @@ var require_escodegen = __commonJS((exports) => {
         result = this.maybeBlockSuffix(stmt.block, result);
         if (stmt.handlers) {
           for (i = 0, iz = stmt.handlers.length;i < iz; ++i) {
-            result = join30(result, this.generateStatement(stmt.handlers[i], S_TFFF));
+            result = join31(result, this.generateStatement(stmt.handlers[i], S_TFFF));
             if (stmt.finalizer || i + 1 !== iz) {
               result = this.maybeBlockSuffix(stmt.handlers[i].body, result);
             }
@@ -60954,7 +61604,7 @@ var require_escodegen = __commonJS((exports) => {
         } else {
           guardedHandlers = stmt.guardedHandlers || [];
           for (i = 0, iz = guardedHandlers.length;i < iz; ++i) {
-            result = join30(result, this.generateStatement(guardedHandlers[i], S_TFFF));
+            result = join31(result, this.generateStatement(guardedHandlers[i], S_TFFF));
             if (stmt.finalizer || i + 1 !== iz) {
               result = this.maybeBlockSuffix(guardedHandlers[i].body, result);
             }
@@ -60962,13 +61612,13 @@ var require_escodegen = __commonJS((exports) => {
           if (stmt.handler) {
             if (Array.isArray(stmt.handler)) {
               for (i = 0, iz = stmt.handler.length;i < iz; ++i) {
-                result = join30(result, this.generateStatement(stmt.handler[i], S_TFFF));
+                result = join31(result, this.generateStatement(stmt.handler[i], S_TFFF));
                 if (stmt.finalizer || i + 1 !== iz) {
                   result = this.maybeBlockSuffix(stmt.handler[i].body, result);
                 }
               }
             } else {
-              result = join30(result, this.generateStatement(stmt.handler, S_TFFF));
+              result = join31(result, this.generateStatement(stmt.handler, S_TFFF));
               if (stmt.finalizer) {
                 result = this.maybeBlockSuffix(stmt.handler.body, result);
               }
@@ -60976,7 +61626,7 @@ var require_escodegen = __commonJS((exports) => {
           }
         }
         if (stmt.finalizer) {
-          result = join30(result, ["finally", this.maybeBlock(stmt.finalizer, S_TFFF)]);
+          result = join31(result, ["finally", this.maybeBlock(stmt.finalizer, S_TFFF)]);
         }
         return result;
       },
@@ -61010,7 +61660,7 @@ var require_escodegen = __commonJS((exports) => {
         withIndent(function() {
           if (stmt.test) {
             result = [
-              join30("case", that.generateExpression(stmt.test, Precedence.Sequence, E_TTT)),
+              join31("case", that.generateExpression(stmt.test, Precedence.Sequence, E_TTT)),
               ":"
             ];
           } else {
@@ -61058,9 +61708,9 @@ var require_escodegen = __commonJS((exports) => {
           result.push(this.maybeBlock(stmt.consequent, S_TFFF));
           result = this.maybeBlockSuffix(stmt.consequent, result);
           if (stmt.alternate.type === Syntax.IfStatement) {
-            result = join30(result, ["else ", this.generateStatement(stmt.alternate, bodyFlags)]);
+            result = join31(result, ["else ", this.generateStatement(stmt.alternate, bodyFlags)]);
           } else {
-            result = join30(result, join30("else", this.maybeBlock(stmt.alternate, bodyFlags)));
+            result = join31(result, join31("else", this.maybeBlock(stmt.alternate, bodyFlags)));
           }
         } else {
           result.push(this.maybeBlock(stmt.consequent, bodyFlags));
@@ -61162,7 +61812,7 @@ var require_escodegen = __commonJS((exports) => {
       },
       ReturnStatement: function(stmt, flags) {
         if (stmt.argument) {
-          return [join30("return", this.generateExpression(stmt.argument, Precedence.Sequence, E_TTT)), this.semicolon(flags)];
+          return [join31("return", this.generateExpression(stmt.argument, Precedence.Sequence, E_TTT)), this.semicolon(flags)];
         }
         return ["return" + this.semicolon(flags)];
       },
@@ -61244,14 +61894,14 @@ var require_escodegen = __commonJS((exports) => {
         if (leftSource.charCodeAt(leftSource.length - 1) === 47 && esutils.code.isIdentifierPartES5(expr.operator.charCodeAt(0))) {
           result = [fragment, noEmptySpace(), expr.operator];
         } else {
-          result = join30(fragment, expr.operator);
+          result = join31(fragment, expr.operator);
         }
         fragment = this.generateExpression(expr.right, rightPrecedence, flags);
         if (expr.operator === "/" && fragment.toString().charAt(0) === "/" || expr.operator.slice(-1) === "<" && fragment.toString().slice(0, 3) === "!--") {
           result.push(noEmptySpace());
           result.push(fragment);
         } else {
-          result = join30(result, fragment);
+          result = join31(result, fragment);
         }
         if (expr.operator === "in" && !(flags & F_ALLOW_IN)) {
           return ["(", result, ")"];
@@ -61291,7 +61941,7 @@ var require_escodegen = __commonJS((exports) => {
         var result, length, i, iz, itemFlags;
         length = expr["arguments"].length;
         itemFlags = flags & F_ALLOW_UNPARATH_NEW && !parentheses && length === 0 ? E_TFT : E_TFF;
-        result = join30("new", this.generateExpression(expr.callee, Precedence.New, itemFlags));
+        result = join31("new", this.generateExpression(expr.callee, Precedence.New, itemFlags));
         if (!(flags & F_ALLOW_UNPARATH_NEW) || parentheses || length > 0) {
           result.push("(");
           for (i = 0, iz = length;i < iz; ++i) {
@@ -61338,11 +61988,11 @@ var require_escodegen = __commonJS((exports) => {
         var result, fragment, rightCharCode, leftSource, leftCharCode;
         fragment = this.generateExpression(expr.argument, Precedence.Unary, E_TTT);
         if (space === "") {
-          result = join30(expr.operator, fragment);
+          result = join31(expr.operator, fragment);
         } else {
           result = [expr.operator];
           if (expr.operator.length > 2) {
-            result = join30(result, fragment);
+            result = join31(result, fragment);
           } else {
             leftSource = toSourceNodeWhenNeeded(result).toString();
             leftCharCode = leftSource.charCodeAt(leftSource.length - 1);
@@ -61365,12 +62015,12 @@ var require_escodegen = __commonJS((exports) => {
           result = "yield";
         }
         if (expr.argument) {
-          result = join30(result, this.generateExpression(expr.argument, Precedence.Yield, E_TTT));
+          result = join31(result, this.generateExpression(expr.argument, Precedence.Yield, E_TTT));
         }
         return parenthesize(result, Precedence.Yield, precedence);
       },
       AwaitExpression: function(expr, precedence, flags) {
-        var result = join30(expr.all ? "await*" : "await", this.generateExpression(expr.argument, Precedence.Await, E_TTT));
+        var result = join31(expr.all ? "await*" : "await", this.generateExpression(expr.argument, Precedence.Await, E_TTT));
         return parenthesize(result, Precedence.Await, precedence);
       },
       UpdateExpression: function(expr, precedence, flags) {
@@ -61442,11 +62092,11 @@ var require_escodegen = __commonJS((exports) => {
         var result, fragment;
         result = ["class"];
         if (expr.id) {
-          result = join30(result, this.generateExpression(expr.id, Precedence.Sequence, E_TTT));
+          result = join31(result, this.generateExpression(expr.id, Precedence.Sequence, E_TTT));
         }
         if (expr.superClass) {
-          fragment = join30("extends", this.generateExpression(expr.superClass, Precedence.Unary, E_TTT));
-          result = join30(result, fragment);
+          fragment = join31("extends", this.generateExpression(expr.superClass, Precedence.Unary, E_TTT));
+          result = join31(result, fragment);
         }
         result.push(space);
         result.push(this.generateStatement(expr.body, S_TFFT));
@@ -61461,7 +62111,7 @@ var require_escodegen = __commonJS((exports) => {
         }
         if (expr.kind === "get" || expr.kind === "set") {
           fragment = [
-            join30(expr.kind, this.generatePropertyKey(expr.key, expr.computed)),
+            join31(expr.kind, this.generatePropertyKey(expr.key, expr.computed)),
             this.generateFunctionBody(expr.value)
           ];
         } else {
@@ -61471,7 +62121,7 @@ var require_escodegen = __commonJS((exports) => {
             this.generateFunctionBody(expr.value)
           ];
         }
-        return join30(result, fragment);
+        return join31(result, fragment);
       },
       Property: function(expr, precedence, flags) {
         if (expr.kind === "get" || expr.kind === "set") {
@@ -61665,7 +62315,7 @@ var require_escodegen = __commonJS((exports) => {
             for (i = 0, iz = expr.blocks.length;i < iz; ++i) {
               fragment = that.generateExpression(expr.blocks[i], Precedence.Sequence, E_TTT);
               if (i > 0 || extra.moz.comprehensionExpressionStartsWithAssignment) {
-                result = join30(result, fragment);
+                result = join31(result, fragment);
               } else {
                 result.push(fragment);
               }
@@ -61673,13 +62323,13 @@ var require_escodegen = __commonJS((exports) => {
           });
         }
         if (expr.filter) {
-          result = join30(result, "if" + space);
+          result = join31(result, "if" + space);
           fragment = this.generateExpression(expr.filter, Precedence.Sequence, E_TTT);
-          result = join30(result, ["(", fragment, ")"]);
+          result = join31(result, ["(", fragment, ")"]);
         }
         if (!extra.moz.comprehensionExpressionStartsWithAssignment) {
           fragment = this.generateExpression(expr.body, Precedence.Assignment, E_TTT);
-          result = join30(result, fragment);
+          result = join31(result, fragment);
         }
         result.push(expr.type === Syntax.GeneratorExpression ? ")" : "]");
         return result;
@@ -61695,8 +62345,8 @@ var require_escodegen = __commonJS((exports) => {
         } else {
           fragment = this.generateExpression(expr.left, Precedence.Call, E_TTT);
         }
-        fragment = join30(fragment, expr.of ? "of" : "in");
-        fragment = join30(fragment, this.generateExpression(expr.right, Precedence.Sequence, E_TTT));
+        fragment = join31(fragment, expr.of ? "of" : "in");
+        fragment = join31(fragment, this.generateExpression(expr.right, Precedence.Sequence, E_TTT));
         return ["for" + space + "(", fragment, ")"];
       },
       SpreadElement: function(expr, precedence, flags) {
@@ -73952,7 +74602,7 @@ var require_ffi_WASM_RELEASE_SYNC = __commonJS((exports) => {
 
 // node_modules/@tootallnate/quickjs-emscripten/dist/generated/emscripten-module.WASM_RELEASE_SYNC.js
 var require_emscripten_module_WASM_RELEASE_SYNC = __commonJS((exports, module) => {
-  var __dirname = "/Users/drewpayment/dev/mink/node_modules/@tootallnate/quickjs-emscripten/dist/generated", __filename = "/Users/drewpayment/dev/mink/node_modules/@tootallnate/quickjs-emscripten/dist/generated/emscripten-module.WASM_RELEASE_SYNC.js";
+  var __dirname = "/Users/drewpayment/dev/mink/.claude/worktrees/dashboard-run-anywhere/node_modules/@tootallnate/quickjs-emscripten/dist/generated", __filename = "/Users/drewpayment/dev/mink/.claude/worktrees/dashboard-run-anywhere/node_modules/@tootallnate/quickjs-emscripten/dist/generated/emscripten-module.WASM_RELEASE_SYNC.js";
   var QuickJSRaw = (() => {
     var _scriptDir = typeof document !== "undefined" && document.currentScript ? document.currentScript.src : undefined;
     if (typeof __filename !== "undefined")
@@ -75401,7 +76051,7 @@ var init_httpUtil = __esm(() => {
 });
 
 // node_modules/@puppeteer/browsers/lib/esm/browser-data/chrome.js
-import { execSync as execSync7 } from "node:child_process";
+import { execSync as execSync8 } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 function folder(platform2) {
@@ -75491,7 +76141,7 @@ function getChromeWindowsLocation(channel2, locationsPrefixes) {
 }
 function getWslVariable(variable) {
   try {
-    const result = execSync7(`cmd.exe /c echo %${variable.toLocaleUpperCase()}%`, {
+    const result = execSync8(`cmd.exe /c echo %${variable.toLocaleUpperCase()}%`, {
       stdio: ["ignore", "pipe", "ignore"],
       encoding: "utf-8"
     }).trim();
@@ -75502,7 +76152,7 @@ function getWslVariable(variable) {
   return;
 }
 function getWslLocation(channel2) {
-  const wslVersion = execSync7("wslinfo --version", {
+  const wslVersion = execSync8("wslinfo --version", {
     stdio: ["ignore", "pipe", "ignore"],
     encoding: "utf-8"
   }).trim();
@@ -75518,7 +76168,7 @@ function getWslLocation(channel2) {
   }
   const windowsPath = getChromeWindowsLocation(channel2, wslPrefixes);
   return windowsPath.map((path2) => {
-    return execSync7(`wslpath "${path2}"`).toString().trim();
+    return execSync8(`wslpath "${path2}"`).toString().trim();
   });
 }
 function getChromeLinuxOrWslLocation(channel2) {
@@ -81793,7 +82443,7 @@ var init_fileUtil = __esm(() => {
 // node_modules/@puppeteer/browsers/lib/esm/install.js
 import assert2 from "node:assert";
 import { spawnSync as spawnSync4 } from "node:child_process";
-import { existsSync as existsSync30, readFileSync as readFileSync24 } from "node:fs";
+import { existsSync as existsSync34, readFileSync as readFileSync25 } from "node:fs";
 import { mkdir as mkdir2, unlink } from "node:fs/promises";
 import os5 from "node:os";
 import path8 from "node:path";
@@ -81846,7 +82496,7 @@ async function installWithProviders(options) {
         continue;
       }
       debugInstall(`Successfully got URL from ${provider.getName()}: ${url}`);
-      if (!existsSync30(browserRoot)) {
+      if (!existsSync34(browserRoot)) {
         await mkdir2(browserRoot, { recursive: true });
       }
       return await installUrl(url, options, provider);
@@ -81879,11 +82529,11 @@ async function installDeps(installedBrowser) {
     return;
   }
   const depsPath = path8.join(path8.dirname(installedBrowser.executablePath), "deb.deps");
-  if (!existsSync30(depsPath)) {
+  if (!existsSync34(depsPath)) {
     debugInstall(`deb.deps file was not found at ${depsPath}`);
     return;
   }
-  const data = readFileSync24(depsPath, "utf-8").split(`
+  const data = readFileSync25(depsPath, "utf-8").split(`
 `).join(",");
   if (process.getuid?.() !== 0) {
     throw new Error("Installing system dependencies requires root privileges");
@@ -81921,11 +82571,11 @@ async function installUrl(url, options, provider) {
   const cache = new Cache(options.cacheDir);
   const browserRoot = cache.browserRoot(options.browser);
   const archivePath = path8.join(browserRoot, `${options.buildId}-${fileName}`);
-  if (!existsSync30(browserRoot)) {
+  if (!existsSync34(browserRoot)) {
     await mkdir2(browserRoot, { recursive: true });
   }
   if (!options.unpack) {
-    if (existsSync30(archivePath)) {
+    if (existsSync34(archivePath)) {
       return archivePath;
     }
     debugInstall(`Downloading binary from ${url}`);
@@ -81946,8 +82596,8 @@ async function installUrl(url, options, provider) {
     cache.writeExecutablePath(options.browser, options.platform, options.buildId, relativeExecutablePath6);
   }
   try {
-    if (existsSync30(outputPath)) {
-      if (!existsSync30(installedBrowser.executablePath)) {
+    if (existsSync34(outputPath)) {
+      if (!existsSync34(installedBrowser.executablePath)) {
         throw new Error(`The browser folder (${outputPath}) exists but the executable (${installedBrowser.executablePath}) is missing`);
       }
       await runSetup(installedBrowser);
@@ -81956,7 +82606,7 @@ async function installUrl(url, options, provider) {
       }
       return installedBrowser;
     }
-    if (!existsSync30(archivePath)) {
+    if (!existsSync34(archivePath)) {
       debugInstall(`Downloading binary from ${url}`);
       try {
         debugTime("download");
@@ -81985,7 +82635,7 @@ async function installUrl(url, options, provider) {
     }
     return installedBrowser;
   } finally {
-    if (existsSync30(archivePath)) {
+    if (existsSync34(archivePath)) {
       await unlink(archivePath);
     }
   }
@@ -81996,7 +82646,7 @@ async function runSetup(installedBrowser) {
       debugTime("permissions");
       const browserDir = path8.dirname(installedBrowser.executablePath);
       const setupExePath = path8.join(browserDir, "setup.exe");
-      if (!existsSync30(setupExePath)) {
+      if (!existsSync34(setupExePath)) {
         return;
       }
       spawnSync4(path8.join(browserDir, "setup.exe"), [`--configure-browser-in-directory=` + browserDir], {
@@ -83362,8 +84012,7 @@ var init_lib2 = __esm(() => {
     require: (path9) => {
       if (true) {
         return __require(path9);
-      } else
-        ;
+      }
     }
   });
   yargsParser.detailed = function(args, opts) {
@@ -83409,14 +84058,14 @@ var init_yerror = __esm(() => {
 });
 
 // node_modules/y18n/build/lib/platform-shims/node.js
-import { readFileSync as readFileSync25, statSync as statSync13, writeFile } from "fs";
+import { readFileSync as readFileSync26, statSync as statSync13, writeFile } from "fs";
 import { format as format2 } from "util";
 import { resolve as resolve12 } from "path";
 var node_default;
 var init_node = __esm(() => {
   node_default = {
     fs: {
-      readFileSync: readFileSync25,
+      readFileSync: readFileSync26,
       writeFile
     },
     format: format2,
@@ -83601,7 +84250,7 @@ var init_y18n = __esm(() => {
 // node_modules/yargs/lib/platform-shims/esm.mjs
 import { notStrictEqual, strictEqual } from "assert";
 import { inspect } from "util";
-import { readFileSync as readFileSync26 } from "fs";
+import { readFileSync as readFileSync27 } from "fs";
 import { fileURLToPath } from "url";
 import { basename as basename9, dirname as dirname14, extname as extname3, relative as relative9, resolve as resolve13 } from "path";
 var REQUIRE_ERROR = "require is not supported by ESM", REQUIRE_DIRECTORY_ERROR = "loading a directory of commands is not supported yet for ESM", __dirname2, mainFilename, esm_default;
@@ -83650,7 +84299,7 @@ var init_esm = __esm(() => {
       nextTick: process.nextTick,
       stdColumns: typeof process.stdout.columns !== "undefined" ? process.stdout.columns : null
     },
-    readFileSync: readFileSync26,
+    readFileSync: readFileSync27,
     require: () => {
       throw new YError(REQUIRE_ERROR);
     },
@@ -87349,9 +87998,9 @@ async function getConnectionTransport(options) {
       throw new Error("Could not detect required browser platform");
     }
     const { convertPuppeteerChannelToBrowsersChannel: convertPuppeteerChannelToBrowsersChannel2 } = await Promise.resolve().then(() => (init_LaunchOptions(), exports_LaunchOptions));
-    const { join: join31 } = await import("node:path");
+    const { join: join32 } = await import("node:path");
     const userDataDir = resolveDefaultUserDataDir3(Browser7.CHROME, platform2, convertPuppeteerChannelToBrowsersChannel2(options.channel));
-    const portPath = join31(userDataDir, "DevToolsActivePort");
+    const portPath = join32(userDataDir, "DevToolsActivePort");
     try {
       const fileContent = await environment.value.fs.promises.readFile(portPath, "ascii");
       const [rawPort, rawPath] = fileContent.split(`
@@ -87575,9 +88224,9 @@ var init_PipeTransport = __esm(() => {
 });
 
 // node_modules/puppeteer-core/lib/esm/puppeteer/node/BrowserLauncher.js
-import { existsSync as existsSync31 } from "node:fs";
+import { existsSync as existsSync35 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join as join31 } from "node:path";
+import { join as join32 } from "node:path";
 
 class BrowserLauncher {
   #browser;
@@ -87602,7 +88251,7 @@ class BrowserLauncher {
       ...options,
       protocol
     });
-    if (!existsSync31(launchArgs.executablePath)) {
+    if (!existsSync35(launchArgs.executablePath)) {
       throw new Error(`Browser was not found at the configured executablePath (${launchArgs.executablePath})`);
     }
     const usePipe = launchArgs.args.includes("--remote-debugging-pipe");
@@ -87677,7 +88326,7 @@ class BrowserLauncher {
       browserCloseCallback();
       const logs = browserProcess.getRecentLogs().join(`
 `);
-      if (logs.includes("Failed to create a ProcessSingleton for your profile directory") || process.platform === "win32" && existsSync31(join31(launchArgs.userDataDir, "lockfile"))) {
+      if (logs.includes("Failed to create a ProcessSingleton for your profile directory") || process.platform === "win32" && existsSync35(join32(launchArgs.userDataDir, "lockfile"))) {
         throw new Error(`The browser is already running for ${launchArgs.userDataDir}. Use a different \`userDataDir\` or stop the running browser first.`);
       }
       if (logs.includes("Missing X server") && options.headless === false) {
@@ -87767,12 +88416,12 @@ class BrowserLauncher {
     });
   }
   getProfilePath() {
-    return join31(this.puppeteer.configuration.temporaryDirectory ?? tmpdir(), `puppeteer_dev_${this.browser}_profile-`);
+    return join32(this.puppeteer.configuration.temporaryDirectory ?? tmpdir(), `puppeteer_dev_${this.browser}_profile-`);
   }
   resolveExecutablePath(headless, validatePath = true) {
     let executablePath = this.puppeteer.configuration.executablePath;
     if (executablePath) {
-      if (validatePath && !existsSync31(executablePath)) {
+      if (validatePath && !existsSync35(executablePath)) {
         throw new Error(`Tried to find the browser at the configured path (${executablePath}), but no executable was found.`);
       }
       return executablePath;
@@ -87795,7 +88444,7 @@ class BrowserLauncher {
       browser: browserType,
       buildId: this.puppeteer.browserVersion
     });
-    if (validatePath && !existsSync31(executablePath)) {
+    if (validatePath && !existsSync35(executablePath)) {
       const configVersion = this.puppeteer.configuration?.[this.browser]?.version;
       if (configVersion) {
         throw new Error(`Tried to find the browser at the configured path (${executablePath}) for version ${configVersion}, but no executable was found.`);
@@ -88610,17 +89259,17 @@ var init_puppeteer_core = __esm(() => {
 });
 
 // src/core/design-eval/capture.ts
-import { mkdirSync as mkdirSync14, statSync as statSync14, existsSync as existsSync32 } from "fs";
-import { join as join32 } from "path";
+import { mkdirSync as mkdirSync14, statSync as statSync14, existsSync as existsSync36 } from "fs";
+import { join as join33 } from "path";
 function findBrowser() {
   const platform2 = process.platform;
   const paths = CHROME_PATHS[platform2] ?? [];
   for (const p of paths) {
-    if (existsSync32(p))
+    if (existsSync36(p))
       return p;
   }
-  const minkBrowsers = join32(minkRoot(), "browsers");
-  if (existsSync32(minkBrowsers)) {
+  const minkBrowsers = join33(minkRoot(), "browsers");
+  if (existsSync36(minkBrowsers)) {
     const found = findChromeInDir(minkBrowsers);
     if (found)
       return found;
@@ -88641,7 +89290,7 @@ function findChromeInDir(dir) {
   try {
     const entries = readdirSync11(dir);
     for (const entry of entries) {
-      const full = join32(dir, entry);
+      const full = join33(dir, entry);
       try {
         const stat2 = statSync15(full);
         if (stat2.isDirectory()) {
@@ -88689,7 +89338,7 @@ async function captureRoute(page, route, baseUrl, viewport, options) {
     const y = section * viewport.height;
     const clipHeight = Math.min(viewport.height, pageHeight - y);
     const fileName = `${prefix}-${viewport.name}-${section}.jpg`;
-    const filePath = join32(options.outputDir, fileName);
+    const filePath = join33(options.outputDir, fileName);
     await page.screenshot({
       path: filePath,
       type: "jpeg",
@@ -90153,7 +90802,7 @@ var exports_wiki = {};
 __export(exports_wiki, {
   wiki: () => wiki
 });
-import { existsSync as existsSync33, statSync as statSync15 } from "fs";
+import { existsSync as existsSync37, statSync as statSync15 } from "fs";
 import { resolve as resolve14 } from "path";
 import { homedir as homedir5 } from "os";
 async function wiki(_cwd, args) {
@@ -90211,7 +90860,7 @@ async function wikiInit(args) {
     console.log(`[mink] initializing vault at ${targetPath}`);
     console.log("  (set a custom path with: mink wiki init /path/to/vault)");
   }
-  const isExisting = existsSync33(targetPath) && statSync15(targetPath).isDirectory();
+  const isExisting = existsSync37(targetPath) && statSync15(targetPath).isDirectory();
   setConfigValue("wiki.path", targetPath);
   ensureVaultStructure();
   seedTemplates(vaultTemplates());
@@ -90440,7 +91089,7 @@ __export(exports_note, {
   note: () => note
 });
 import { resolve as resolve15 } from "path";
-import { existsSync as existsSync34, readFileSync as readFileSync27 } from "fs";
+import { existsSync as existsSync38, readFileSync as readFileSync28 } from "fs";
 async function note(cwd, args) {
   if (!isWikiEnabled()) {
     console.error("[mink] wiki feature is disabled");
@@ -90465,13 +91114,13 @@ async function note(cwd, args) {
     const date = new Date().toISOString().split("T")[0];
     const content = parsed.positional || parsed.body || "";
     const filePath = appendToDaily(date, content);
-    updateVaultIndexForFile(filePath, readFileSync27(filePath, "utf-8"));
+    updateVaultIndexForFile(filePath, readFileSync28(filePath, "utf-8"));
     console.log(`[mink] daily note: ${filePath}`);
     return;
   }
   if (parsed.file) {
     const sourcePath = resolve15(cwd, parsed.file);
-    if (!existsSync34(sourcePath)) {
+    if (!existsSync38(sourcePath)) {
       console.error(`[mink] file not found: ${sourcePath}`);
       process.exit(1);
     }
@@ -90553,7 +91202,7 @@ function detectSourceProject(cwd) {
     const vaultPath = resolveVaultPath();
     if (cwd.startsWith(vaultPath))
       return;
-    return generateProjectId(cwd);
+    return projectIdFor(cwd);
   } catch {
     return;
   }
@@ -90632,23 +91281,23 @@ var exports_skill = {};
 __export(exports_skill, {
   skill: () => skill
 });
-import { join as join33, resolve as resolve16, dirname as dirname16 } from "path";
+import { join as join34, resolve as resolve16, dirname as dirname16 } from "path";
 import { homedir as homedir6 } from "os";
 import {
-  existsSync as existsSync35,
+  existsSync as existsSync39,
   mkdirSync as mkdirSync15,
   copyFileSync,
   unlinkSync as unlinkSync6,
   readdirSync as readdirSync11,
-  rmSync,
+  rmSync as rmSync2,
   symlinkSync as symlinkSync2,
   lstatSync as lstatSync2
 } from "fs";
 function getSkillsSourceDir() {
   let dir = dirname16(new URL(import.meta.url).pathname);
   while (true) {
-    if (existsSync35(join33(dir, "package.json")) && existsSync35(join33(dir, "skills"))) {
-      return join33(dir, "skills");
+    if (existsSync39(join34(dir, "package.json")) && existsSync39(join34(dir, "skills"))) {
+      return join34(dir, "skills");
     }
     const parent = dirname16(dir);
     if (parent === dir)
@@ -90659,12 +91308,12 @@ function getSkillsSourceDir() {
 }
 function getAvailableSkills() {
   const dir = getSkillsSourceDir();
-  if (!existsSync35(dir))
+  if (!existsSync39(dir))
     return [];
-  return readdirSync11(dir, { withFileTypes: true }).filter((d) => d.isDirectory() && existsSync35(join33(dir, d.name, "SKILL.md"))).map((d) => d.name);
+  return readdirSync11(dir, { withFileTypes: true }).filter((d) => d.isDirectory() && existsSync39(join34(dir, d.name, "SKILL.md"))).map((d) => d.name);
 }
 function isInstalled(skillName) {
-  return existsSync35(join33(AGENTS_SKILLS_DIR, skillName, "SKILL.md"));
+  return existsSync39(join34(AGENTS_SKILLS_DIR, skillName, "SKILL.md"));
 }
 async function skill(args) {
   const sub = args[0];
@@ -90700,26 +91349,26 @@ function skillInstall(name) {
   }
   mkdirSync15(AGENTS_SKILLS_DIR, { recursive: true });
   for (const skillName of skills) {
-    const srcDir = join33(sourceDir, skillName);
-    const srcFile = join33(srcDir, "SKILL.md");
-    const destDir = join33(AGENTS_SKILLS_DIR, skillName);
-    if (!existsSync35(srcFile)) {
+    const srcDir = join34(sourceDir, skillName);
+    const srcFile = join34(srcDir, "SKILL.md");
+    const destDir = join34(AGENTS_SKILLS_DIR, skillName);
+    if (!existsSync39(srcFile)) {
       console.error(`[mink] skill not found: ${skillName}`);
       continue;
     }
     mkdirSync15(destDir, { recursive: true });
-    copyDirRecursive(srcDir, destDir);
+    copyDirRecursive2(srcDir, destDir);
     mkdirSync15(CLAUDE_SKILLS_DIR, { recursive: true });
-    const symlink = join33(CLAUDE_SKILLS_DIR, skillName);
+    const symlink = join34(CLAUDE_SKILLS_DIR, skillName);
     try {
-      if (existsSync35(symlink)) {
+      if (existsSync39(symlink)) {
         if (lstatSync2(symlink).isSymbolicLink() || lstatSync2(symlink).isFile()) {
           unlinkSync6(symlink);
         } else {
-          rmSync(symlink, { recursive: true, force: true });
+          rmSync2(symlink, { recursive: true, force: true });
         }
       }
-      const relativeTarget = join33("..", "..", ".agents", "skills", skillName);
+      const relativeTarget = join34("..", "..", ".agents", "skills", skillName);
       symlinkSync2(relativeTarget, symlink);
     } catch {}
     console.log(`[mink] installed: ${skillName} -> ${destDir}`);
@@ -90730,15 +91379,15 @@ function skillInstall(name) {
 function skillUninstall(name) {
   const skills = name ? [name] : getAvailableSkills();
   for (const skillName of skills) {
-    const destDir = join33(AGENTS_SKILLS_DIR, skillName);
-    if (!existsSync35(destDir)) {
+    const destDir = join34(AGENTS_SKILLS_DIR, skillName);
+    if (!existsSync39(destDir)) {
       console.log(`[mink] not installed: ${skillName}`);
       continue;
     }
-    rmSync(destDir, { recursive: true, force: true });
-    const symlink = join33(CLAUDE_SKILLS_DIR, skillName);
+    rmSync2(destDir, { recursive: true, force: true });
+    const symlink = join34(CLAUDE_SKILLS_DIR, skillName);
     try {
-      if (existsSync35(symlink))
+      if (existsSync39(symlink))
         unlinkSync6(symlink);
     } catch {}
     console.log(`[mink] uninstalled: ${skillName}`);
@@ -90753,7 +91402,7 @@ function skillList() {
   if (installed.length > 0) {
     console.log("  Installed:");
     for (const s of installed) {
-      console.log(`    ${s}  (${join33(AGENTS_SKILLS_DIR, s)})`);
+      console.log(`    ${s}  (${join34(AGENTS_SKILLS_DIR, s)})`);
     }
   }
   if (notInstalled.length > 0) {
@@ -90769,14 +91418,14 @@ function skillList() {
   console.log("  Install with: mink skill install");
   console.log("  Or via skills CLI: npx skills add drewpayment/mink");
 }
-function copyDirRecursive(src, dest) {
+function copyDirRecursive2(src, dest) {
   const entries = readdirSync11(src, { withFileTypes: true });
   for (const entry of entries) {
-    const srcPath = join33(src, entry.name);
-    const destPath = join33(dest, entry.name);
+    const srcPath = join34(src, entry.name);
+    const destPath = join34(dest, entry.name);
     if (entry.isDirectory()) {
       mkdirSync15(destPath, { recursive: true });
-      copyDirRecursive(srcPath, destPath);
+      copyDirRecursive2(srcPath, destPath);
     } else {
       copyFileSync(srcPath, destPath);
     }
@@ -90784,8 +91433,8 @@ function copyDirRecursive(src, dest) {
 }
 var AGENTS_SKILLS_DIR, CLAUDE_SKILLS_DIR;
 var init_skill = __esm(() => {
-  AGENTS_SKILLS_DIR = join33(homedir6(), ".agents", "skills");
-  CLAUDE_SKILLS_DIR = join33(homedir6(), ".claude", "skills");
+  AGENTS_SKILLS_DIR = join34(homedir6(), ".agents", "skills");
+  CLAUDE_SKILLS_DIR = join34(homedir6(), ".claude", "skills");
 });
 
 // src/commands/agent.ts
@@ -90793,12 +91442,12 @@ var exports_agent = {};
 __export(exports_agent, {
   agent: () => agent
 });
-import { join as join34, resolve as resolve17, dirname as dirname17 } from "path";
+import { join as join35, resolve as resolve17, dirname as dirname17 } from "path";
 import { homedir as homedir7 } from "os";
 import {
-  existsSync as existsSync36,
+  existsSync as existsSync40,
   mkdirSync as mkdirSync16,
-  readFileSync as readFileSync28,
+  readFileSync as readFileSync29,
   writeFileSync as writeFileSync11
 } from "fs";
 import { createHash as createHash3 } from "crypto";
@@ -90806,8 +91455,8 @@ import { spawnSync as spawnSync6 } from "child_process";
 function getAgentTemplatePath() {
   let dir = dirname17(new URL(import.meta.url).pathname);
   while (true) {
-    if (existsSync36(join34(dir, "package.json")) && existsSync36(join34(dir, "agents", TEMPLATE_FILE))) {
-      return join34(dir, "agents", TEMPLATE_FILE);
+    if (existsSync40(join35(dir, "package.json")) && existsSync40(join35(dir, "agents", TEMPLATE_FILE))) {
+      return join35(dir, "agents", TEMPLATE_FILE);
     }
     const parent = dirname17(dir);
     if (parent === dir)
@@ -90819,10 +91468,10 @@ function getAgentTemplatePath() {
 function getMinkVersion() {
   let dir = dirname17(new URL(import.meta.url).pathname);
   while (true) {
-    const pkgPath = join34(dir, "package.json");
-    if (existsSync36(pkgPath)) {
+    const pkgPath = join35(dir, "package.json");
+    if (existsSync40(pkgPath)) {
       try {
-        const pkg = JSON.parse(readFileSync28(pkgPath, "utf-8"));
+        const pkg = JSON.parse(readFileSync29(pkgPath, "utf-8"));
         if (pkg.name && pkg.version)
           return pkg.version;
       } catch {}
@@ -90845,30 +91494,30 @@ function sha2562(text) {
   return createHash3("sha256").update(text).digest("hex");
 }
 function claudeAgentsDir() {
-  return join34(homedir7(), ".claude", "agents");
+  return join35(homedir7(), ".claude", "agents");
 }
 function installedAgentPath() {
-  return join34(claudeAgentsDir(), INSTALLED_FILE);
+  return join35(claudeAgentsDir(), INSTALLED_FILE);
 }
 function installAgentDefinition(opts) {
   const templatePath = getAgentTemplatePath();
-  if (!existsSync36(templatePath)) {
+  if (!existsSync40(templatePath)) {
     throw new Error(`[mink agent] bundled agent template not found at ${templatePath}
 ` + "  This usually means the package was installed without bundled assets.");
   }
   const installed = installedAgentPath();
-  if (opts.skip && existsSync36(installed)) {
+  if (opts.skip && existsSync40(installed)) {
     return { action: "skipped", path: installed };
   }
-  const template = readFileSync28(templatePath, "utf-8");
+  const template = readFileSync29(templatePath, "utf-8");
   const rendered = renderTemplate(template, {
     MINK_ROOT: minkRoot(),
     VAULT_PATH: resolveVaultPath(),
     MINK_VERSION: getMinkVersion()
   });
-  const exists = existsSync36(installed);
+  const exists = existsSync40(installed);
   if (!opts.force && exists) {
-    const current = readFileSync28(installed, "utf-8");
+    const current = readFileSync29(installed, "utf-8");
     if (sha2562(current) === sha2562(rendered)) {
       return { action: "unchanged", path: installed };
     }
@@ -90944,7 +91593,7 @@ async function agent(_cwd, rawArgs) {
   }
   const skipUpdate = args.noUpdate || process.env.MINK_AGENT_NO_UPDATE === "1";
   const root = minkRoot();
-  if (!existsSync36(root)) {
+  if (!existsSync40(root)) {
     mkdirSync16(root, { recursive: true });
   }
   let result;
@@ -90996,25 +91645,25 @@ var init_agent = __esm(() => {
 });
 
 // src/core/sync-merge-drivers.ts
-import { readFileSync as readFileSync29, writeFileSync as writeFileSync12, appendFileSync as appendFileSync2 } from "fs";
-import { join as join35 } from "path";
+import { readFileSync as readFileSync30, writeFileSync as writeFileSync12, appendFileSync as appendFileSync2 } from "fs";
+import { join as join36 } from "path";
 function logWarning(driver, args, err) {
   try {
     const line = `[${new Date().toISOString()}] ${driver} fallback for ${args.filePath}: ${err instanceof Error ? err.message : String(err)}
 `;
-    appendFileSync2(join35(minkRoot(), "sync-warnings.log"), line);
+    appendFileSync2(join36(minkRoot(), "sync-warnings.log"), line);
   } catch {}
 }
 function readJsonOrNull(path12) {
   try {
-    return JSON.parse(readFileSync29(path12, "utf-8"));
+    return JSON.parse(readFileSync30(path12, "utf-8"));
   } catch {
     return null;
   }
 }
 function readTextOrEmpty(path12) {
   try {
-    return readFileSync29(path12, "utf-8");
+    return readFileSync30(path12, "utf-8");
   } catch {
     return "";
   }
@@ -91188,12 +91837,13 @@ async function sync(args) {
       return handleReconcile(args.slice(1));
     case "migrate": {
       const { syncMigrateCommand: syncMigrateCommand2 } = await Promise.resolve().then(() => (init_sync_migrate(), exports_sync_migrate));
-      syncMigrateCommand2();
+      syncMigrateCommand2(args.slice(1));
       return;
     }
     default:
       console.error(`[mink] unknown sync subcommand: ${subcommand}`);
-      console.error("Usage: mink sync [init|status|push|pull|pause|resume|disconnect|reconcile|migrate|merge-driver]");
+      console.error("Usage: mink sync [init|status|push|pull|pause|resume|disconnect|reconcile|merge-driver]");
+      console.error("       mink sync migrate [--dry-run|--rollback]");
       process.exit(1);
   }
 }
@@ -91415,7 +92065,9 @@ function sessionStart(cwd) {
   } catch {}
   try {
     const { readSyncVersion: readSyncVersion2, MINK_SYNC_VERSION: MINK_SYNC_VERSION2 } = (init_sync(), __toCommonJS(exports_sync));
-    if (readSyncVersion2() < MINK_SYNC_VERSION2) {
+    const { resolveConfigValue: resolveConfigValue2 } = (init_global_config(), __toCommonJS(exports_global_config));
+    const identityOn = resolveConfigValue2("projects.identity").value === "git-remote";
+    if (readSyncVersion2() < MINK_SYNC_VERSION2 || identityOn) {
       const { migrateSyncLayout: migrateSyncLayout2 } = (init_sync_migrate(), __toCommonJS(exports_sync_migrate));
       migrateSyncLayout2();
     }
@@ -91439,13 +92091,13 @@ function sessionStart(cwd) {
       const index = loadVaultIndex();
       const inboxCount = Object.values(index.entries).filter((e) => e.category === "inbox").length;
       try {
-        const { join: join8 } = __require("path");
-        const { existsSync: existsSync8 } = __require("fs");
+        const { join: join10 } = __require("path");
+        const { existsSync: existsSync12 } = __require("fs");
         const { resolveVaultPath: resolveVaultPath2 } = (init_vault(), __toCommonJS(exports_vault));
         const { updateMasterIndex: updateMasterIndex2 } = (init_note_linker(), __toCommonJS(exports_note_linker));
         const vaultPath = resolveVaultPath2();
-        const masterIndexPath = join8(vaultPath, "_index.md");
-        if (!existsSync8(masterIndexPath)) {
+        const masterIndexPath = join10(vaultPath, "_index.md");
+        if (!existsSync12(masterIndexPath)) {
           updateMasterIndex2(vaultPath);
         }
       } catch {}
@@ -91469,8 +92121,8 @@ init_state_aggregator();
 init_action_log();
 init_device();
 init_vault();
-import { statSync as statSync5, existsSync as existsSync10, readFileSync as readFileSync9 } from "fs";
-import { join as join10, dirname as dirname4 } from "path";
+import { statSync as statSync5, existsSync as existsSync14, readFileSync as readFileSync10 } from "fs";
+import { join as join12, dirname as dirname4 } from "path";
 function hasActivity(state) {
   return Object.keys(state.reads).length > 0 || state.writes.length > 0;
 }
@@ -91512,10 +92164,10 @@ function sessionStop(sessionFile, finalizer, onReminder = (msg) => console.error
       effectiveFinalizer.updateSession(summary);
     }
     try {
-      const logPath = join10(projDir, "state", deviceId, "action-log.md");
+      const logPath = join12(projDir, "state", deviceId, "action-log.md");
       const logWriter = createActionLogWriter(logPath);
       logWriter.appendSessionEnd(summary);
-      const cfgRaw = safeReadJson(join10(projDir, "config.json"));
+      const cfgRaw = safeReadJson(join12(projDir, "config.json"));
       consolidateLog(logPath, {
         maxEntries: cfgRaw?.actionLogMaxEntries ?? 200,
         retentionDays: cfgRaw?.actionLogRetentionDays ?? 7
@@ -91532,9 +92184,9 @@ function sessionStop(sessionFile, finalizer, onReminder = (msg) => console.error
       }
     }
   }
-  const memoryPath = join10(projDir, "learning-memory.md");
-  const cfgPath = join10(projDir, "config.json");
-  if (existsSync10(memoryPath)) {
+  const memoryPath = join12(projDir, "learning-memory.md");
+  const cfgPath = join12(projDir, "config.json");
+  if (existsSync14(memoryPath)) {
     reflect(projDir, memoryPath, cfgPath);
   }
   if (isLearningMemoryStale(memoryPath)) {
@@ -91554,13 +92206,13 @@ function sessionStop(sessionFile, finalizer, onReminder = (msg) => console.error
   atomicWriteJson(sessionFile, state);
 }
 function writeSessionToWiki(state, projDir) {
-  const metaRaw = safeReadJson(join10(projDir, "project-meta.json"));
+  const metaRaw = safeReadJson(join12(projDir, "project-meta.json"));
   const projectName = metaRaw?.name ?? "unknown";
   const date = new Date().toISOString().split("T")[0];
   const readCount = Object.keys(state.reads).length;
   const writeCount = state.writes.length;
-  const sessionDir = join10(vaultProjects(projectName), "sessions");
-  const sessionFile = join10(sessionDir, `${date}.md`);
+  const sessionDir = join12(vaultProjects(projectName), "sessions");
+  const sessionFile = join12(sessionDir, `${date}.md`);
   const timestamp = new Date().toLocaleTimeString("en-US", {
     hour: "2-digit",
     minute: "2-digit",
@@ -91585,8 +92237,8 @@ function writeSessionToWiki(state, projDir) {
     }
   }
   entry.push("");
-  if (existsSync10(sessionFile)) {
-    const existing = readFileSync9(sessionFile, "utf-8");
+  if (existsSync14(sessionFile)) {
+    const existing = readFileSync10(sessionFile, "utf-8");
     atomicWriteText(sessionFile, existing.trimEnd() + `
 ` + entry.join(`
 `));
@@ -91767,9 +92419,9 @@ switch (command2) {
   case "-v": {
     const { resolve: resolve18, dirname: dirname18 } = await import("path");
     const cliPath = resolve18(dirname18(new URL(import.meta.url).pathname));
-    const { readFileSync: readFileSync30 } = await import("fs");
+    const { readFileSync: readFileSync31 } = await import("fs");
     try {
-      const pkg = JSON.parse(readFileSync30(resolve18(cliPath, "../package.json"), "utf-8"));
+      const pkg = JSON.parse(readFileSync31(resolve18(cliPath, "../package.json"), "utf-8"));
       console.log(`mink ${pkg.version}`);
     } catch {
       console.log("mink (unknown version)");

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1,18 +1,64 @@
 import { existsSync } from "fs";
 import { projectDir } from "../core/paths";
+import {
+  listRegisteredProjects,
+  type RegisteredProject,
+} from "../core/project-registry";
+
+export type StartupResolution =
+  | { kind: "active"; cwd: string }
+  | { kind: "fallback"; cwd: string; project: RegisteredProject }
+  | { kind: "none" };
+
+/**
+ * Resolve which project's cwd to hand to the dashboard server at startup.
+ *
+ * The dashboard UI has an in-app project switcher, so `mink dashboard` does
+ * not need to be launched from inside an active mink project. When the cwd
+ * is not an initialized project, fall back to any registered project — the
+ * user can switch from there.
+ */
+export function resolveStartupCwd(
+  cwd: string,
+  registered: RegisteredProject[] = listRegisteredProjects(),
+): StartupResolution {
+  if (existsSync(projectDir(cwd))) {
+    return { kind: "active", cwd };
+  }
+  if (registered.length === 0) {
+    return { kind: "none" };
+  }
+  const fallback = [...registered].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  )[0];
+  return { kind: "fallback", cwd: fallback.cwd, project: fallback };
+}
 
 export async function dashboard(cwd: string, args: string[]): Promise<void> {
-  if (!existsSync(projectDir(cwd))) {
-    console.error("[mink] project not initialized. Run: mink init");
+  const resolution = resolveStartupCwd(cwd);
+  if (resolution.kind === "none") {
+    console.error(
+      "[mink] no mink projects found. Run `mink init` in a project first.",
+    );
     process.exit(1);
   }
+  if (resolution.kind === "fallback") {
+    console.log(
+      `[mink] not in a mink project — starting dashboard with "${resolution.project.name}". ` +
+        "Use the in-app project switcher to change projects.",
+    );
+  }
+  const startupCwd = resolution.cwd;
 
   const portArg = args.find((a) => a.startsWith("--port="));
   const port = portArg ? parseInt(portArg.split("=")[1], 10) : 4040;
   const noOpen = args.includes("--no-open");
 
   const { startDashboardServer } = await import("../core/dashboard-server");
-  const { url } = await startDashboardServer(cwd, { port, open: !noOpen });
+  const { url } = await startDashboardServer(startupCwd, {
+    port,
+    open: !noOpen,
+  });
 
   console.log(`[mink] dashboard running at ${url}`);
   console.log("[mink] press Ctrl+C to stop");

--- a/tests/unit/dashboard-startup.test.ts
+++ b/tests/unit/dashboard-startup.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { atomicWriteJson } from "../../src/core/fs-utils";
+import { projectDir } from "../../src/core/paths";
+import { resolveStartupCwd } from "../../src/commands/dashboard";
+import type { RegisteredProject } from "../../src/core/project-registry";
+
+function makeRegistered(name: string, cwd: string): RegisteredProject {
+  return {
+    id: `id-${name}`,
+    cwd,
+    name,
+    version: "0.1.0",
+  };
+}
+
+describe("resolveStartupCwd", () => {
+  let initializedCwd: string;
+
+  beforeEach(() => {
+    initializedCwd = join(
+      tmpdir(),
+      `mink-dash-startup-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    );
+    mkdirSync(initializedCwd, { recursive: true });
+    const stateDir = projectDir(initializedCwd);
+    mkdirSync(stateDir, { recursive: true });
+    atomicWriteJson(join(stateDir, "project-meta.json"), {
+      cwd: initializedCwd,
+      name: "active",
+      initTimestamp: "2024-01-01T00:00:00.000Z",
+      version: "0.1.0",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(initializedCwd, { recursive: true, force: true });
+    try {
+      rmSync(projectDir(initializedCwd), { recursive: true, force: true });
+    } catch {}
+  });
+
+  test("uses cwd directly when it is an initialized mink project", () => {
+    const result = resolveStartupCwd(initializedCwd, []);
+    expect(result.kind).toBe("active");
+    if (result.kind === "active") {
+      expect(result.cwd).toBe(initializedCwd);
+    }
+  });
+
+  test("falls back to first registered project (sorted by name) when cwd is unrelated", () => {
+    const unrelated = join(tmpdir(), `not-a-mink-project-${Date.now()}`);
+    const registered = [
+      makeRegistered("zebra", "/tmp/zebra"),
+      makeRegistered("alpha", "/tmp/alpha"),
+      makeRegistered("mango", "/tmp/mango"),
+    ];
+
+    const result = resolveStartupCwd(unrelated, registered);
+    expect(result.kind).toBe("fallback");
+    if (result.kind === "fallback") {
+      expect(result.project.name).toBe("alpha");
+      expect(result.cwd).toBe("/tmp/alpha");
+    }
+  });
+
+  test("returns 'none' when cwd is unrelated and no projects are registered", () => {
+    const unrelated = join(tmpdir(), `not-a-mink-project-${Date.now()}`);
+    const result = resolveStartupCwd(unrelated, []);
+    expect(result.kind).toBe("none");
+  });
+});


### PR DESCRIPTION
## Summary

`mink dashboard` currently exits with `[mink] project not initialized. Run: mink init` when launched from a directory that isn't an active mink project. Since the dashboard UI already has an in-app project switcher and reads state from `~/.mink/projects/<id>/` (not the cwd), that restriction is more restrictive than necessary.

This PR makes `mink dashboard` work from anywhere by falling back to a registered project when the cwd isn't an active mink project. Users can then change project via the existing in-app switcher.

## Behavior

| Scenario | Before | After |
| --- | --- | --- |
| Run from an active mink project | Opens dashboard for that project | Same |
| Run from an unrelated directory, with registered projects | Errors and exits | Falls back to first registered project (sorted by name); prints a one-line notice |
| Run from an unrelated directory, no registered projects | Errors and exits | Errors and exits with an updated message pointing to `mink init` |

Fallback notice example:

```
[mink] not in a mink project — starting dashboard with "afiusa". Use the in-app project switcher to change projects.
[mink] dashboard running at http://127.0.0.1:4040
```

## Implementation

- Extracted `resolveStartupCwd(cwd, registered?)` from `src/commands/dashboard.ts`. Returns a discriminated union (`active` / `fallback` / `none`) so the caller drives messaging and exit behavior.
- The dashboard server already supports project resolution via the registry (`listRegisteredProjects`, `swapWatcher`, `GET /api/projects`), so no server-side changes were needed.

## Tests

- New unit tests in `tests/unit/dashboard-startup.test.ts` cover all three outcomes (active / fallback / none) with injected registrations — no live `~/.mink/` side effects.
- Full dashboard suite (`tests/integration/dashboard.test.ts`, `tests/unit/dashboard-api.test.ts`) passes: 38/38.
- Typecheck clean; production build succeeds.
- Smoke-tested manually: ran the built CLI from `/tmp`, dashboard started on the fallback project and listened on the configured port.

## Pre-existing failures (not caused by this PR)

- `tests/integration/status.test.ts > shows status for initialized project` — fails on this branch *and* on `main` because it reads the user's live `~/.mink/` daemon PID instead of an isolated test fixture. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
