### PR TITLE
fix(status): report sharded action-log and learning-memory as ok

### DIFF
--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -17,7 +17,11 @@ import {
   aggregateTokenLedger,
   aggregateBugMemory,
   aggregateLearningMemory,
+  listDeviceShardsAt,
+  listLearningMemorySidecarPathsAt,
+  shardPath,
 } from "../core/state-aggregator";
+import { projectDir } from "../core/paths";
 import { loadCounters } from "../core/state-counters";
 import { getDaemonStatus } from "../core/daemon";
 
@@ -45,6 +49,37 @@ function checkTextFile(name: string, filePath: string): FileCheck {
   }
 }
 
+// Reports "ok" when canonical OR any device shard / sidecar exists with content.
+// action-log and learning-memory now live in per-device shards; checking only the
+// canonical path made initialized projects look empty.
+function checkShardedText(name: string, candidatePaths: string[]): FileCheck {
+  const canonical = candidatePaths[0];
+  for (const p of candidatePaths) {
+    if (!existsSync(p)) continue;
+    try {
+      if (statSync(p).size === 0) continue;
+      readFileSync(p, "utf-8");
+      return { name, path: p, status: "ok" };
+    } catch {
+      return { name, path: p, status: "corrupt" };
+    }
+  }
+  return { name, path: canonical, status: "missing" };
+}
+
+function actionLogCandidates(cwd: string): string[] {
+  const dir = projectDir(cwd);
+  return [
+    actionLogPath(cwd),
+    ...listDeviceShardsAt(dir).map((id) => shardPath(dir, id, "action-log.md")),
+  ];
+}
+
+function learningMemoryCandidates(cwd: string): string[] {
+  const dir = projectDir(cwd);
+  return [learningMemoryPath(cwd), ...listLearningMemorySidecarPathsAt(dir)];
+}
+
 export function status(cwd: string): void {
   console.log("[mink] project status");
   console.log();
@@ -54,10 +89,10 @@ export function status(cwd: string): void {
     checkJsonFile("session.json", sessionPath(cwd)),
     checkJsonFile("file-index.json", fileIndexPath(cwd), isFileIndex),
     checkJsonFile("config.json", configPath(cwd)),
-    checkTextFile("learning-memory.md", learningMemoryPath(cwd)),
+    checkShardedText("learning-memory.md", learningMemoryCandidates(cwd)),
     checkJsonFile("token-ledger.json", tokenLedgerPath(cwd)),
     checkJsonFile("bug-memory.json", bugMemoryPath(cwd)),
-    checkTextFile("action-log.md", actionLogPath(cwd)),
+    checkShardedText("action-log.md", actionLogCandidates(cwd)),
   ];
 
   console.log("  State files:");

--- a/src/core/state-aggregator.ts
+++ b/src/core/state-aggregator.ts
@@ -28,7 +28,7 @@ import type {
 // projectDir(cwd)). The cwd-based variants below are thin wrappers for the
 // common case where the caller has cwd in hand.
 
-function listDeviceShardsAt(projDir: string): string[] {
+export function listDeviceShardsAt(projDir: string): string[] {
   const stateDir = join(projDir, "state");
   if (!existsSync(stateDir)) return [];
   try {
@@ -46,7 +46,7 @@ function listDeviceShardsAt(projDir: string): string[] {
 
 const SIDECAR_RE = /^learning-memory\.([^.]+)\.md$/;
 
-function listLearningMemorySidecarPathsAt(projDir: string): string[] {
+export function listLearningMemorySidecarPathsAt(projDir: string): string[] {
   if (!existsSync(projDir)) return [];
   try {
     return readdirSync(projDir)
@@ -57,7 +57,7 @@ function listLearningMemorySidecarPathsAt(projDir: string): string[] {
   }
 }
 
-function shardPath(projDir: string, deviceId: string, file: string): string {
+export function shardPath(projDir: string, deviceId: string, file: string): string {
   return join(projDir, "state", deviceId, file);
 }
 

--- a/tests/integration/status.test.ts
+++ b/tests/integration/status.test.ts
@@ -132,4 +132,42 @@ describe("status command", () => {
     const output = logs.join("\n");
     expect(output).toContain("corrupt");
   });
+
+  test("reports action-log.md as ok when only device shards have content", () => {
+    const stateDir = projectDir(testCwd);
+    const shardDir = join(stateDir, "state", "device-abc");
+    mkdirSync(shardDir, { recursive: true });
+    writeFileSync(join(shardDir, "action-log.md"), "# Action Log\n\n## Session 1\n");
+
+    status(testCwd);
+
+    const output = logs.join("\n");
+    expect(output).toContain("action-log.md: ok");
+  });
+
+  test("reports learning-memory.md as ok when only a sidecar exists", () => {
+    const stateDir = projectDir(testCwd);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, "learning-memory.device-abc.md"),
+      "# Learning Memory\n\n## User Preferences\n- pref\n"
+    );
+
+    status(testCwd);
+
+    const output = logs.join("\n");
+    expect(output).toContain("learning-memory.md: ok");
+  });
+
+  test("reports action-log.md as missing when neither canonical nor shards exist", () => {
+    const stateDir = projectDir(testCwd);
+    mkdirSync(stateDir, { recursive: true });
+    // No action-log anywhere; create one unrelated file so the project is "init'd"
+    writeFileSync(join(stateDir, "session.json"), "{}");
+
+    status(testCwd);
+
+    const output = logs.join("\n");
+    expect(output).toContain("action-log.md: missing");
+  });
 });


### PR DESCRIPTION
## Summary

- `mink status` reported `action-log.md` and `learning-memory.md` as **missing** on initialized projects because it only checked the canonical paths. Both files have lived in per-device shards (`state/<id>/action-log.md`, `learning-memory.<id>.md`) since the multi-device split — the aggregators already read shards correctly, but the status check did not.
- Status check is now shard-aware: reports `ok` when canonical **or** any shard / sidecar has content, `missing` only when nothing exists anywhere, `corrupt` if a found file is unreadable.
- Exports `listDeviceShardsAt`, `listLearningMemorySidecarPathsAt`, and `shardPath` from `state-aggregator.ts` so the status command builds its candidate list from the same source as the aggregators.

## Before / after on a real project

Local mink-on-mink state — only sharded action-log exists, no canonical:

Before:
```
action-log.md: missing
```

After:
```
action-log.md: ok
```

## Test plan
- [x] Added 3 integration tests: ok via shard, ok via sidecar, still missing when nothing exists
- [x] `bun test tests/integration/status.test.ts` — new tests pass; the only failure is the pre-existing host-daemon-pollution test documented in CLAUDE.md
- [x] `bunx tsc --noEmit` clean
- [x] Verified against real local project state — sharded `action-log.md` now reports `ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)