### PR TITLE
fix(update): skip cross-device projects instead of crashing the batch

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,9 +1,32 @@
+import { existsSync } from "fs";
 import { resolve } from "path";
-import { listRegisteredProjects } from "../core/project-registry";
+import {
+  listRegisteredProjects,
+  type RegisteredProject,
+} from "../core/project-registry";
 import { createBackup } from "../core/backup";
 import { projectMetaPath } from "../core/paths";
 import { atomicWriteJson, safeReadJson } from "../core/fs-utils";
+import { getOrCreateDeviceId } from "../core/device";
 import { buildHooksConfig, mergeHooksIntoSettings, resolveCliPath } from "./init";
+
+// Pick the project's working-copy path for *this* device. When a project has
+// `pathsByDevice`, prefer the current device's entry. If the map exists but
+// has no entry for us, the project is registered elsewhere — return null so
+// the caller skips it (instead of trying to mkdir into a foreign absolute
+// path like `/home/<user>/…` on macOS, which fails with ENOTSUP on autofs
+// and aborts the batch — see issue #95). Legacy single-device projects with
+// no map fall back to the singular `cwd`.
+export function resolveLocalCwd(
+  project: RegisteredProject,
+  deviceId: string
+): string | null {
+  const map = project.pathsByDevice;
+  if (map && Object.keys(map).length > 0) {
+    return map[deviceId] ?? null;
+  }
+  return project.cwd || null;
+}
 
 function parseArgs(args: string[]): {
   dryRun: boolean;
@@ -79,9 +102,29 @@ export async function update(cwd: string, args: string[]): Promise<void> {
 
   const cliPath = resolveCliPath();
   const newHooks = buildHooksConfig(cliPath);
+  const deviceId = getOrCreateDeviceId();
+
+  let updated = 0;
+  let skipped = 0;
+  let failed = 0;
 
   for (const target of targets) {
     console.log(`[mink] updating: ${target.name} (${target.id})`);
+
+    // Resolve the working-copy path for the current device. Cross-device-only
+    // projects (registered from another machine) are skipped rather than
+    // crashing the batch on a foreign absolute path.
+    const localCwd = resolveLocalCwd(target, deviceId);
+    if (!localCwd) {
+      console.log("  skipped: not registered on this device");
+      skipped++;
+      continue;
+    }
+    if (!existsSync(localCwd)) {
+      console.log(`  skipped: path missing on this device (${localCwd})`);
+      skipped++;
+      continue;
+    }
 
     if (dryRun) {
       console.log("  [dry-run] would update hooks and project metadata");
@@ -89,28 +132,43 @@ export async function update(cwd: string, args: string[]): Promise<void> {
       continue;
     }
 
-    // Create backup
-    const backupName = createBackup(target.cwd);
-    console.log(`  backup: ${backupName}`);
+    try {
+      // Create backup
+      const backupName = createBackup(localCwd);
+      console.log(`  backup: ${backupName}`);
 
-    // Update hooks
-    const settingsPath = resolve(target.cwd, ".claude", "settings.json");
-    mergeHooksIntoSettings(settingsPath, newHooks);
-    console.log("  hooks: updated");
+      // Update hooks
+      const settingsPath = resolve(localCwd, ".claude", "settings.json");
+      mergeHooksIntoSettings(settingsPath, newHooks);
+      console.log("  hooks: updated");
 
-    // Update project meta
-    const metaPath = projectMetaPath(target.cwd);
-    const existing = safeReadJson(metaPath) as Record<string, unknown> | null;
-    atomicWriteJson(metaPath, {
-      ...(existing ?? {}),
-      cwd: target.cwd,
-      name: target.name,
-      version: "0.1.0",
-    });
-    console.log("  metadata: updated");
+      // Update project meta. Preserve `pathsByDevice` and other v3 fields; only
+      // refresh the singular `cwd` (the local-machine fallback) and the name/
+      // version bookkeeping so a downgrade still reads a meaningful value.
+      const metaPath = projectMetaPath(localCwd);
+      const existing = safeReadJson(metaPath) as Record<string, unknown> | null;
+      atomicWriteJson(metaPath, {
+        ...(existing ?? {}),
+        cwd: localCwd,
+        name: target.name,
+        version: "0.1.0",
+      });
+      console.log("  metadata: updated");
+      updated++;
+    } catch (err) {
+      // One broken project must not stop the batch. Surface the failure and
+      // move on so the rest of the user's projects still get refreshed.
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`  failed: ${message}`);
+      failed++;
+    }
   }
 
   if (!dryRun) {
-    console.log(`[mink] ${targets.length} project(s) updated`);
+    const parts = [`${updated} updated`];
+    if (skipped > 0) parts.push(`${skipped} skipped`);
+    if (failed > 0) parts.push(`${failed} failed`);
+    console.log(`[mink] ${parts.join(", ")}`);
+    if (failed > 0) process.exitCode = 1;
   }
 }

--- a/tests/unit/update-cross-device.test.ts
+++ b/tests/unit/update-cross-device.test.ts
@@ -1,0 +1,184 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { resolveLocalCwd, update } from "../../src/commands/update";
+import { projectDir, projectMetaPath } from "../../src/core/paths";
+import { atomicWriteJson } from "../../src/core/fs-utils";
+
+// See issue #95: `mink update` used to iterate every registered project and
+// mkdir into its raw `cwd`, which explodes on macOS when the path belongs to
+// another device (autofs sockets under /home/… return ENOTSUP and the whole
+// batch aborts). These tests pin the new behavior — foreign projects are
+// skipped and one bad project no longer nukes the run.
+
+describe("resolveLocalCwd", () => {
+  const local = "/local/path";
+  const remote = "/home/other/proj";
+  const thisDevice = "device-a";
+  const otherDevice = "device-b";
+
+  test("prefers pathsByDevice[currentDevice] when present", () => {
+    const got = resolveLocalCwd(
+      {
+        id: "p",
+        cwd: remote,
+        name: "p",
+        version: "0.1.0",
+        aliases: [],
+        pathsByDevice: { [thisDevice]: local, [otherDevice]: remote },
+      },
+      thisDevice
+    );
+    expect(got).toBe(local);
+  });
+
+  test("returns null when pathsByDevice exists but has no entry for us", () => {
+    const got = resolveLocalCwd(
+      {
+        id: "p",
+        cwd: remote,
+        name: "p",
+        version: "0.1.0",
+        aliases: [],
+        pathsByDevice: { [otherDevice]: remote },
+      },
+      thisDevice
+    );
+    expect(got).toBeNull();
+  });
+
+  test("falls back to legacy singular cwd when no map is present", () => {
+    const got = resolveLocalCwd(
+      {
+        id: "p",
+        cwd: local,
+        name: "p",
+        version: "0.1.0",
+        aliases: [],
+        pathsByDevice: {},
+      },
+      thisDevice
+    );
+    expect(got).toBe(local);
+  });
+
+  test("returns null when neither map nor cwd is usable", () => {
+    const got = resolveLocalCwd(
+      {
+        id: "p",
+        cwd: "",
+        name: "p",
+        version: "0.1.0",
+        aliases: [],
+        pathsByDevice: {},
+      },
+      thisDevice
+    );
+    expect(got).toBeNull();
+  });
+});
+
+describe("update() cross-device batch", () => {
+  let minkRoot: string;
+  let localCwd: string;
+  const prevRoot = process.env.MINK_ROOT_OVERRIDE;
+
+  beforeEach(() => {
+    minkRoot = mkdtempSync(join(tmpdir(), "mink-update-root-"));
+    localCwd = mkdtempSync(join(tmpdir(), "mink-update-local-"));
+    process.env.MINK_ROOT_OVERRIDE = minkRoot;
+    // Seed a stable device id so pathsByDevice lookups are deterministic.
+    writeFileSync(join(minkRoot, "device-id"), "test-device\n");
+  });
+
+  afterEach(() => {
+    rmSync(minkRoot, { recursive: true, force: true });
+    rmSync(localCwd, { recursive: true, force: true });
+    if (prevRoot === undefined) delete process.env.MINK_ROOT_OVERRIDE;
+    else process.env.MINK_ROOT_OVERRIDE = prevRoot;
+  });
+
+  function registerProject(
+    cwd: string,
+    name: string,
+    pathsByDevice: Record<string, string> | null
+  ) {
+    const stateDir = projectDir(cwd);
+    mkdirSync(stateDir, { recursive: true });
+    const meta: Record<string, unknown> = {
+      cwd,
+      name,
+      initTimestamp: "2024-01-01T00:00:00.000Z",
+      version: "0.1.0",
+    };
+    if (pathsByDevice) meta.pathsByDevice = pathsByDevice;
+    atomicWriteJson(join(stateDir, "project-meta.json"), meta);
+  }
+
+  test("skips projects registered only on other devices", async () => {
+    // Foreign project — no entry for us. Path deliberately points at a
+    // location that would fail if we tried to mkdir into it.
+    registerProject("/home/other-user/foreign-proj", "foreign", {
+      "some-other-device": "/home/other-user/foreign-proj",
+    });
+    // Local project we should actually update.
+    registerProject(localCwd, "local", { "test-device": localCwd });
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.join(" "));
+    };
+    try {
+      await update(localCwd, []);
+    } finally {
+      console.log = origLog;
+    }
+
+    // Batch survived — local project got its hooks.
+    expect(existsSync(join(localCwd, ".claude", "settings.json"))).toBe(true);
+    // And the foreign project was surfaced as skipped, not silently dropped.
+    const skipLine = logs.find(
+      (l) => l.includes("foreign") || l.includes("not registered on this device")
+    );
+    expect(skipLine).toBeDefined();
+  });
+
+  test("skips projects whose local path is missing on disk", async () => {
+    const gonePath = join(tmpdir(), "mink-update-gone-" + Date.now());
+    // Register a project pointing at a path that never existed (legacy
+    // single-device meta, cwd points at nothing).
+    registerProject(gonePath, "gone", null);
+    registerProject(localCwd, "local", null);
+
+    await update(localCwd, []);
+
+    expect(existsSync(join(localCwd, ".claude", "settings.json"))).toBe(true);
+    expect(existsSync(join(gonePath, ".claude", "settings.json"))).toBe(false);
+  });
+
+  test("preserves pathsByDevice when refreshing metadata", async () => {
+    const preserved = {
+      "test-device": localCwd,
+      "other-device": "/home/other/proj",
+    };
+    registerProject(localCwd, "local", preserved);
+
+    await update(localCwd, []);
+
+    const meta = JSON.parse(
+      readFileSync(projectMetaPath(localCwd), "utf-8")
+    ) as Record<string, unknown>;
+    expect(meta.pathsByDevice).toEqual(preserved);
+    expect(meta.cwd).toBe(localCwd);
+    expect(meta.name).toBe("local");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #95.

`mink update` iterates every project in `~/.mink/projects/` and calls `mkdirSync(dirname(settingsPath), { recursive: true })` against the raw `cwd` from `project-meta.json`. When `~/.mink/` is synced across devices, that `cwd` can point at another machine's absolute path — a Linux `/home/<user>/…` seen from a macOS host. On macOS `/home/` is an autofs socket, so `mkdir` returns `ENOTSUP` (errno -45), which `{ recursive: true }` doesn't swallow. The whole update aborts and no other project gets refreshed.

Two independent problems, both addressed here:

- **Cross-device projects shouldn't be touched at all.** The v3 schema already carries `pathsByDevice: Record<deviceId, cwd>`. New `resolveLocalCwd(project, deviceId)` prefers the current device's entry; when the map exists but has no entry for us, the project is registered elsewhere and we skip. Legacy single-device projects (no map) still fall back to `cwd`. We also skip when the resolved path doesn't actually exist on disk.
- **Per-project failures shouldn't be fatal to the batch.** The per-project body is now wrapped in `try/catch`. A broken project logs `failed: <message>` and the loop continues. The batch reports `N updated, N skipped, N failed` and sets `process.exitCode = 1` only when something genuinely failed (skips are not failures).

The metadata refresh now uses the resolved local path and preserves `pathsByDevice` (via the existing `...existing` spread), so a v3 project's cross-device map survives an update run.

## Reproduction (before this PR)

With `~/.mink/` synced between a Mac and a Linux workstation, one of the Linux-only projects has:

```json
{
  "cwd": "/home/vanillax/programming/project-nomad",
  "name": "project-nomad",
  "pathsByDevice": {
    "b0be80cf-…-linux": "/home/vanillax/programming/project-nomad"
  }
}
```

Running `mink update` on the Mac:

```
[mink] updating: project-nomad (project-nomad-410e79)
  backup: backup-20260710-171232619
ENOTSUP: operation not supported on socket, mkdir '/home/vanillax'
    at mergeHooksIntoSettings (…/cli.bun.js:5295:13)
    at update (…/cli.bun.js:14206:27)
```

## After this PR

```
[mink] updating: project-nomad (project-nomad-410e79)
  skipped: not registered on this device
[mink] updating: my-mac-project (…)
  backup: backup-…
  hooks: updated
  metadata: updated
[mink] 1 updated, 1 skipped
```

## Test plan

- [x] New `tests/unit/update-cross-device.test.ts` covers:
  - `resolveLocalCwd` returns the current-device entry when present.
  - Returns `null` when `pathsByDevice` exists but has no entry for us (foreign-device project).
  - Falls back to legacy singular `cwd` when no map is present.
  - Returns `null` when neither map nor `cwd` is usable.
  - `update()` skips a foreign-device project and still updates the local one in the same batch (this is the exact issue #95 scenario — foreign path is under `/home/other-user/…` so the pre-fix code would have crashed).
  - `update()` skips a project whose local path is missing on disk.
  - `update()` preserves `pathsByDevice` when writing the refreshed metadata.
- [x] Existing `tests/integration/update.test.ts` still passes.
- [x] `bunx tsc --noEmit` clean.
- [x] Full `bun test` — 1251 pass. The 10 failures are the pre-existing local-only failures documented in `CLAUDE.md` ("host daemon pollution, dashboard build artefacts") and reproduce on unmodified `main`. None touch the update path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)